### PR TITLE
Tighten RBAC to match actual controller-manager usage

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -19,7 +19,6 @@ rules:
   - deployments
   verbs:
   - create
-  - delete
   - get
   - list
   - patch
@@ -41,21 +40,10 @@ rules:
   - gateway.networking.k8s.io
   resources:
   - gatewayclasses
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - gateway.networking.k8s.io
-  resources:
   - gateways
   verbs:
-  - create
-  - delete
   - get
   - list
-  - patch
-  - update
   - watch
 - apiGroups:
   - gateway.networking.k8s.io
@@ -69,13 +57,11 @@ rules:
   - meridio-2.nordix.org
   resources:
   - distributiongroups
+  - gatewayconfigurations
+  - l34routes
   verbs:
-  - create
-  - delete
   - get
   - list
-  - patch
-  - update
   - watch
 - apiGroups:
   - meridio-2.nordix.org
@@ -85,13 +71,3 @@ rules:
   - get
   - patch
   - update
-- apiGroups:
-  - meridio-2.nordix.org
-  resources:
-  - gatewayconfigurations
-  - gatewayrouters
-  - l34routes
-  verbs:
-  - get
-  - list
-  - watch

--- a/internal/controller/distributiongroup/controller.go
+++ b/internal/controller/distributiongroup/controller.go
@@ -77,7 +77,7 @@ type DistributionGroupReconciler struct {
 // - ClusterRole: gateways, nodes
 // This allows principle of least privilege for namespace-scoped deployments.
 //
-// +kubebuilder:rbac:groups=meridio-2.nordix.org,resources=distributiongroups,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=meridio-2.nordix.org,resources=distributiongroups,verbs=get;list;watch
 // +kubebuilder:rbac:groups=meridio-2.nordix.org,resources=distributiongroups/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=discovery.k8s.io,resources=endpointslices,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch

--- a/internal/controller/gateway/controller.go
+++ b/internal/controller/gateway/controller.go
@@ -43,12 +43,15 @@ type GatewayReconciler struct {
 	LBServiceAccount string // ServiceAccount name for LB Deployment pods
 }
 
-// +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gateways,verbs=get;list;watch;create;update;patch;delete
+// TODO(RBAC): Split into namespace-scoped Role and cluster-scoped ClusterRole
+// This allows principle of least privilege for namespace-scoped deployments.
+//
+// +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gateways,verbs=get;list;watch
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gateways/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gatewayclasses,verbs=get;list;watch
 // +kubebuilder:rbac:groups=meridio-2.nordix.org,resources=l34routes,verbs=get;list;watch
 // +kubebuilder:rbac:groups=meridio-2.nordix.org,resources=gatewayconfigurations,verbs=get;list;watch
-// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch
 
 // Reconcile manages Gateway lifecycle
 func (r *GatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {

--- a/internal/controller/router/controller.go
+++ b/internal/controller/router/controller.go
@@ -45,8 +45,8 @@ type RouterReconciler struct {
 	Bird bird.BirdInterface
 }
 
-// +kubebuilder:rbac:groups=meridio-2.nordix.org,resources=gatewayrouters,verbs=get;list;watch
-// +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gateways,verbs=get;list;watch
+// RBAC for the router controller is managed via config/rbac/lb-serviceaccount.yaml
+// (dedicated ServiceAccount/Role for LB Pods). No kubebuilder:rbac markers here.
 
 // Reconcile implements the reconciliation of the Gateway for the router.
 // This function is triggered by any change (create/update/delete) in any resource related


### PR DESCRIPTION
- Remove write verbs (create/update/patch/delete) from gateways and distributiongroups markers — controller only reads these resources
- Remove delete from deployments marker — cleanup is handled by ownerReference garbage collection
- Remove router controller RBAC markers to prevent leaking into the controller-manager's ClusterRole (router uses dedicated LB Pod role)
- Remove gatewayrouters from role.yaml (not used by controller-manager)
- Regenerate role.yaml via make manifests