### PR TITLE
Stop router if either bird, or monitor fails.

### DIFF
--- a/cmd/router/cmd/run.go
+++ b/cmd/router/cmd/run.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"golang.org/x/sync/errgroup"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -151,18 +152,28 @@ func runRouter(ctx context.Context, cfg *config.RouterConfig) error {
 	setupLog.Info("starting router", "gateway", cfg.GatewayName, "namespace", cfg.GatewayNamespace)
 
 	ctx = ctrl.SetupSignalHandler()
+	g, ctx := errgroup.WithContext(ctx)
 
-	go func() {
+	g.Go(func() error {
 		if err := birdInstance.Run(ctx); err != nil {
-			setupLog.Error(err, "BIRD stopped")
+			return fmt.Errorf("BIRD stopped: %w", err)
 		}
-	}()
+		if ctx.Err() == nil {
+			return fmt.Errorf("BIRD exited unexpectedly")
+		}
+		return nil
+	})
 
-	// Start monitoring BGP connectivity
-	go monitorConnectivity(ctx, mgr, birdInstance)
+	g.Go(func() error {
+		return monitorConnectivity(ctx, mgr, birdInstance)
+	})
 
-	if err := mgr.Start(ctx); err != nil {
-		setupLog.Error(err, "problem running manager")
+	g.Go(func() error {
+		return mgr.Start(ctx)
+	})
+
+	if err := g.Wait(); err != nil {
+		setupLog.Error(err, "router exited")
 		return err
 	}
 
@@ -170,20 +181,18 @@ func runRouter(ctx context.Context, cfg *config.RouterConfig) error {
 }
 
 // monitorConnectivity monitors BGP connectivity and logs status changes
-func monitorConnectivity(ctx context.Context, mgr ctrl.Manager, birdInstance *bird.Bird) {
+func monitorConnectivity(ctx context.Context, mgr ctrl.Manager, birdInstance *bird.Bird) error {
 	log := ctrl.Log.WithName("monitor")
 
 	// Wait for manager cache to sync
 	if !mgr.GetCache().WaitForCacheSync(ctx) {
-		log.Error(nil, "failed to wait for cache sync")
-		return
+		return fmt.Errorf("failed to wait for cache sync")
 	}
 
 	// Start monitoring with 1 second interval
 	statusCh, err := birdInstance.Monitor(ctx, 1*time.Second)
 	if err != nil {
-		log.Error(err, "failed to start monitoring")
-		return
+		return fmt.Errorf("failed to start monitoring: %w", err)
 	}
 
 	var lastCount int
@@ -192,10 +201,13 @@ func monitorConnectivity(ctx context.Context, mgr ctrl.Manager, birdInstance *bi
 	for {
 		select {
 		case <-ctx.Done():
-			return
+			return nil
 		case status, ok := <-statusCh:
 			if !ok {
-				return
+				if ctx.Err() != nil {
+					return nil
+				}
+				return fmt.Errorf("monitor channel closed unexpectedly")
 			}
 
 			count := protocolsUp(status.Protocols)

--- a/go.mod
+++ b/go.mod
@@ -89,7 +89,7 @@ require (
 	golang.org/x/mod v0.29.0 // indirect
 	golang.org/x/net v0.47.0 // indirect
 	golang.org/x/oauth2 v0.30.0 // indirect
-	golang.org/x/sync v0.18.0 // indirect
+	golang.org/x/sync v0.18.0
 	golang.org/x/sys v0.38.0
 	golang.org/x/term v0.37.0 // indirect
 	golang.org/x/text v0.31.0 // indirect

--- a/internal/bird/bird.go
+++ b/internal/bird/bird.go
@@ -33,8 +33,6 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
-var errBirdRunning = errors.New("bird is already running")
-
 // BirdInterface defines the interface for BIRD operations
 type BirdInterface interface {
 	Run(ctx context.Context) error
@@ -78,7 +76,7 @@ func (b *Bird) Run(ctx context.Context) error {
 	b.mu.Lock()
 	if b.running {
 		b.mu.Unlock()
-		return errBirdRunning
+		return fmt.Errorf("BIRD is already running")
 	}
 
 	if _, err := os.Stat(b.ConfigFile); errors.Is(err, os.ErrNotExist) {
@@ -95,7 +93,7 @@ func (b *Bird) Run(ctx context.Context) error {
 	cmd.WaitDelay = 3 * time.Second
 	if err := cmd.Start(); err != nil {
 		b.mu.Unlock()
-		return fmt.Errorf("bird failed to start: %w", err)
+		return fmt.Errorf("BIRD failed to start: %w", err)
 	}
 
 	b.running = true
@@ -105,7 +103,7 @@ func (b *Bird) Run(ctx context.Context) error {
 		b.mu.Lock()
 		b.running = false
 		b.mu.Unlock()
-		return fmt.Errorf("bird failed: %w", err)
+		return fmt.Errorf("BIRD failed: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
https://github.com/Nordix/Meridio-2/issues/62
https://github.com/Nordix/Meridio-2/issues/61

It turned out to be pretty basic, just added a cancel, to the context used for the monitor, bird, and the manager.

I'm not quite sure whether we want to fail in cases if for example birdc call fails, but I'm guessing its best to leave it for the time when we do the VIP exposure on the readiness gates