### PR TITLE
Add scan time to BIRD kernel protocol configuration

### DIFF
--- a/cmd/router/cmd/run.go
+++ b/cmd/router/cmd/run.go
@@ -77,6 +77,9 @@ func runRouter(ctx context.Context, cfg *config.RouterConfig) error {
 	if cfg.GatewayName == "" || cfg.GatewayNamespace == "" {
 		return fmt.Errorf("gateway-name and gateway-namespace are required")
 	}
+	if cfg.BirdKernelScanTime < 1 {
+		return fmt.Errorf("bird-kernel-scan-time must be at least 1 second (got %d)", cfg.BirdKernelScanTime)
+	}
 
 	setupLog.Info("Starting Router controller", "config", cfg)
 
@@ -122,7 +125,7 @@ func runRouter(ctx context.Context, cfg *config.RouterConfig) error {
 		return err
 	}
 
-	birdInstance := bird.New(bird.WithLogParams(cfg.BirdLogs))
+	birdInstance := bird.New(bird.WithLogParams(cfg.BirdLogs), bird.WithKernelScanTime(cfg.BirdKernelScanTime))
 
 	if err = (&router.RouterReconciler{
 		Client:           mgr.GetClient(),

--- a/internal/bird/bird.go
+++ b/internal/bird/bird.go
@@ -62,10 +62,9 @@ func WithKernelScanTime(seconds int) Option {
 
 func New(opts ...Option) *Bird {
 	b := &Bird{
-		SocketPath:     "/var/run/bird/bird.ctl",
-		ConfigFile:     "/etc/bird/bird.conf",
-		KernelScanTime: defaultKernelScanTime,
-		nl:             &netlink.Handle{},
+		SocketPath: "/var/run/bird/bird.ctl",
+		ConfigFile: "/etc/bird/bird.conf",
+		nl:         &netlink.Handle{},
 	}
 	for _, o := range opts {
 		o(b)

--- a/internal/bird/bird.go
+++ b/internal/bird/bird.go
@@ -41,12 +41,13 @@ type BirdInterface interface {
 }
 
 type Bird struct {
-	SocketPath string
-	ConfigFile string
-	LogParams  BirdLogParams
-	nl         abstractNetlink
-	running    bool
-	mu         sync.Mutex
+	SocketPath     string
+	ConfigFile     string
+	LogParams      BirdLogParams
+	KernelScanTime int
+	nl             abstractNetlink
+	running        bool
+	mu             sync.Mutex
 }
 
 type Option func(*Bird)
@@ -55,11 +56,16 @@ func WithLogParams(params BirdLogParams) Option {
 	return func(b *Bird) { b.LogParams = params }
 }
 
+func WithKernelScanTime(seconds int) Option {
+	return func(b *Bird) { b.KernelScanTime = seconds }
+}
+
 func New(opts ...Option) *Bird {
 	b := &Bird{
-		SocketPath: "/var/run/bird/bird.ctl",
-		ConfigFile: "/etc/bird/bird.conf",
-		nl:         &netlink.Handle{},
+		SocketPath:     "/var/run/bird/bird.ctl",
+		ConfigFile:     "/etc/bird/bird.conf",
+		KernelScanTime: defaultKernelScanTime,
+		nl:             &netlink.Handle{},
 	}
 	for _, o := range opts {
 		o(b)
@@ -143,7 +149,7 @@ func (b *Bird) Configure(ctx context.Context, vips []string, routers []*meridio2
 }
 
 func (b *Bird) generateConfig(vips []string, routers []*meridio2v1alpha1.GatewayRouter) (string, error) {
-	data := birdConfigData{KernelTableID: defaultKernelTableID, LogParams: b.LogParams}
+	data := birdConfigData{KernelTableID: defaultKernelTableID, KernelScanTime: b.KernelScanTime, LogParams: b.LogParams}
 
 	for _, vip := range vips {
 		if isIPv6(vip) {

--- a/internal/bird/bird_test.go
+++ b/internal/bird/bird_test.go
@@ -157,6 +157,7 @@ protocol kernel {
 		import none;
 		export filter gateway_routes;
 	};
+	scan time 10;
 	kernel table 4096;
 	merge paths on;
 }
@@ -166,6 +167,7 @@ protocol kernel {
 		import none;
 		export filter gateway_routes;
 	};
+	scan time 10;
 	kernel table 4096;
 	merge paths on;
 }

--- a/internal/bird/bird_test.go
+++ b/internal/bird/bird_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestGenerateConfig(t *testing.T) {
-	b := New()
+	b := New(WithKernelScanTime(10))
 
 	t.Run("empty config", func(t *testing.T) {
 		conf, err := b.generateConfig([]string{}, []*meridio2v1alpha1.GatewayRouter{})
@@ -85,7 +85,7 @@ func TestGenerateConfig(t *testing.T) {
 		bWithLogs := New(WithLogParams(BirdLogParams{
 			{Type: "stderr", Classes: []string{"info", "warning", "error", "fatal"}},
 			{Type: "file", Path: "/var/log/bird.log", Size: 1048576, BackupPath: "/var/log/bird.log.1", Classes: []string{"all"}},
-		}))
+		}), WithKernelScanTime(10))
 		router := &meridio2v1alpha1.GatewayRouter{
 			ObjectMeta: metav1.ObjectMeta{Name: "gatewayrouter-sample"},
 			Spec: meridio2v1alpha1.GatewayRouterSpec{

--- a/internal/bird/config.go
+++ b/internal/bird/config.go
@@ -27,10 +27,9 @@ import (
 )
 
 const (
-	defaultKernelTableID  = 4096
-	defaultKernelScanTime = 10
-	defaultLocalPort      = 179
-	defaultRemotePort     = 179
+	defaultKernelTableID = 4096
+	defaultLocalPort     = 179
+	defaultRemotePort    = 179
 )
 
 type birdConfigData struct {

--- a/internal/bird/config.go
+++ b/internal/bird/config.go
@@ -27,17 +27,19 @@ import (
 )
 
 const (
-	defaultKernelTableID = 4096
-	defaultLocalPort     = 179
-	defaultRemotePort    = 179
+	defaultKernelTableID  = 4096
+	defaultKernelScanTime = 10
+	defaultLocalPort      = 179
+	defaultRemotePort     = 179
 )
 
 type birdConfigData struct {
-	KernelTableID int
-	LogParams     BirdLogParams
-	IPv4VIPs      []string
-	IPv6VIPs      []string
-	Routers       []routerData
+	KernelTableID  int
+	KernelScanTime int
+	LogParams      BirdLogParams
+	IPv4VIPs       []string
+	IPv6VIPs       []string
+	Routers        []routerData
 }
 
 type routerData struct {
@@ -98,6 +100,7 @@ protocol kernel {
 		import none;
 		export filter gateway_routes;
 	};
+	scan time {{.KernelScanTime}};
 	kernel table {{.KernelTableID}};
 	merge paths on;
 }
@@ -107,6 +110,7 @@ protocol kernel {
 		import none;
 		export filter gateway_routes;
 	};
+	scan time {{.KernelScanTime}};
 	kernel table {{.KernelTableID}};
 	merge paths on;
 }

--- a/internal/common/config/router.go
+++ b/internal/common/config/router.go
@@ -26,17 +26,18 @@ import (
 
 // RouterConfig holds configuration for the router
 type RouterConfig struct {
-	GatewayName      string
-	GatewayNamespace string
-	ProbeAddr        string
-	LogLevel         string
-	MetricsAddr      string
-	SecureMetrics    bool
-	MetricsCertPath  string
-	MetricsCertName  string
-	MetricsCertKey   string
-	EnableHTTP2      bool
-	BirdLogs         bird.BirdLogParams
+	GatewayName        string
+	GatewayNamespace   string
+	ProbeAddr          string
+	LogLevel           string
+	MetricsAddr        string
+	SecureMetrics      bool
+	MetricsCertPath    string
+	MetricsCertName    string
+	MetricsCertKey     string
+	EnableHTTP2        bool
+	BirdLogs           bird.BirdLogParams
+	BirdKernelScanTime int
 }
 
 // AddFlags adds configuration flags to the provided FlagSet
@@ -62,6 +63,8 @@ func (c *RouterConfig) AddFlags(fs *pflag.FlagSet) {
 		"The name of the metrics server key file.")
 	fs.BoolVar(&c.EnableHTTP2, "enable-http2", false,
 		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
+	fs.IntVar(&c.BirdKernelScanTime, "bird-kernel-scan-time", 10,
+		"Interval in seconds for BIRD kernel protocol route table scanning")
 	fs.Var(&c.BirdLogs, "bird-log",
 		"BIRD log destination (repeatable).\n"+
 			"Format: type:params:classes\n"+
@@ -96,6 +99,7 @@ func (c *RouterConfig) BindEnv(fs *pflag.FlagSet) {
 	bindString(fs, "metrics-cert-name", "MERIDIO_METRICS_CERT_NAME", &c.MetricsCertName)
 	bindString(fs, "metrics-cert-key", "MERIDIO_METRICS_CERT_KEY", &c.MetricsCertKey)
 	bindBool(fs, "enable-http2", "MERIDIO_ENABLE_HTTP2", &c.EnableHTTP2)
+	bindInt(fs, "bird-kernel-scan-time", "MERIDIO_BIRD_KERNEL_SCAN_TIME", &c.BirdKernelScanTime)
 	bindBirdLogs(fs, "bird-log", "MERIDIO_BIRD_LOG", &c.BirdLogs)
 }
 


### PR DESCRIPTION
Add configurable scan time to both IPv4 and IPv6 kernel protocol blocks in the BIRD configuration. This fixes a 30-50 second delay for BGP-learned routes to appear in the kernel routing table when using BIRD 3.x.

Configuration:
  --bird-kernel-scan-time / MERIDIO_BIRD_KERNEL_SCAN_TIME (default: 10)

Port of Meridio v1 fix: https://github.com/Nordix/Meridio/pull/607

Closes #80