### PR TITLE
Adjust the go template generating bird config

### DIFF
--- a/internal/bird/bird.go
+++ b/internal/bird/bird.go
@@ -20,8 +20,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"os/exec"
+	"slices"
 	"strings"
 	"sync"
 	"syscall"
@@ -158,13 +160,26 @@ func (b *Bird) generateConfig(vips []string, routers []*meridio2v1alpha1.Gateway
 		}
 	}
 
+	slices.SortFunc(routers, func(a, b *meridio2v1alpha1.GatewayRouter) int {
+		if a.Name < b.Name {
+			return -1
+		}
+		if a.Name > b.Name {
+			return 1
+		}
+		return 0
+	})
+
+	ifset := make(map[string]bool)
 	for _, r := range routers {
 		rd, err := toRouterData(r)
 		if err != nil {
 			return "", err
 		}
 		data.Routers = append(data.Routers, rd)
+		ifset[r.Spec.Interface] = true
 	}
+	data.BGPInterfaces = slices.Sorted(maps.Keys(ifset))
 
 	var buf strings.Builder
 	if err := birdConfigTmpl.Execute(&buf, data); err != nil {

--- a/internal/bird/bird_test.go
+++ b/internal/bird/bird_test.go
@@ -137,7 +137,7 @@ template bgp BGP_TEMPLATE {
 	debug {events, states};
 	direct;
 	hold time 90;
-	bfd on;
+	bfd off;
 	graceful restart off;
 	setkey off;
 	ipv4 {
@@ -173,13 +173,13 @@ protocol kernel {
 }
 
 protocol bfd {
-	interface "*" {};
+	accept direct;
+	interface "vlan-100" {};
 }
 
 protocol static VIP4 {
 	ipv4 { preference 110; };
 	route 20.0.0.1/32 via "lo";
-
 }
 
 protocol bgp 'NBR-gatewayrouter-sample' from BGP_TEMPLATE {
@@ -200,6 +200,95 @@ protocol bgp 'NBR-gatewayrouter-sample' from BGP_TEMPLATE {
 
 		if normalizeWhitespace(got) != normalizeWhitespace(want) {
 			t.Errorf("config mismatch\nGot:\n%s\n\nWant:\n%s", got, want)
+		}
+	})
+
+	t.Run("duplicate interface dedup", func(t *testing.T) {
+		routers := []*meridio2v1alpha1.GatewayRouter{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "gw-v4"},
+				Spec: meridio2v1alpha1.GatewayRouterSpec{
+					Interface: "net1", Address: "192.168.1.1",
+					BGP: meridio2v1alpha1.BgpSpec{RemoteASN: 65000, LocalASN: 65001},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "gw-v6"},
+				Spec: meridio2v1alpha1.GatewayRouterSpec{
+					Interface: "net1", Address: "fd00::1",
+					BGP: meridio2v1alpha1.BgpSpec{RemoteASN: 65000, LocalASN: 65001},
+				},
+			},
+		}
+
+		conf, err := b.generateConfig([]string{}, routers)
+		if err != nil {
+			t.Fatalf("generateConfig() error = %v", err)
+		}
+
+		count := strings.Count(conf, `interface "net1" {}`)
+		if count != 1 {
+			t.Errorf("expected 1 BFD interface entry, got %d\n%s", count, conf)
+		}
+	})
+
+	t.Run("sorted by name with 4 routers", func(t *testing.T) {
+		routers := []*meridio2v1alpha1.GatewayRouter{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "D"},
+				Spec: meridio2v1alpha1.GatewayRouterSpec{
+					Interface: "if_D", Address: "192.168.4.1",
+					BGP: meridio2v1alpha1.BgpSpec{RemoteASN: 65000, LocalASN: 65001},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "B"},
+				Spec: meridio2v1alpha1.GatewayRouterSpec{
+					Interface: "if_B", Address: "192.168.2.1",
+					BGP: meridio2v1alpha1.BgpSpec{RemoteASN: 65000, LocalASN: 65001},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "C"},
+				Spec: meridio2v1alpha1.GatewayRouterSpec{
+					Interface: "if_C", Address: "192.168.3.1",
+					BGP: meridio2v1alpha1.BgpSpec{RemoteASN: 65000, LocalASN: 65001},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "A"},
+				Spec: meridio2v1alpha1.GatewayRouterSpec{
+					Interface: "if_A", Address: "192.168.1.1",
+					BGP: meridio2v1alpha1.BgpSpec{RemoteASN: 65000, LocalASN: 65001},
+				},
+			},
+		}
+
+		conf, err := b.generateConfig([]string{}, routers)
+		if err != nil {
+			t.Fatalf("generateConfig() error = %v", err)
+		}
+
+		// Verify BFD interface ordering is sorted alphabetically
+		wantIfOrder := []string{`interface "if_A"`, `interface "if_B"`, `interface "if_C"`, `interface "if_D"`}
+		prev := 0
+		for _, s := range wantIfOrder {
+			idx := strings.Index(conf[prev:], s)
+			if idx < 0 {
+				t.Fatalf("BFD interface %q not found after position %d", s, prev)
+			}
+			prev += idx + len(s)
+		}
+
+		// Verify BGP protocol ordering is sorted by router name
+		wantBGPOrder := []string{"NBR-A", "NBR-B", "NBR-C", "NBR-D"}
+		prev = 0
+		for _, s := range wantBGPOrder {
+			idx := strings.Index(conf[prev:], s)
+			if idx < 0 {
+				t.Fatalf("BGP protocol %q not found after position %d", s, prev)
+			}
+			prev += idx + len(s)
 		}
 	})
 }

--- a/internal/bird/config.go
+++ b/internal/bird/config.go
@@ -39,6 +39,7 @@ type birdConfigData struct {
 	IPv4VIPs       []string
 	IPv6VIPs       []string
 	Routers        []routerData
+	BGPInterfaces  []string
 }
 
 type routerData struct {
@@ -79,7 +80,7 @@ template bgp BGP_TEMPLATE {
 	debug {events, states};
 	direct;
 	hold time 90;
-	bfd on;
+	bfd off;
 	graceful restart off;
 	setkey off;
 	ipv4 {
@@ -115,7 +116,14 @@ protocol kernel {
 }
 
 protocol bfd {
+	accept direct;
+{{- if .BGPInterfaces}}
+{{- range .BGPInterfaces}}
+	interface "{{.}}" {};
+{{- end}}
+{{- else}}
 	interface "*" {};
+{{- end}}
 }
 {{- if .IPv4VIPs}}
 


### PR DESCRIPTION
- By default it should use bfd off.
- Only interfaces between routers are now present in the bfd secion.
- Added some tests

Restricting the multihop didn't seem necessary, according to the bird config, and our 1000 handed ai companion for multihop setup you would need the multihop {} field set, so present should only be single hop.

https://github.com/Nordix/Meridio-2/issues/59?issue=Nordix%7CMeridio-2%7C72