### PR TITLE
Add missing +optional tag

### DIFF
--- a/api/v1alpha1/gatewayconfiguration_types.go
+++ b/api/v1alpha1/gatewayconfiguration_types.go
@@ -109,6 +109,7 @@ type ContainerArgs struct {
 	// If false, controller ignores 'resources', deferring to VPA/other external tool.
 	EnforceResources bool `json:"enforceResources"`
 
+	// +optional
 	ResizePolicy []corev1.ContainerResizePolicy `json:"resizePolicy,omitempty"`
 }
 


### PR DESCRIPTION
zolug pointed out the missing tag/annotation


Interestingly when kubebuilder built the schema the ResizePolicy field was make implicitly optional regardless the +optinal tag or not, so the generated schema is the same, hence I'm only adding a single file.