### PR TITLE
Add OCI image labels for build metadata

### DIFF
--- a/build/controller-manager/Dockerfile
+++ b/build/controller-manager/Dockerfile
@@ -36,6 +36,8 @@ FROM alpine:3.22
 ARG USER
 ARG UID
 ARG HOME=/home/${USER}
+ARG GIT_COMMIT=unknown
+ARG BUILD_DATE=unknown
 
 RUN addgroup -g ${UID} ${USER} \
   && adduser -D -h ${HOME} -u ${UID} -G ${USER} ${USER} \
@@ -44,5 +46,8 @@ RUN addgroup -g ${UID} ${USER} \
 WORKDIR ${HOME}
 COPY --from=builder /workspace/manager .
 USER ${UID}:${UID}
+
+LABEL org.opencontainers.image.revision="${GIT_COMMIT}" \
+      org.opencontainers.image.created="${BUILD_DATE}"
 
 ENTRYPOINT ["./manager", "run"]

--- a/build/network-sidecar/Dockerfile
+++ b/build/network-sidecar/Dockerfile
@@ -36,6 +36,8 @@ FROM alpine:3.22
 ARG USER
 ARG UID
 ARG HOME=/home/${USER}
+ARG GIT_COMMIT=unknown
+ARG BUILD_DATE=unknown
 
 RUN apk add --no-cache libcap \
   && addgroup -g ${UID} ${USER} \
@@ -47,5 +49,8 @@ COPY --from=builder /workspace/network-sidecar .
 RUN setcap 'cap_net_admin+ep' ./network-sidecar
 
 USER ${UID}:${UID}
+
+LABEL org.opencontainers.image.revision="${GIT_COMMIT}" \
+      org.opencontainers.image.created="${BUILD_DATE}"
 
 ENTRYPOINT ["./network-sidecar", "run"]

--- a/build/router/Dockerfile
+++ b/build/router/Dockerfile
@@ -27,10 +27,13 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build \
               -X github.com/nordix/meridio-2/internal/common/version.BuildDate=${BUILD_DATE}" \
     -a -o router ./cmd/router
 
+# Runtime stage
 FROM alpine
 ARG USER
 ARG UID
 ARG HOME
+ARG GIT_COMMIT=unknown
+ARG BUILD_DATE=unknown
 
 RUN apk update && apk add iproute2 tcpdump nftables bird iputils net-tools libcap \
   && setcap 'cap_sys_ptrace,cap_dac_override+ep' /sbin/ss \
@@ -49,5 +52,8 @@ COPY --from=builder /workspace/router .
 RUN setcap 'cap_net_admin+ep' ./router \
   && setcap 'cap_net_admin,cap_net_bind_service,cap_net_raw+ep' /usr/sbin/bird
 USER ${UID}:${UID}
+
+LABEL org.opencontainers.image.revision="${GIT_COMMIT}" \
+      org.opencontainers.image.created="${BUILD_DATE}"
 
 ENTRYPOINT ["./router", "run"]

--- a/build/stateless-load-balancer/Dockerfile
+++ b/build/stateless-load-balancer/Dockerfile
@@ -51,6 +51,8 @@ RUN curl -L https://netfilter.org/projects/libmnl/files/libmnl-1.0.4.tar.bz2 > /
 FROM alpine:3.22
 ARG USER
 ARG UID
+ARG GIT_COMMIT=unknown
+ARG BUILD_DATE=unknown
 
 RUN apk update && apk add iproute2 tcpdump nftables libcap
 
@@ -67,5 +69,8 @@ RUN setcap 'cap_net_admin+ep' /app/stateless-load-balancer \
   && setcap 'cap_net_admin+ep' /usr/sbin/nft
 
 USER ${UID}:${UID}
+
+LABEL org.opencontainers.image.revision="${GIT_COMMIT}" \
+      org.opencontainers.image.created="${BUILD_DATE}"
 
 ENTRYPOINT ["/app/stateless-load-balancer", "run"]


### PR DESCRIPTION
## Summary

Adds OCI standard image labels to all four container images to expose git commit SHA and build timestamp as image metadata.

## Changes

- Added `org.opencontainers.image.revision` label (git commit SHA)
- Added `org.opencontainers.image.created` label (build timestamp)
- Applied to all images:
  - `controller-manager`
  - `network-sidecar`
  - `stateless-load-balancer`
  - `router`

## Implementation

The labels are added to the final stage of each Dockerfile using the existing `GIT_COMMIT` and `BUILD_DATE` build args that are already passed from the Makefile and embedded in the binaries.

## Benefits

- **Traceability**: Easily identify which git commit produced an image
- **Tooling integration**: Container registries (Docker Hub, GHCR) automatically display OCI labels
- **Consistency**: Same metadata in both binary (`--version`) and image labels
- **Standards compliance**: Follows [OCI image spec annotations](https://github.com/opencontainers/image-spec/blob/main/annotations.md)