### PR TITLE
Add router and network-sidecar to CI/E2E workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,6 +78,8 @@ jobs:
         image:
           - controller-manager
           - stateless-load-balancer
+          - router
+          - network-sidecar
     steps:
       - uses: actions/checkout@v6
       - run: make ${{ matrix.image }} BUILD_STEPS=build

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -48,6 +48,8 @@ jobs:
         image:
           - controller-manager
           - stateless-load-balancer
+          - router
+          - network-sidecar
     steps:
       - uses: actions/checkout@v6
       - uses: docker/login-action@v4
@@ -59,7 +61,7 @@ jobs:
 
   kind:
     runs-on: ubuntu-latest
-    needs: build-and-push
+    needs: [get-tag, build-and-push]
     strategy:
       fail-fast: false
       matrix:

--- a/Makefile
+++ b/Makefile
@@ -177,7 +177,7 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 	if [ -n "$$out" ]; then echo "$$out" | "$(KUBECTL)" delete --ignore-not-found=$(ignore-not-found) -f -; else echo "No CRDs to delete; skipping."; fi
 
 .PHONY: deploy
-deploy: manifests kustomize cert-manager ## Deploy controller to the K8s cluster specified in ~/.kube/config.
+deploy: manifests kustomize cert-manager gateway-api ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	cd config/controller-manager && "$(KUSTOMIZE)" edit set image controller-manager=$(REGISTRY)/controller-manager:$(VERSION_CONTROLLER_MANAGER)
 	cd config/default && "$(KUSTOMIZE)" edit set namespace $(NAMESPACE)
 	"$(KUSTOMIZE)" build config/default | "$(KUBECTL)" apply -f -
@@ -244,6 +244,13 @@ cert-manager: # Install cert-manager if not present
 		kubectl wait --for=condition=Available --timeout=300s -n cert-manager deployment/cert-manager; \
 		kubectl wait --for=condition=Available --timeout=300s -n cert-manager deployment/cert-manager-webhook; \
 		kubectl wait --for=condition=Available --timeout=300s -n cert-manager deployment/cert-manager-cainjector; \
+	}
+
+.PHONY: gateway-api
+gateway-api: # Install Gateway API CRDs if not present
+	@kubectl get crd gateways.gateway.networking.k8s.io >/dev/null 2>&1 || { \
+		echo "Installing Gateway API CRDs..."; \
+		kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.0/standard-install.yaml; \
 	}
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist


### PR DESCRIPTION
## Summary

Extends CI and E2E workflows to build and test the router and network-sidecar components.

## Changes

- **CI workflow**: Added `router` and `network-sidecar` to the build matrix
- **E2E workflow**:
  - Added `router` and `network-sidecar` to the build-and-push matrix
  - Fixed `kind` job dependency to include `get-tag` (was missing)
- **Makefile**:
  - Added `gateway-api` target to automatically install Gateway API CRDs if not present
  - Updated `deploy` target to depend on `gateway-api` (ensures CRDs are installed before deployment)