### PR TITLE
Add BIRD log rotation support to router container

### DIFF
--- a/cmd/router/cmd/run.go
+++ b/cmd/router/cmd/run.go
@@ -122,7 +122,7 @@ func runRouter(ctx context.Context, cfg *config.RouterConfig) error {
 		return err
 	}
 
-	birdInstance := bird.New(bird.WithLogFile(cfg.BirdLogFile))
+	birdInstance := bird.New(bird.WithLogFile(cfg.BirdLogFile), bird.WithLogFileSize(cfg.BirdLogFileSize))
 
 	if err = (&router.RouterReconciler{
 		Client:           mgr.GetClient(),

--- a/config/templates/lb-deployment.yaml
+++ b/config/templates/lb-deployment.yaml
@@ -74,6 +74,8 @@ spec:
               fieldPath: metadata.namespace
         - name: MERIDIO_BIRD_LOG_FILE
           value: /var/log/bird/bird.log
+        - name: MERIDIO_BIRD_LOG_FILE_SIZE
+          value: "104857600"  # 100 MiB
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
@@ -112,4 +114,3 @@ spec:
       - name: bird-log
         emptyDir:
           medium: Memory
-          sizeLimit: 300Mi # TODO: Configure BIRD's own log rotation and size limit

--- a/internal/bird/bird.go
+++ b/internal/bird/bird.go
@@ -40,17 +40,22 @@ type BirdInterface interface {
 }
 
 type Bird struct {
-	SocketPath string
-	ConfigFile string
-	LogFile    string
-	running    bool
-	mu         sync.Mutex
+	SocketPath  string
+	ConfigFile  string
+	LogFile     string
+	LogFileSize int // bytes; if >0, enables rotation with 1 backup file
+	running     bool
+	mu          sync.Mutex
 }
 
 type Option func(*Bird)
 
 func WithLogFile(path string) Option {
 	return func(b *Bird) { b.LogFile = path }
+}
+
+func WithLogFileSize(bytes int) Option {
+	return func(b *Bird) { b.LogFileSize = bytes }
 }
 
 func New(opts ...Option) *Bird {
@@ -140,7 +145,7 @@ func (b *Bird) Configure(ctx context.Context, vips []string, routers []*meridio2
 }
 
 func (b *Bird) generateConfig(vips []string, routers []*meridio2v1alpha1.GatewayRouter) (string, error) {
-	data := birdConfigData{KernelTableID: defaultKernelTableID, LogFile: b.LogFile}
+	data := birdConfigData{KernelTableID: defaultKernelTableID, LogFile: b.LogFile, LogFileSize: b.LogFileSize}
 
 	for _, vip := range vips {
 		if isIPv6(vip) {

--- a/internal/bird/config.go
+++ b/internal/bird/config.go
@@ -35,6 +35,7 @@ const (
 type birdConfigData struct {
 	KernelTableID int
 	LogFile       string
+	LogFileSize   int // bytes; if >0, enables rotation with 1 backup
 	IPv4VIPs      []string
 	IPv6VIPs      []string
 	Routers       []routerData
@@ -56,7 +57,11 @@ type routerData struct {
 //nolint:lll
 var birdConfigTmpl = template.Must(template.New("bird.conf").Parse(`log stderr all;
 {{- if .LogFile}}
+{{- if .LogFileSize}}
+log "{{.LogFile}}" {{.LogFileSize}} "{{.LogFile}}.1" all;
+{{- else}}
 log "{{.LogFile}}" all;
+{{- end}}
 {{- end}}
 
 protocol device {}

--- a/internal/common/config/router.go
+++ b/internal/common/config/router.go
@@ -33,6 +33,7 @@ type RouterConfig struct {
 	MetricsCertKey   string
 	EnableHTTP2      bool
 	BirdLogFile      string
+	BirdLogFileSize  int
 }
 
 // AddFlags adds configuration flags to the provided FlagSet
@@ -60,6 +61,8 @@ func (c *RouterConfig) AddFlags(fs *pflag.FlagSet) {
 		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
 	fs.StringVar(&c.BirdLogFile, "bird-log-file", "/var/log/bird/bird.log",
 		"Path to BIRD log file. BIRD writes protocol and routing events here.")
+	fs.IntVar(&c.BirdLogFileSize, "bird-log-file-size", 0,
+		"Max BIRD log file size in bytes. If >0, enables log rotation with 1 backup file.")
 }
 
 // BindEnv binds environment variables to configuration fields
@@ -77,4 +80,5 @@ func (c *RouterConfig) BindEnv(fs *pflag.FlagSet) {
 	bindString(fs, "metrics-cert-key", "MERIDIO_METRICS_CERT_KEY", &c.MetricsCertKey)
 	bindBool(fs, "enable-http2", "MERIDIO_ENABLE_HTTP2", &c.EnableHTTP2)
 	bindString(fs, "bird-log-file", "MERIDIO_BIRD_LOG_FILE", &c.BirdLogFile)
+	bindInt(fs, "bird-log-file-size", "MERIDIO_BIRD_LOG_FILE_SIZE", &c.BirdLogFileSize)
 }


### PR DESCRIPTION
Related to #67 

Configure BIRD's native log rotation via bird.conf when a file size limit is provided. BIRD rotates the log file when it exceeds the limit, keeping 1 backup file (<logfile>.1).

Router:
- Add LogFileSize field and WithLogFileSize option to Bird struct
- bird.conf template: generate size/backup syntax when LogFileSize > 0
- Add --bird-log-file-size flag / MERIDIO_BIRD_LOG_FILE_SIZE env var

LB deployment template:
- Set MERIDIO_BIRD_LOG_FILE_SIZE=104857600 (100 MiB) on router container
- Remove emptyDir sizeLimit on bird-log volume (BIRD handles rotation)