### PR TITLE
Fix belongsToGateway to check DistributionGroup.spec.parentRefs

### DIFF
--- a/docs/operations/constraints-and-limitations.md
+++ b/docs/operations/constraints-and-limitations.md
@@ -48,25 +48,21 @@ Resource changes in `GatewayConfiguration.spec.verticalScaling` trigger Pod recr
 
 The LB controller assigns fwmarks and routing table IDs using the formula `DG_ID × 1024 + 5000 + endpoint_identifier`, where DG_ID is assigned sequentially per DistributionGroup. The base offset (5000), multiplier (1024), and the use of fwmark as table ID are hardcoded and not configurable. The multiplier of 1024 imposes a hard limit of 1024 endpoints per DistributionGroup at the LB routing level. This range must not overlap with other fwmark or routing table usage on the LB Pod's network namespace. Note: DG_ID assignment is in-memory and sequential — when multiple DGs are created concurrently, different LB Pods may assign different DG_IDs to the same DistributionGroup, resulting in different routing table ranges per LB for the same DG. This is acceptable as the routing tables are local to each LB Pod.
 
-**10. DistributionGroups with only direct `parentRefs` are not processed by the LB**
-
-The `belongsToGateway` check resolves DG-to-Gateway membership only via L34Routes (checks if any L34Route references both this Gateway and the DG). It does not check `DistributionGroup.spec.parentRefs`. The `gatewayEnqueue` mapper does check `parentRefs` to trigger reconciliation, but the reconcile loop then skips the DG because `belongsToGateway` returns false. A DG with only a direct `parentRef` (no L34Route) will be enqueued but not processed. Fix: extend `belongsToGateway` to also check `distGroup.Spec.ParentRefs`.
-
 ## Router Controller
 
-**11. VIPs advertised regardless of LB distribution readiness**
+**10. VIPs advertised regardless of LB distribution readiness**
 
 VIPs are announced via BGP as soon as the router's BGP sessions are established, without waiting for the collocated LB to have active endpoints. This can cause traffic loss during LB Pod startup or scale-out: external traffic is attracted before the LB is capable of distributing it to application endpoints.
 
-**12. No connectivity-based readiness signaling to the controller-manager**
+**11. No connectivity-based readiness signaling to the controller-manager**
 
 The router only logs BGP state changes — it does not set Pod readiness gates or signal the controller-manager about external connectivity status. As a result, the ENC controller cannot react to a running LB Pod losing external connectivity. The network sidecar's next-hop list will not be updated when an LB Pod's BGP sessions go down, meaning application Pods may continue routing return traffic through an LB that has lost external connectivity.
 
-**13. BIRD error propagation missing**
+**12. BIRD error propagation missing**
 
 If BIRD crashes, the router controller continues running with healthy probes while doing nothing. BIRD failure is not propagated to the process lifecycle.
 
-**14. BGP-learned routes may be delayed up to 60 seconds in kernel routing table**
+**13. BGP-learned routes may be delayed up to 60 seconds in kernel routing table**
 
 The `kernel` protocol blocks in the generated bird.conf do not set `scan time`. BIRD 3.x's default is 60 seconds, which can delay BGP-learned routes from appearing in the kernel routing table by 30-50 seconds. Meridio v1 fixed this with `scan time 10`.
 
@@ -74,64 +70,64 @@ The `kernel` protocol blocks in the generated bird.conf do not set `scan time`. 
 
 PMTU handling is implemented: the LB controller creates a nftables PMTU SNAT chain at startup that rewrites ICMP Frag Needed / Packet Too Big source addresses to the VIP. Requires `fwmark_reflect` sysctls — see [Gateway controller docs](../controllers/gateway.md#sysctl-prerequisites-for-lb-pods).
 
-**16. BGP authentication not supported**
+**15. BGP authentication not supported**
 
 The GatewayRouter CRD has no field for BGP MD5 or TCP-AO authentication. Meridio v1 supported this.
 
-**17. Static routing with BFD not supported**
+**16. Static routing with BFD not supported**
 
 Only BGP-based GatewayRouter configuration is implemented. Static routing with BFD (as an alternative to BGP for simpler deployments) is not supported.
 
-**18. BFD not fully restricted**
+**17. BFD not fully restricted**
 
 BFD source ports are not restricted to the IANA-approved range (49152–65535) per RFC 5881 — BIRD on Linux does not support `IP_PORTRANGE`, requiring a `ip_local_port_range` sysctl workaround that is not yet configured. BFD is not restricted to single-hop mode port (3784), and BFD sessions are not restricted by configuration to the external interface(s) only.
 
 ## Sidecar Controller
 
-**19. No sidecar restart recovery**
+**18. No sidecar restart recovery**
 
 All in-memory state (`tableIDs`, `managedVIPs`) is lost on sidecar container restart. This causes VIP leaks (old VIPs not removed from the interface) and orphaned routing rules/tables when table IDs are reallocated differently after restart. Restarting the sidecar container/process is not recommended.
 
-**20. Sidecar policy routing rule priority not configurable** *(architectural constraint)*
+**19. Sidecar policy routing rule priority not configurable** *(architectural constraint)*
 
 Source-based routing rules (`ip rule`) are created without an explicit priority. The kernel auto-assigns priorities just below the `main` table (32766), which produces correct ordering for the current use case. However, the priority is not configurable.
 
-**21. Sidecar uses routing table ID range 50000–55000** *(architectural constraint)*
+**20. Sidecar uses routing table ID range 50000–55000** *(architectural constraint)*
 
 The network sidecar allocates kernel routing table IDs from the range 50000–55000 (one table per Gateway connection). This range must not overlap with routing tables used by other components in the Pod's network namespace. The range is configurable via `--min-table-id` / `--max-table-id` (or `MERIDIO_MIN_TABLE_ID` / `MERIDIO_MAX_TABLE_ID`).
 
 ## DistributionGroup Controller
 
-**22. Default `maxEndpoints` per DistributionGroup is 32**
+**21. Default `maxEndpoints` per DistributionGroup is 32**
 
 When `DistributionGroup.spec.maglev.maxEndpoints` is not set, the controller defaults to 32 endpoints. This is the current MVP default and may be revised. The equivalent parameter in Meridio v1 (`MaxTargets`) defaulted to 100.
 
-**23. Node failure detection not implemented**
+**22. Node failure detection not implemented**
 
 When a Node becomes NotReady, the controller does not immediately reconcile affected DistributionGroups to remove endpoints on that Node. Endpoint removal is delayed until the Pod deletion propagates, or Pod readiness changes.
 
 ## Deployment / Operations
 
-**24. No runtime log level change**
+**23. No runtime log level change**
 
 Log level is set at startup via `--log-level` / `MERIDIO_LOG_LEVEL` and cannot be changed without restarting the process. All four controllers (controller-manager, router, loadbalancer, sidecar) share this limitation.
 
-**25. No cert-wait-timeout**
+**24. No cert-wait-timeout**
 
 The controller-manager crashes immediately if TLS certificates are not yet provisioned. When deployed simultaneously with cert-manager (e.g., via a single Helm chart), this causes several restart cycles before certs are ready.
 
-**26. Minimum Kubernetes version 1.31** *(architectural constraint)*
+**25. Minimum Kubernetes version 1.31** *(architectural constraint)*
 
 Required by CEL CIDR/IP validation libraries used in CRD validation rules (`isCIDR()`, `cidr().prefixLength()`, `ip().family()`). For MVP, some CEL validations have been temporarily removed to allow running on older Kubernetes versions where test environments with 1.31+ were not available. This is a temporary workaround — the full CEL validations must be restored for production use.
 
-**27. Upgrades not verified**
+**26. Upgrades not verified**
 
 No upgrade path has been tested or documented. In-place upgrades of the controller-manager, LB Pods, or sidecar containers should be treated as untested. CRD schema changes, controller behavior changes between versions may cause disruption.
 
-**28. Scaling not extensively verified**
+**27. Scaling not extensively verified**
 
 Basic functionality has been tested with a small number of Gateways, DistributionGroups, and application Pods. Behavior at scale (many Gateways, large numbers of endpoints per DG, high Pod churn) has not been systematically verified. Dynamic scaling of LB Deployment replicas (via `GatewayConfiguration.spec.horizontalScaling` or HPA) has also not been extensively tested. Scaling may work but is best-effort for the MVP.
 
-**29. Controller-manager multi-replica deployment not verified**
+**28. Controller-manager multi-replica deployment not verified**
 
 The controller-manager enables leader election by default in the deployment manifest (`--leader-elect`, using controller-runtime's lease-based leader election with ID `e9d059a3.nordix.org`), but running multiple replicas for high availability has not been tested.

--- a/docs/operations/constraints-and-limitations.md
+++ b/docs/operations/constraints-and-limitations.md
@@ -48,90 +48,86 @@ Resource changes in `GatewayConfiguration.spec.verticalScaling` trigger Pod recr
 
 The LB controller assigns fwmarks and routing table IDs using the formula `DG_ID × 1024 + 5000 + endpoint_identifier`, where DG_ID is assigned sequentially per DistributionGroup. The base offset (5000), multiplier (1024), and the use of fwmark as table ID are hardcoded and not configurable. The multiplier of 1024 imposes a hard limit of 1024 endpoints per DistributionGroup at the LB routing level. This range must not overlap with other fwmark or routing table usage on the LB Pod's network namespace. Note: DG_ID assignment is in-memory and sequential — when multiple DGs are created concurrently, different LB Pods may assign different DG_IDs to the same DistributionGroup, resulting in different routing table ranges per LB for the same DG. This is acceptable as the routing tables are local to each LB Pod.
 
-**10. DistributionGroups with only direct `parentRefs` are not processed by the LB**
-
-The `belongsToGateway` check resolves DG-to-Gateway membership only via L34Routes (checks if any L34Route references both this Gateway and the DG). It does not check `DistributionGroup.spec.parentRefs`. The `gatewayEnqueue` mapper does check `parentRefs` to trigger reconciliation, but the reconcile loop then skips the DG because `belongsToGateway` returns false. A DG with only a direct `parentRef` (no L34Route) will be enqueued but not processed. Fix: extend `belongsToGateway` to also check `distGroup.Spec.ParentRefs`.
-
 ## Router Controller
 
-**11. VIPs advertised regardless of LB distribution readiness**
+**10. VIPs advertised regardless of LB distribution readiness**
 
 VIPs are announced via BGP as soon as the router's BGP sessions are established, without waiting for the collocated LB to have active endpoints. This can cause traffic loss during LB Pod startup or scale-out: external traffic is attracted before the LB is capable of distributing it to application endpoints.
 
-**12. No connectivity-based readiness signaling to the controller-manager**
+**11. No connectivity-based readiness signaling to the controller-manager**
 
 The router only logs BGP state changes — it does not set Pod readiness gates or signal the controller-manager about external connectivity status. As a result, the ENC controller cannot react to a running LB Pod losing external connectivity. The network sidecar's next-hop list will not be updated when an LB Pod's BGP sessions go down, meaning application Pods may continue routing return traffic through an LB that has lost external connectivity.
 
-**13. BIRD error propagation missing**
+**12. BIRD error propagation missing**
 
 If BIRD crashes, the router controller continues running with healthy probes while doing nothing. BIRD failure is not propagated to the process lifecycle.
 
-**14. BGP-learned routes may be delayed up to 60 seconds in kernel routing table**
+**13. BGP-learned routes may be delayed up to 60 seconds in kernel routing table**
 
 The `kernel` protocol blocks in the generated bird.conf do not set `scan time`. BIRD 3.x's default is 60 seconds, which can delay BGP-learned routes from appearing in the kernel routing table by 30-50 seconds. Meridio v1 fixed this with `scan time 10`.
 
-**15. PMTU handling not implemented in LB Pods**
+**14. PMTU handling not implemented in LB Pods**
 
 The nftables rules and sysctls required to handle MTU differences between external and internal networks are not in place. This may cause issues when the external network has a larger MTU than the internal network towards application endpoints.
 
-**16. BGP authentication not supported**
+**15. BGP authentication not supported**
 
 The GatewayRouter CRD has no field for BGP MD5 or TCP-AO authentication. Meridio v1 supported this.
 
-**17. Static routing with BFD not supported**
+**16. Static routing with BFD not supported**
 
 Only BGP-based GatewayRouter configuration is implemented. Static routing with BFD (as an alternative to BGP for simpler deployments) is not supported.
 
-**18. BFD not fully restricted**
+**17. BFD not fully restricted**
 
 BFD source ports are not restricted to the IANA-approved range (49152–65535) per RFC 5881 — BIRD on Linux does not support `IP_PORTRANGE`, requiring a `ip_local_port_range` sysctl workaround that is not yet configured. BFD is not restricted to single-hop mode port (3784), and BFD sessions are not restricted by configuration to the external interface(s) only.
 
 ## Sidecar Controller
 
-**19. No sidecar restart recovery**
+**18. No sidecar restart recovery**
 
 All in-memory state (`tableIDs`, `managedVIPs`) is lost on sidecar container restart. This causes VIP leaks (old VIPs not removed from the interface) and orphaned routing rules/tables when table IDs are reallocated differently after restart. Restarting the sidecar container/process is not recommended.
 
-**20. Sidecar policy routing rule priority not configurable** *(architectural constraint)*
+**19. Sidecar policy routing rule priority not configurable** *(architectural constraint)*
 
 Source-based routing rules (`ip rule`) are created without an explicit priority. The kernel auto-assigns priorities just below the `main` table (32766), which produces correct ordering for the current use case. However, the priority is not configurable.
 
-**21. Sidecar uses routing table ID range 50000–55000** *(architectural constraint)*
+**20. Sidecar uses routing table ID range 50000–55000** *(architectural constraint)*
 
 The network sidecar allocates kernel routing table IDs from the range 50000–55000 (one table per Gateway connection). This range must not overlap with routing tables used by other components in the Pod's network namespace. The range is configurable via `--min-table-id` / `--max-table-id` (or `MERIDIO_MIN_TABLE_ID` / `MERIDIO_MAX_TABLE_ID`).
 
 ## DistributionGroup Controller
 
-**22. Default `maxEndpoints` per DistributionGroup is 32**
+**21. Default `maxEndpoints` per DistributionGroup is 32**
 
 When `DistributionGroup.spec.maglev.maxEndpoints` is not set, the controller defaults to 32 endpoints. This is the current MVP default and may be revised. The equivalent parameter in Meridio v1 (`MaxTargets`) defaulted to 100.
 
-**23. Node failure detection not implemented**
+**22. Node failure detection not implemented**
 
 When a Node becomes NotReady, the controller does not immediately reconcile affected DistributionGroups to remove endpoints on that Node. Endpoint removal is delayed until the Pod deletion propagates, or Pod readiness changes.
 
 ## Deployment / Operations
 
-**24. No runtime log level change**
+**23. No runtime log level change**
 
 Log level is set at startup via `--log-level` / `MERIDIO_LOG_LEVEL` and cannot be changed without restarting the process. All four controllers (controller-manager, router, loadbalancer, sidecar) share this limitation.
 
-**25. No cert-wait-timeout**
+**24. No cert-wait-timeout**
 
 The controller-manager crashes immediately if TLS certificates are not yet provisioned. When deployed simultaneously with cert-manager (e.g., via a single Helm chart), this causes several restart cycles before certs are ready.
 
-**26. Minimum Kubernetes version 1.31** *(architectural constraint)*
+**25. Minimum Kubernetes version 1.31** *(architectural constraint)*
 
 Required by CEL CIDR/IP validation libraries used in CRD validation rules (`isCIDR()`, `cidr().prefixLength()`, `ip().family()`). For MVP, some CEL validations have been temporarily removed to allow running on older Kubernetes versions where test environments with 1.31+ were not available. This is a temporary workaround — the full CEL validations must be restored for production use.
 
-**27. Upgrades not verified**
+**26. Upgrades not verified**
 
 No upgrade path has been tested or documented. In-place upgrades of the controller-manager, LB Pods, or sidecar containers should be treated as untested. CRD schema changes, controller behavior changes between versions may cause disruption.
 
-**28. Scaling not extensively verified**
+**27. Scaling not extensively verified**
 
 Basic functionality has been tested with a small number of Gateways, DistributionGroups, and application Pods. Behavior at scale (many Gateways, large numbers of endpoints per DG, high Pod churn) has not been systematically verified. Dynamic scaling of LB Deployment replicas (via `GatewayConfiguration.spec.horizontalScaling` or HPA) has also not been extensively tested. Scaling may work but is best-effort for the MVP.
 
-**29. Controller-manager multi-replica deployment not verified**
+**28. Controller-manager multi-replica deployment not verified**
 
 The controller-manager enables leader election by default in the deployment manifest (`--leader-elect`, using controller-runtime's lease-based leader election with ID `e9d059a3.nordix.org`), but running multiple replicas for high availability has not been tested.

--- a/internal/controller/loadbalancer/controller.go
+++ b/internal/controller/loadbalancer/controller.go
@@ -86,7 +86,11 @@ type nftablesManager interface {
 	Cleanup() error
 }
 
-const kindDistributionGroup = "DistributionGroup"
+const (
+	kindDistributionGroup = "DistributionGroup"
+	groupGatewayAPI       = "gateway.networking.k8s.io"
+	kindGateway           = "Gateway"
+)
 
 func (c *Controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logr := log.FromContext(ctx)
@@ -188,6 +192,27 @@ func (c *Controller) cleanupDistributionGroup(ctx context.Context, distGroupName
 // belongsToGateway checks if a DistributionGroup belongs to this Gateway
 // by checking if any L34Route references both this Gateway and this DistributionGroup
 func (c *Controller) belongsToGateway(ctx context.Context, distGroup *meridio2v1alpha1.DistributionGroup) (bool, error) {
+	// 1. Direct parentRefs: DistributionGroup.spec.parentRefs → Gateway
+	for _, parentRef := range distGroup.Spec.ParentRefs {
+		group := groupGatewayAPI
+		if parentRef.Group != nil {
+			group = *parentRef.Group
+		}
+		kind := kindGateway
+		if parentRef.Kind != nil {
+			kind = *parentRef.Kind
+		}
+		namespace := distGroup.Namespace
+		if parentRef.Namespace != nil {
+			namespace = *parentRef.Namespace
+		}
+		if group == groupGatewayAPI && kind == kindGateway &&
+			parentRef.Name == c.GatewayName && namespace == c.GatewayNamespace {
+			return true, nil
+		}
+	}
+
+	// 2. Indirect via L34Route: L34Route.parentRefs → Gateway AND L34Route.backendRefs → DG
 	l34routeList := &meridio2v1alpha1.L34RouteList{}
 	if err := c.List(ctx, l34routeList, client.InNamespace(c.GatewayNamespace)); err != nil {
 		return false, fmt.Errorf("failed to list L34Routes: %w", err)

--- a/internal/controller/loadbalancer/controller.go
+++ b/internal/controller/loadbalancer/controller.go
@@ -88,7 +88,7 @@ type nftablesManager interface {
 
 const (
 	kindDistributionGroup = "DistributionGroup"
-	groupGatewayAPI       = "gateway.networking.k8s.io"
+	groupGatewayAPI       = gatewayv1.GroupName
 	kindGateway           = "Gateway"
 )
 

--- a/internal/controller/loadbalancer/controller_test.go
+++ b/internal/controller/loadbalancer/controller_test.go
@@ -254,6 +254,76 @@ var _ = Describe("LoadBalancer Controller", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(BeFalse())
 		})
+
+		It("should return true when DistributionGroup has direct parentRef to this Gateway", func() {
+			distGroup := &meridio2v1alpha1.DistributionGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-distgroup",
+					Namespace: namespace,
+				},
+				Spec: meridio2v1alpha1.DistributionGroupSpec{
+					ParentRefs: []meridio2v1alpha1.ParentReference{
+						{Name: gatewayName},
+					},
+				},
+			}
+
+			fakeClient = fake.NewClientBuilder().
+				WithScheme(scheme).
+				Build()
+			controller.Client = fakeClient
+
+			result, err := controller.belongsToGateway(ctx, distGroup)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeTrue())
+		})
+
+		It("should return false when DistributionGroup has parentRef to different Gateway", func() {
+			distGroup := &meridio2v1alpha1.DistributionGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-distgroup",
+					Namespace: namespace,
+				},
+				Spec: meridio2v1alpha1.DistributionGroupSpec{
+					ParentRefs: []meridio2v1alpha1.ParentReference{
+						{Name: "other-gateway"},
+					},
+				},
+			}
+
+			fakeClient = fake.NewClientBuilder().
+				WithScheme(scheme).
+				Build()
+			controller.Client = fakeClient
+
+			result, err := controller.belongsToGateway(ctx, distGroup)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeFalse())
+		})
+
+		It("should return true via direct parentRef even without L34Routes", func() {
+			distGroup := &meridio2v1alpha1.DistributionGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-distgroup",
+					Namespace: namespace,
+				},
+				Spec: meridio2v1alpha1.DistributionGroupSpec{
+					ParentRefs: []meridio2v1alpha1.ParentReference{
+						{Name: gatewayName},
+					},
+				},
+			}
+
+			// No L34Routes exist — direct parentRef should still match
+			fakeClient = fake.NewClientBuilder().
+				WithScheme(scheme).
+				Build()
+			controller.Client = fakeClient
+
+			result, err := controller.belongsToGateway(ctx, distGroup)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeTrue())
+		})
 	})
 
 	Describe("reconcileNFQLBInstance", func() {

--- a/internal/controller/loadbalancer/flows.go
+++ b/internal/controller/loadbalancer/flows.go
@@ -224,13 +224,13 @@ func (c *Controller) listMatchingL34Routes(ctx context.Context, distGroup *merid
 func (c *Controller) referencesGateway(route *meridio2v1alpha1.L34Route) bool {
 	for _, parentRef := range route.Spec.ParentRefs {
 		// Default Group to "gateway.networking.k8s.io" when unspecified
-		group := "gateway.networking.k8s.io"
+		group := groupGatewayAPI
 		if parentRef.Group != nil {
 			group = string(*parentRef.Group)
 		}
 
 		// Default Kind to "Gateway" when unspecified
-		kind := "Gateway"
+		kind := kindGateway
 		if parentRef.Kind != nil {
 			kind = string(*parentRef.Kind)
 		}
@@ -243,7 +243,7 @@ func (c *Controller) referencesGateway(route *meridio2v1alpha1.L34Route) bool {
 
 		// Check if this parentRef matches our Gateway
 		if group == gatewayv1.GroupVersion.Group &&
-			kind == "Gateway" &&
+			kind == kindGateway &&
 			string(parentRef.Name) == c.GatewayName &&
 			namespace == c.GatewayNamespace {
 			return true


### PR DESCRIPTION
belongsToGateway only checked L34Route-based indirect references (L34Route.parentRefs → Gateway AND L34Route.backendRefs → DG). It did not check DistributionGroup.spec.parentRefs directly.

This caused DGs with only a direct parentRef to a Gateway (no L34Route linking them) to be enqueued by the gatewayEnqueue mapper but silently skipped during reconciliation.

Add direct parentRef check as the first path in belongsToGateway, before the L34Route-based check. Uses the same defaulting logic as gatewayEnqueue (default Group to gateway.networking.k8s.io, Kind to Gateway, Namespace to DG namespace).

When a DG has only a direct parentRef (no L34Route), the NFQLB instance and targets are created (warm pool), but reconcileFlows produces zero flows — correct behavior for pre-populated hash ring.

Also extract gateway API string literals into constants.

Related issue: gh-108