### PR TITLE
Add SCTP multihoming e2e test suite and restore low-mtu suite

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,6 +80,7 @@ jobs:
           - stateless-load-balancer
           - router
           - network-sidecar
+          - example-target
     steps:
       - uses: actions/checkout@v6
       - run: make ${{ matrix.image }} BUILD_STEPS=build

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -50,6 +50,7 @@ jobs:
           - stateless-load-balancer
           - router
           - network-sidecar
+          - example-target
     steps:
       - uses: actions/checkout@v6
       - uses: docker/login-action@v4
@@ -68,6 +69,8 @@ jobs:
         suite:
           - common-appnetwork
           - separate-appnetwork
+          - sctp-multihoming
+          - low-mtu
         k8s_version:
           - v1.32.2
           - v1.31.6

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ help: ## Display this help.
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
-IMAGES ?= controller-manager stateless-load-balancer router network-sidecar
+IMAGES ?= controller-manager stateless-load-balancer router network-sidecar example-target
 
 # Versions
 VERSION ?= latest
@@ -26,6 +26,7 @@ VERSION_CONTROLLER_MANAGER ?= $(VERSION)
 VERSION_SLLB ?= $(VERSION)
 VERSION_ROUTER ?= $(VERSION)
 VERSION_NETWORK_SIDECAR ?= $(VERSION)
+VERSION_EXAMPLE_TARGET ?= $(VERSION)
 LOCAL_VERSION ?= $(VERSION)
 
 # Container registry
@@ -106,7 +107,7 @@ network-sidecar: ## Build the network-sidecar.
 
 .PHONY: example-target
 example-target: ## Build the example target application.
-	BUILD_DIR=examples/target/build IMAGE=example-target $(MAKE) -s $(BUILD_STEPS)
+	VERSION=$(VERSION_EXAMPLE_TARGET) BUILD_DIR=examples/target/build IMAGE=example-target $(MAKE) -s $(BUILD_STEPS)
 
 ################################################################################
 ##@ Testing & Code check
@@ -157,8 +158,8 @@ install-hooks: ## Install git pre-commit hook to run 'make check' before commits
 generate: manifests generate-controller ## Generate everything.
 
 .PHONY: manifests
-manifests: controller-gen ## Generate WebhookConfiguration and CustomResourceDefinition objects.
-	"$(CONTROLLER_GEN)" crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
+	"$(CONTROLLER_GEN)" rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
 .PHONY: generate-controller
 generate-controller: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.

--- a/Makefile
+++ b/Makefile
@@ -138,6 +138,7 @@ test: generate setup-envtest ## Run the unit tests.
 
 .PHONY: e2e
 e2e: ## Run end-to-end tests.
+	$(MAKE) -C test/e2e REGISTRY=$(REGISTRY) VERSION=$(VERSION) deploy-all
 	$(MAKE) -C test/e2e REGISTRY=$(REGISTRY) VERSION=$(VERSION) test
 	$(MAKE) -C test/e2e undeploy-all
 	$(MAKE) -C test/e2e cluster-cleanup

--- a/examples/target/build/example-target/Dockerfile
+++ b/examples/target/build/example-target/Dockerfile
@@ -8,26 +8,49 @@ ARG USER
 ARG UID
 ARG HOME
 
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install base packages and netperfmeter
 RUN apt-get update -y \
   && apt-get install -y --no-install-recommends \
-     iproute2 tcpdump net-tools iputils-ping netcat-traditional \
-     wget screen xz-utils strace nftables iperf3 libcap2-bin \
+     ca-certificates \
+     gnupg \
+     software-properties-common \
+     iproute2 \
+     tcpdump \
+     net-tools \
+     iputils-ping \
+     netcat-traditional \
+     wget \
+     screen \
+     xz-utils \
+     strace \
+     nftables \
+     iperf3 \
+     libcap2-bin \
+     lksctp-tools \
+  && add-apt-repository -y ppa:dreibh/ppa \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends netperfmeter-all \
   && setcap 'cap_sys_ptrace,cap_dac_override+ep' /usr/bin/ss \
   && setcap 'cap_sys_ptrace,cap_dac_override+ep' /usr/bin/netstat \
   && setcap 'cap_net_raw+ep' /usr/bin/ping \
   && setcap 'cap_net_raw+ep' /usr/bin/tcpdump \
   && setcap 'cap_sys_ptrace+ep' /usr/bin/strace \
-  && rm -rf /var/lib/apt/lists/*
+  && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
+# Create non-root user
 RUN groupadd --gid $UID $USER \
   && useradd $USER --create-home --home-dir $HOME --no-log-init --uid $UID --gid $UID \
   && chown -R :root "${HOME}" && chmod -R g+s=u "${HOME}"
 
 WORKDIR $HOME
 
+# Install ctraffic
 ADD https://github.com/Nordix/ctraffic/releases/download/v1.7.0/ctraffic.gz ctraffic.gz
 RUN gunzip ctraffic.gz && chmod a+x ctraffic
 
+# Install mconnect
 ADD https://github.com/Nordix/mconnect/releases/download/v2.2.0/mconnect.xz mconnect.xz
 RUN unxz mconnect.xz && chmod a+x mconnect
 

--- a/examples/target/build/example-target/Dockerfile
+++ b/examples/target/build/example-target/Dockerfile
@@ -10,12 +10,10 @@ ARG HOME
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Install base packages and netperfmeter
+# Install base packages
 RUN apt-get update -y \
   && apt-get install -y --no-install-recommends \
      ca-certificates \
-     gnupg \
-     software-properties-common \
      iproute2 \
      tcpdump \
      net-tools \
@@ -29,15 +27,26 @@ RUN apt-get update -y \
      iperf3 \
      libcap2-bin \
      lksctp-tools \
-  && add-apt-repository -y ppa:dreibh/ppa \
-  && apt-get update \
-  && apt-get install -y --no-install-recommends netperfmeter-all \
+     build-essential \
+     cmake \
+     libsctp-dev \
+     libbz2-dev \
   && setcap 'cap_sys_ptrace,cap_dac_override+ep' /usr/bin/ss \
   && setcap 'cap_sys_ptrace,cap_dac_override+ep' /usr/bin/netstat \
   && setcap 'cap_net_raw+ep' /usr/bin/ping \
   && setcap 'cap_net_raw+ep' /usr/bin/tcpdump \
   && setcap 'cap_sys_ptrace+ep' /usr/bin/strace \
   && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
+
+# Build and install netperfmeter from source
+RUN wget -q https://www.nntb.no/~dreibh/netperfmeter/download/netperfmeter-2.0.2.tar.xz \
+  && tar xf netperfmeter-2.0.2.tar.xz \
+  && cd netperfmeter-2.0.2 \
+  && cmake . -DWITH_ICONS=OFF \
+  && make -j$(nproc) \
+  && make install \
+  && cd .. \
+  && rm -rf netperfmeter-2.0.2 netperfmeter-2.0.2.tar.xz
 
 # Create non-root user
 RUN groupadd --gid $UID $USER \

--- a/hack/vpn-gateway/Dockerfile
+++ b/hack/vpn-gateway/Dockerfile
@@ -1,14 +1,56 @@
-FROM golang:1.23 AS builder
+FROM ubuntu:24.04 AS bird-builder
 
-RUN git clone --depth 1 -b v1.7.0 https://github.com/Nordix/ctraffic.git /tmp/ctraffic && \
-    cd /tmp/ctraffic && \
-    CGO_ENABLED=0 go build -o ctraffic ./cmd/ctraffic
+ENV DEBIAN_FRONTEND=noninteractive
 
-FROM alpine:latest
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    flex \
+    bison \
+    libreadline-dev \
+    wget \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
 
-RUN apk update && apk add iproute2 iputils tcpdump bird ethtool
+WORKDIR /tmp
+RUN wget https://bird.network.cz/download/bird-3.1.2.tar.gz \
+    && tar -xzf bird-3.1.2.tar.gz \
+    && cd bird-3.1.2 \
+    && ./configure \
+    && make -j$(nproc) \
+    && make install
 
-RUN mkdir -p /etc/bird/ /run/bird
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        lksctp-tools \
+        iproute2 \
+        tcpdump \
+        iputils-ping \
+        ethtool \
+        libreadline8t64 \
+        xz-utils \
+        software-properties-common \
+    && add-apt-repository -y ppa:dreibh/ppa \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends netperfmeter-all \
+    && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
+
+COPY --from=bird-builder /usr/local/sbin/bird /usr/sbin/bird
+COPY --from=bird-builder /usr/local/sbin/birdc /usr/sbin/birdc
+
+ADD https://github.com/Nordix/ctraffic/releases/download/v1.7.0/ctraffic.gz /tmp/ctraffic.gz
+RUN gunzip /tmp/ctraffic.gz \
+  && chmod u+x /tmp/ctraffic \
+  && mv /tmp/ctraffic /usr/bin/
+
+ADD https://github.com/Nordix/mconnect/releases/download/v2.2.0/mconnect.xz /tmp/mconnect.xz
+RUN unxz /tmp/mconnect.xz \
+  && chmod u+x /tmp/mconnect \
+  && mv /tmp/mconnect /usr/bin/ \
+  && mkdir -p /etc/bird/ /run/bird /usr/local/var/run
 
 ARG BIRD_CONFIG_PATH=.
 
@@ -19,7 +61,5 @@ COPY $BIRD_CONFIG_PATH/bird-filler-net.conf /etc/bird/
 
 COPY $BIRD_CONFIG_PATH/init.sh /init.sh
 RUN chmod +x /init.sh
-
-COPY --from=builder /tmp/ctraffic/ctraffic /opt/ctraffic
 
 CMD ["/init.sh"]

--- a/hack/vpn-gateway/Dockerfile
+++ b/hack/vpn-gateway/Dockerfile
@@ -25,6 +25,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
+        ca-certificates \
         lksctp-tools \
         iproute2 \
         tcpdump \
@@ -32,11 +33,21 @@ RUN apt-get update && \
         ethtool \
         libreadline8t64 \
         xz-utils \
-        software-properties-common \
-    && add-apt-repository -y ppa:dreibh/ppa \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends netperfmeter-all \
+        wget \
+        build-essential \
+        cmake \
+        libsctp-dev \
+        libbz2-dev \
     && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
+
+RUN wget -q https://www.nntb.no/~dreibh/netperfmeter/download/netperfmeter-2.0.2.tar.xz \
+    && tar xf netperfmeter-2.0.2.tar.xz \
+    && cd netperfmeter-2.0.2 \
+    && cmake . -DWITH_ICONS=OFF \
+    && make -j$(nproc) \
+    && make install \
+    && cd .. \
+    && rm -rf netperfmeter-2.0.2 netperfmeter-2.0.2.tar.xz
 
 COPY --from=bird-builder /usr/local/sbin/bird /usr/sbin/bird
 COPY --from=bird-builder /usr/local/sbin/birdc /usr/sbin/birdc

--- a/hack/vpn-gateway/bird-gw.conf
+++ b/hack/vpn-gateway/bird-gw.conf
@@ -28,7 +28,7 @@ protocol kernel {
 }
 
 
-# ns-a gw-a1 peers on VLAN 100 (ASN 64512)
+# separate-appnetwork gw-a1 peers on VLAN 100 (ASN 64512)
 protocol bgp GW4_A1 from LINK {
 	local 169.254.100.150 port 10179 as 4200000000;
 	neighbor range 0.0.0.0/0 port 10179 as 64512;
@@ -39,7 +39,7 @@ protocol bgp GW4_A1 from LINK {
 	};
 }
 
-# ns-a gw-a2 peers on VLAN 200 (ASN 64513)
+# separate-appnetwork gw-a2 peers on VLAN 200 (ASN 64513)
 protocol bgp GW4_A2 from LINK {
 	local 169.254.200.150 port 10179 as 4200000000;
 	neighbor range 0.0.0.0/0 port 10179 as 64513;
@@ -50,7 +50,7 @@ protocol bgp GW4_A2 from LINK {
 	};
 }
 
-# ns-b gw-b1 peers on VLAN 300 (ASN 64514)
+# common-appnetwork gw-b1 peers on VLAN 300 (ASN 64514)
 protocol bgp GW4_B1 from LINK {
 	local 169.254.101.150 port 10179 as 4200000000;
 	neighbor range 0.0.0.0/0 port 10179 as 64514;
@@ -61,7 +61,7 @@ protocol bgp GW4_B1 from LINK {
 	};
 }
 
-# ns-b gw-b2 peers on VLAN 400 (ASN 64515)
+# common-appnetwork gw-b2 peers on VLAN 400 (ASN 64515)
 protocol bgp GW4_B2 from LINK {
 	local 169.254.201.150 port 10179 as 4200000000;
 	neighbor range 0.0.0.0/0 port 10179 as 64515;
@@ -72,10 +72,32 @@ protocol bgp GW4_B2 from LINK {
 	};
 }
 
-# low-mtu gw-m1 peers on VLAN 500 (ASN 64516)
+# sctp-multihoming path 1 on VLAN 500 (ASN 64516)
+protocol bgp GW4_SCTP1 from LINK {
+	local 169.254.102.150 port 10179 as 4200000000;
+	neighbor range 0.0.0.0/0 port 10179 as 64516;
+	dynamic name "GW4_SCTP1_";
+	ipv4 {
+		import all;
+		export filter bgp_announce;
+	};
+}
+
+# sctp-multihoming path 2 on VLAN 600 (ASN 64517)
+protocol bgp GW4_SCTP2 from LINK {
+	local 169.254.202.150 port 10179 as 4200000000;
+	neighbor range 0.0.0.0/0 port 10179 as 64517;
+	dynamic name "GW4_SCTP2_";
+	ipv4 {
+		import all;
+		export filter bgp_announce;
+	};
+}
+
+# low-mtu gw-m1 peers on VLAN 700 (ASN 64518)
 protocol bgp GW4_M1 from LINK {
 	local 169.254.50.150 port 10179 as 4200000000;
-	neighbor range 0.0.0.0/0 port 10179 as 64516;
+	neighbor range 0.0.0.0/0 port 10179 as 64518;
 	dynamic name "GW4_M1_";
 	ipv4 {
 		import all;

--- a/hack/vpn-gateway/init.sh
+++ b/hack/vpn-gateway/init.sh
@@ -3,38 +3,50 @@
 sysctl -w net.ipv4.fib_multipath_hash_policy=1
 sysctl -w net.ipv4.conf.all.forwarding=1
 
-# VLAN 100 — ns-a gw-a1
+# VLAN 100 — separate-appnetwork gw-a1
 ip link add link eth0 name vlan1 type vlan id 100
 ip link set vlan1 up
 ip addr add 169.254.100.150/24 dev vlan1
 ip addr add 200.100.0.100/32 dev vlan1
 
-# VLAN 200 — ns-a gw-a2
+# VLAN 200 — separate-appnetwork gw-a2
 ip link add link eth0 name vlan2 type vlan id 200
 ip link set vlan2 up
 ip addr add 169.254.200.150/24 dev vlan2
 ip addr add 200.200.0.100/32 dev vlan2
 
-# VLAN 300 — ns-b gw-b1
+# VLAN 300 — common-appnetwork gw-b1
 ip link add link eth0 name vlan3 type vlan id 300
 ip link set vlan3 up
 ip addr add 169.254.101.150/24 dev vlan3
 ip addr add 200.100.0.101/32 dev vlan3
 
-# VLAN 400 — ns-b gw-b2
+# VLAN 400 — common-appnetwork gw-b2
 ip link add link eth0 name vlan4 type vlan id 400
 ip link set vlan4 up
 ip addr add 169.254.201.150/24 dev vlan4
 ip addr add 200.200.0.101/32 dev vlan4
 
-# VLAN 500 — low-mtu gw-m1
+# VLAN 500 — sctp-multihoming path 1
 ip link add link eth0 name vlan5 type vlan id 500
 ip link set vlan5 up
-ip addr add 169.254.50.150/24 dev vlan5
-ip addr add 200.50.0.100/32 dev vlan5
+ip addr add 169.254.102.150/24 dev vlan5
+ip addr add 200.100.0.100/32 dev vlan5
+
+# VLAN 600 — sctp-multihoming path 2
+ip link add link eth0 name vlan6 type vlan id 600
+ip link set vlan6 up
+ip addr add 169.254.202.150/24 dev vlan6
+ip addr add 200.100.1.100/32 dev vlan6
+
+# VLAN 700 — low-mtu gw-m1
+ip link add link eth0 name vlan7 type vlan id 700
+ip link set vlan7 up
+ip addr add 169.254.50.150/24 dev vlan7
+ip addr add 200.50.0.100/32 dev vlan7
 
 ethtool -K eth0 tx off
 
-echo "VPN Gateway ready on VLAN 100, 200, 300, 400, 500"
+echo "VPN Gateway ready on VLAN 100, 200, 300, 400, 500, 600, 700"
 
 /usr/sbin/bird -d -c /etc/bird/bird-gw.conf

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -28,7 +28,7 @@ MULTUS_VERSION ?= v4.1.2
 WHEREABOUTS_VERSION ?= v0.8.0
 
 # Suites
-SUITES ?= common-appnetwork separate-appnetwork low-mtu
+SUITES ?= common-appnetwork separate-appnetwork sctp-multihoming low-mtu
 
 # Test flags (e.g., make test GINKGO_FLAGS="--junit-report=report.xml")
 GINKGO_FLAGS ?=
@@ -153,6 +153,11 @@ define deploy-suite
 	fi; \
 	$(KUBECTL) wait --for=condition=Available --timeout=180s -n $$NS deployment/meridio-2-controller-manager-$$SUITE_LABEL; \
 	$(KUBECTL) wait --for=condition=Ready --timeout=60s -n $$NS certificate/meridio-2-serving-cert-$$SUITE_LABEL; \
+	timeout=60; elapsed=0; \
+	until $(KUBECTL) get endpoints -n $$NS meridio-2-webhook-service-$$SUITE_LABEL -o jsonpath='{.subsets[*].addresses[*].ip}' | grep -q .; do \
+		sleep 1; elapsed=$$((elapsed + 1)); \
+		if [ $$elapsed -ge $$timeout ]; then echo "Timeout waiting for webhook endpoint"; exit 1; fi; \
+	done; \
 	$(KUBECTL) apply -f $$SUITE_DIR/rbac.yaml; \
 	$(KUBECTL) apply -f $$SUITE_DIR/nad.yaml -n $$NS; \
 	$(KUBECTL) apply -f $$SUITE_DIR/gateway.yaml -n $$NS; \
@@ -164,7 +169,7 @@ define deploy-suite
 		if [ $$elapsed -ge $$timeout ]; then echo "Timeout waiting for deployments: $(4)"; exit 1; fi; \
 	done; \
 	$(KUBECTL) wait --for=condition=Available --timeout=300s -n $$NS $(foreach dep,$(4),deployment/$(dep)); \
-	sed 's|registry.nordix.org/cloud-native/meridio-2/network-sidecar:latest|$(REGISTRY)/network-sidecar:$(VERSION)|g' $$SUITE_DIR/targets.yaml | $(KUBECTL) apply -n $$NS -f -; \
+	sed 's|registry.nordix.org/cloud-native/meridio-2/network-sidecar:latest|$(REGISTRY)/network-sidecar:$(VERSION)|g; s|registry.nordix.org/cloud-native/meridio-2/example-target:latest|$(REGISTRY)/example-target:$(VERSION)|g' $$SUITE_DIR/targets.yaml | $(KUBECTL) apply -n $$NS -f -; \
 	$(KUBECTL) wait --for=condition=Available --timeout=300s -n $$NS $$($(KUBECTL) get deployment -n $$NS -l app -o name | grep target)
 endef
 
@@ -211,6 +216,27 @@ undeploy-separate-appnetwork: ## Undeploy separate-appnetwork topology.
 	$(KUBECTL) delete namespace $$NS --ignore-not-found=true
 
 ################################################################################
+##@ Suite: sctp-multihoming
+################################################################################
+
+.PHONY: sctp-multihoming
+sctp-multihoming: deploy-sctp-multihoming test-sctp-multihoming ## Deploy and test sctp-multihoming suite.
+
+.PHONY: deploy-sctp-multihoming
+deploy-sctp-multihoming: cluster ## Deploy sctp-multihoming topology.
+	$(call deploy-suite,e2e-sctp-multihoming,$(shell pwd)/suites/sctp-multihoming,sctp-multihoming,sllb-sctp-gw1 sllb-sctp-gw2)
+
+.PHONY: test-sctp-multihoming
+test-sctp-multihoming: ## Run e2e tests for sctp-multihoming suite.
+	cd $(PROJECT_ROOT)/test/e2e && go run github.com/onsi/ginkgo/v2/ginkgo -v --tags=e2e --focus="SCTP Multihoming" $(GINKGO_FLAGS)
+
+.PHONY: undeploy-sctp-multihoming
+undeploy-sctp-multihoming: ## Undeploy sctp-multihoming topology.
+	@NS=e2e-sctp-multihoming; \
+	$(KUBECTL) delete validatingwebhookconfiguration meridio-2-validating-webhook-configuration-sctp-multihoming --ignore-not-found=true; \
+	$(KUBECTL) delete namespace $$NS --ignore-not-found=true
+
+################################################################################
 ##@ Suite: low-mtu
 ################################################################################
 
@@ -218,12 +244,12 @@ undeploy-separate-appnetwork: ## Undeploy separate-appnetwork topology.
 low-mtu: deploy-low-mtu test-low-mtu ## Deploy and test low-mtu suite.
 
 .PHONY: deploy-low-mtu
-deploy-low-mtu: cluster ## Deploy low-mtu topology (1200 MTU app network for PMTU testing).
+deploy-low-mtu: cluster ## Deploy low-mtu topology.
 	$(call deploy-suite,e2e-low-mtu,$(shell pwd)/suites/low-mtu,low-mtu,sllb-gw-m1)
 
 .PHONY: test-low-mtu
 test-low-mtu: ## Run e2e tests for low-mtu suite.
-	cd $(PROJECT_ROOT)/test/e2e && go run github.com/onsi/ginkgo/v2/ginkgo -v --tags=e2e --focus="Low MTU"
+	cd $(PROJECT_ROOT)/test/e2e && go run github.com/onsi/ginkgo/v2/ginkgo -v --tags=e2e --focus="Low MTU" $(GINKGO_FLAGS)
 
 .PHONY: undeploy-low-mtu
 undeploy-low-mtu: ## Undeploy low-mtu topology.

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -170,7 +170,7 @@ define deploy-suite
 	done; \
 	$(KUBECTL) wait --for=condition=Available --timeout=300s -n $$NS $(foreach dep,$(4),deployment/$(dep)); \
 	sed 's|registry.nordix.org/cloud-native/meridio-2/network-sidecar:latest|$(REGISTRY)/network-sidecar:$(VERSION)|g; s|registry.nordix.org/cloud-native/meridio-2/example-target:latest|$(REGISTRY)/example-target:$(VERSION)|g' $$SUITE_DIR/targets.yaml | $(KUBECTL) apply -n $$NS -f -; \
-	$(KUBECTL) wait --for=condition=Available --timeout=300s -n $$NS $$($(KUBECTL) get deployment -n $$NS -l app -o name | grep target); \
+	$(KUBECTL) wait --for=condition=Available --timeout=480s -n $$NS $$($(KUBECTL) get deployment -n $$NS -l app -o name | grep target); \
 	echo "Waiting for all pods to be ready in namespace $$NS..."; \
 	timeout=300; elapsed=0; \
 	until [ $$($(KUBECTL) get pods -n $$NS --field-selector=status.phase!=Succeeded,status.phase!=Failed -o json | jq -r '.items[] | select(.status.phase=="Running" and ([.status.conditions[] | select(.type=="Ready" and .status=="True")] | length) > 0) | .metadata.name' | wc -l) -eq $$($(KUBECTL) get pods -n $$NS --field-selector=status.phase!=Succeeded,status.phase!=Failed --no-headers | wc -l) ]; do \

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -277,7 +277,7 @@ deploy-all: ## Deploy all suites.
 	@for suite in $(SUITES); do $(MAKE) deploy-$$suite || exit 1; done
 
 .PHONY: test
-test: deploy-all ## Run all e2e tests in parallel.
+test: ## Run all e2e tests in parallel.
 	cd $(PROJECT_ROOT)/test/e2e && go run github.com/onsi/ginkgo/v2/ginkgo -v -p --tags=e2e $(GINKGO_FLAGS)
 
 .PHONY: undeploy-all

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -170,7 +170,18 @@ define deploy-suite
 	done; \
 	$(KUBECTL) wait --for=condition=Available --timeout=300s -n $$NS $(foreach dep,$(4),deployment/$(dep)); \
 	sed 's|registry.nordix.org/cloud-native/meridio-2/network-sidecar:latest|$(REGISTRY)/network-sidecar:$(VERSION)|g; s|registry.nordix.org/cloud-native/meridio-2/example-target:latest|$(REGISTRY)/example-target:$(VERSION)|g' $$SUITE_DIR/targets.yaml | $(KUBECTL) apply -n $$NS -f -; \
-	$(KUBECTL) wait --for=condition=Available --timeout=300s -n $$NS $$($(KUBECTL) get deployment -n $$NS -l app -o name | grep target)
+	$(KUBECTL) wait --for=condition=Available --timeout=300s -n $$NS $$($(KUBECTL) get deployment -n $$NS -l app -o name | grep target); \
+	echo "Waiting for all pods to be ready in namespace $$NS..."; \
+	timeout=300; elapsed=0; \
+	until [ $$($(KUBECTL) get pods -n $$NS --field-selector=status.phase!=Succeeded,status.phase!=Failed -o json | jq -r '.items[] | select(.status.phase=="Running" and ([.status.conditions[] | select(.type=="Ready" and .status=="True")] | length) > 0) | .metadata.name' | wc -l) -eq $$($(KUBECTL) get pods -n $$NS --field-selector=status.phase!=Succeeded,status.phase!=Failed --no-headers | wc -l) ]; do \
+		sleep 2; elapsed=$$((elapsed + 2)); \
+		if [ $$elapsed -ge $$timeout ]; then \
+			echo "Timeout waiting for all pods to be ready. Current state:"; \
+			$(KUBECTL) get pods -n $$NS; \
+			exit 1; \
+		fi; \
+	done; \
+	echo "All pods ready in namespace $$NS"
 endef
 
 ################################################################################

--- a/test/e2e/e2e_suite_sctp_test.go
+++ b/test/e2e/e2e_suite_sctp_test.go
@@ -1,0 +1,275 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"fmt"
+	"os/exec"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	e2eutils "github.com/nordix/meridio-2/test/e2e/utils"
+	"github.com/nordix/meridio-2/test/utils"
+)
+
+type sctpGwTestCase struct {
+	name   string
+	vip    string
+	dgName string
+}
+
+type sctpSuiteTestCase struct {
+	name           string
+	namespace      string
+	targetApp      string
+	targetReplicas int
+	gateways       []sctpGwTestCase
+}
+
+var sctpTestCases = []sctpSuiteTestCase{
+	{
+		name:           "SCTP Multihoming",
+		namespace:      "e2e-sctp-multihoming",
+		targetApp:      "sctp-target",
+		targetReplicas: 1,
+		gateways: []sctpGwTestCase{
+			{name: "sctp-gw1", vip: "50.0.0.1", dgName: "sctp-dg1"},
+			{name: "sctp-gw2", vip: "50.0.0.2", dgName: "sctp-dg2"},
+		},
+	},
+}
+
+var _ = Describe("E2E SCTP Multihoming Suites", func() {
+	SetDefaultEventuallyTimeout(5 * time.Minute)
+	SetDefaultEventuallyPollingInterval(2 * time.Second)
+
+	for _, suite := range sctpTestCases {
+		suite := suite
+		Describe(suite.name, Ordered, func() {
+			Context("Deployment", func() {
+				for _, gw := range suite.gateways {
+					gw := gw
+					It(fmt.Sprintf("should have %s Accepted", gw.name), func() {
+						Eventually(func(g Gomega) {
+							cmd := exec.Command("kubectl", "get", "gateway", gw.name, "-n", suite.namespace,
+								"-o", "jsonpath={.status.conditions[?(@.type=='Accepted')].status}")
+							out, err := utils.Run(cmd)
+							g.Expect(err).NotTo(HaveOccurred())
+							g.Expect(out).To(Equal("True"))
+						}).Should(Succeed())
+					})
+
+					It(fmt.Sprintf("should have %s Programmed", gw.name), func() {
+						Eventually(func(g Gomega) {
+							cmd := exec.Command("kubectl", "get", "gateway", gw.name, "-n", suite.namespace,
+								"-o", "jsonpath={.status.conditions[?(@.type=='Programmed')].status}")
+							out, err := utils.Run(cmd)
+							g.Expect(err).NotTo(HaveOccurred())
+							g.Expect(out).To(Equal("True"))
+						}).Should(Succeed())
+					})
+
+					It(fmt.Sprintf("should deploy LB Pod for %s", gw.name), func() {
+						Eventually(func(g Gomega) {
+							cmd := exec.Command("kubectl", "get", "pods", "-n", suite.namespace,
+								"-l", fmt.Sprintf("gateway.networking.k8s.io/gateway-name=%s", gw.name),
+								"-o", "jsonpath={.items[*].status.phase}")
+							out, err := utils.Run(cmd)
+							g.Expect(err).NotTo(HaveOccurred())
+							g.Expect(out).To(ContainSubstring("Running"))
+						}).Should(Succeed())
+					})
+
+					It(fmt.Sprintf("should have %s LB Pod containers ready", gw.name), func() {
+						Eventually(func(g Gomega) {
+							cmd := exec.Command("kubectl", "get", "pods", "-n", suite.namespace,
+								"-l", fmt.Sprintf("gateway.networking.k8s.io/gateway-name=%s", gw.name),
+								"-o", "jsonpath={.items[*].status.containerStatuses[*].ready}")
+							out, err := utils.Run(cmd)
+							g.Expect(err).NotTo(HaveOccurred())
+							g.Expect(out).NotTo(ContainSubstring("false"), "all containers should be ready")
+						}).Should(Succeed())
+					})
+				}
+
+				It("should have Gateway status.addresses populated with VIPs", func() {
+					for _, gw := range suite.gateways {
+						gw := gw
+						Eventually(func(g Gomega) {
+							cmd := exec.Command("kubectl", "get", "gateway", gw.name, "-n", suite.namespace,
+								"-o", "jsonpath={.status.addresses[*].value}")
+							out, err := utils.Run(cmd)
+							g.Expect(err).NotTo(HaveOccurred())
+							g.Expect(out).To(ContainSubstring(gw.vip), "Gateway %s should have VIP %s in status", gw.name, gw.vip)
+						}).Should(Succeed())
+					}
+				})
+
+				It("should have DistributionGroups Ready", func() {
+					for _, gw := range suite.gateways {
+						gw := gw
+						Eventually(func(g Gomega) {
+							cmd := exec.Command("kubectl", "get", "distg", gw.dgName, "-n", suite.namespace,
+								"-o", "jsonpath={.status.conditions[?(@.type=='Ready')].status}")
+							out, err := utils.Run(cmd)
+							g.Expect(err).NotTo(HaveOccurred())
+							g.Expect(out).To(Equal("True"), "%s should be Ready", gw.dgName)
+						}).Should(Succeed())
+					}
+				})
+
+				It(fmt.Sprintf("should create %d ENCs (one per target pod)", suite.targetReplicas), func() {
+					Eventually(func(g Gomega) {
+						cmd := exec.Command("kubectl", "get", "enc", "-n", suite.namespace,
+							"-o", "jsonpath={range .items[*]}{.metadata.name}{\"\\n\"}{end}")
+						out, err := utils.Run(cmd)
+						g.Expect(err).NotTo(HaveOccurred())
+						g.Expect(len(utils.GetNonEmptyLines(out))).To(Equal(suite.targetReplicas))
+					}).Should(Succeed())
+				})
+
+				It("should create EndpointSlices with Maglev IDs for each DistributionGroup", func() {
+					for _, gw := range suite.gateways {
+						gw := gw
+						Eventually(func(g Gomega) {
+							cmd := exec.Command("kubectl", "get", "endpointslice", "-n", suite.namespace,
+								"-l", fmt.Sprintf("meridio-2.nordix.org/distribution-group=%s", gw.dgName),
+								"-o", "json")
+							out, err := utils.Run(cmd)
+							g.Expect(err).NotTo(HaveOccurred())
+
+							var result struct {
+								Items []struct {
+									Endpoints []struct {
+										Addresses []string `json:"addresses"`
+										Zone      *string  `json:"zone"`
+									} `json:"endpoints"`
+								} `json:"items"`
+							}
+							err = utils.ParseJSON(out, &result)
+							g.Expect(err).NotTo(HaveOccurred())
+							g.Expect(result.Items).NotTo(BeEmpty(), "no EndpointSlices found for %s", gw.dgName)
+
+							totalEndpoints := 0
+							for _, slice := range result.Items {
+								for _, ep := range slice.Endpoints {
+									totalEndpoints++
+									g.Expect(ep.Zone).NotTo(BeNil(), "endpoint missing zone field")
+									g.Expect(*ep.Zone).To(MatchRegexp(`^maglev:\d+$`), "invalid Maglev ID format")
+								}
+							}
+							g.Expect(totalEndpoints).To(Equal(suite.targetReplicas),
+								"%s: expected %d endpoints, got %d", gw.dgName, suite.targetReplicas, totalEndpoints)
+						}).Should(Succeed())
+					}
+				})
+
+				It(fmt.Sprintf("should have %d target Pods running with sidecar", suite.targetReplicas), func() {
+					Eventually(func(g Gomega) {
+						cmd := exec.Command("kubectl", "get", "pods", "-n", suite.namespace,
+							"-l", fmt.Sprintf("app=%s", suite.targetApp), "--field-selector=status.phase=Running",
+							"-o", "jsonpath={range .items[*]}{.metadata.name}{\"\\n\"}{end}")
+						out, err := utils.Run(cmd)
+						g.Expect(err).NotTo(HaveOccurred())
+						g.Expect(len(utils.GetNonEmptyLines(out))).To(Equal(suite.targetReplicas))
+					}).Should(Succeed())
+				})
+
+				It("should have all ENCs Ready", func() {
+					Eventually(func(g Gomega) {
+						cmd := exec.Command("kubectl", "get", "enc", "-n", suite.namespace,
+							"-o", "jsonpath={range .items[*]}{.status.conditions[?(@.type=='Ready')].status}{\"\\n\"}{end}")
+						out, err := utils.Run(cmd)
+						g.Expect(err).NotTo(HaveOccurred())
+						lines := utils.GetNonEmptyLines(out)
+						g.Expect(len(lines)).To(Equal(suite.targetReplicas), "expected %d ENCs", suite.targetReplicas)
+						for _, status := range lines {
+							g.Expect(status).To(Equal("True"), "all ENCs should be Ready")
+						}
+					}).Should(Succeed())
+				})
+			})
+
+			Context("Traffic", func() {
+				BeforeAll(func() {
+					By("waiting for BGP routes to propagate to VPN gateway")
+					for _, gw := range suite.gateways {
+						Eventually(func() error { return e2eutils.Ping(gw.vip) }).Should(Succeed())
+					}
+				})
+
+				Context("ICMP reachability", func() {
+					for _, gw := range suite.gateways {
+						gw := gw
+						It("handles ping on "+gw.name+" VIP", func() {
+							Expect(e2eutils.Ping(gw.vip)).To(Succeed())
+						})
+					}
+				})
+
+				Context("SCTP multihoming", func() {
+					It("maintains zero loss with saturated bidirectional traffic", func() {
+						By("running NetPerfMeter SCTP test for 30 seconds")
+
+						// Start NetPerfMeter in background
+						done := make(chan *e2eutils.NetPerfMeterResult, 1)
+						errCh := make(chan error, 1)
+
+						go func() {
+							result, err := e2eutils.RunNetPerfMeterClient(e2eutils.NetPerfMeterConfig{
+								Target:         suite.gateways[0].vip + ":9000",
+								LocalAddrs:     []string{"200.100.0.100", "200.100.1.100"},
+								Protocol:       "sctp",
+								Duration:       30,
+								FrameRate:      "const0",
+								FrameSize:      "const1400",
+								ControlOverTCP: true,
+							})
+							done <- result
+							if err != nil {
+								errCh <- err
+							}
+						}()
+
+						By("waiting for SCTP association to establish")
+						time.Sleep(3 * time.Second)
+
+						By("verifying SCTP association exists")
+						found, details, err := e2eutils.CheckSCTPAssociationWithVIPs(
+							9000,
+							[]string{"200.100.0.100", "200.100.1.100"},
+							[]string{suite.gateways[0].vip, suite.gateways[1].vip},
+						)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(found).To(BeTrue(), "SCTP association not found with all local addresses and VIPs")
+						GinkgoWriter.Printf("SCTP association found:\n%s\n", details)
+
+						By("waiting for NetPerfMeter to complete")
+						var result *e2eutils.NetPerfMeterResult
+						select {
+						case result = <-done:
+							GinkgoWriter.Printf("NetPerfMeter completed\n")
+						case <-time.After(35 * time.Second):
+							Fail("NetPerfMeter timed out")
+						}
+
+						By("validating zero packet and frame loss")
+						GinkgoWriter.Printf("NetPerfMeter results:\n")
+						GinkgoWriter.Printf("  Transmitted: %d bytes\n", result.TransmittedBytes)
+						GinkgoWriter.Printf("  Received: %d bytes\n", result.ReceivedBytes)
+						GinkgoWriter.Printf("  Packet Loss: %d\n", result.PacketLoss)
+						GinkgoWriter.Printf("  Frame Loss: %d\n", result.FrameLoss)
+
+						Expect(result.TransmittedBytes).To(BeNumerically(">", 0))
+						Expect(result.ReceivedBytes).To(BeNumerically(">", 0))
+						Expect(result.PacketLoss).To(Equal(0))
+						Expect(result.FrameLoss).To(Equal(0))
+					})
+				})
+			})
+		})
+	}
+})

--- a/test/e2e/e2e_suite_sctp_test.go
+++ b/test/e2e/e2e_suite_sctp_test.go
@@ -234,16 +234,17 @@ var _ = Describe("E2E SCTP Multihoming Suites", func() {
 						}()
 
 						By("waiting for SCTP association to establish")
-						time.Sleep(3 * time.Second)
-
-						By("verifying SCTP association exists")
-						found, details, err := e2eutils.CheckSCTPAssociationWithVIPs(
-							9000,
-							[]string{"200.100.0.100", "200.100.1.100"},
-							[]string{suite.gateways[0].vip, suite.gateways[1].vip},
-						)
-						Expect(err).NotTo(HaveOccurred())
-						Expect(found).To(BeTrue(), "SCTP association not found with all local addresses and VIPs")
+						var details string
+						Eventually(func(g Gomega) {
+							found, d, err := e2eutils.CheckSCTPAssociationWithVIPs(
+								9000,
+								[]string{"200.100.0.100", "200.100.1.100"},
+								[]string{suite.gateways[0].vip, suite.gateways[1].vip},
+							)
+							g.Expect(err).NotTo(HaveOccurred())
+							g.Expect(found).To(BeTrue(), "SCTP association not found with all local addresses and VIPs")
+							details = d
+						}).Should(Succeed())
 						GinkgoWriter.Printf("SCTP association found:\n%s\n", details)
 
 						By("waiting for NetPerfMeter to complete")

--- a/test/e2e/e2e_suite_sctp_test.go
+++ b/test/e2e/e2e_suite_sctp_test.go
@@ -220,13 +220,12 @@ var _ = Describe("E2E SCTP Multihoming Suites", func() {
 
 						go func() {
 							result, err := e2eutils.RunNetPerfMeterClient(e2eutils.NetPerfMeterConfig{
-								Target:         suite.gateways[0].vip + ":9000",
-								LocalAddrs:     []string{"200.100.0.100", "200.100.1.100"},
-								Protocol:       "sctp",
-								Duration:       30,
-								FrameRate:      "const0",
-								FrameSize:      "const1400",
-								ControlOverTCP: true,
+								Target:     suite.gateways[0].vip + ":9000",
+								LocalAddrs: []string{"200.100.0.100", "200.100.1.100"},
+								Protocol:   "sctp",
+								Duration:   30,
+								FrameRate:  "const0",
+								FrameSize:  "const1400",
 							})
 							done <- result
 							if err != nil {
@@ -268,6 +267,7 @@ var _ = Describe("E2E SCTP Multihoming Suites", func() {
 						Expect(result.PacketLoss).To(Equal(0))
 						Expect(result.FrameLoss).To(Equal(0))
 					})
+
 				})
 			})
 		})

--- a/test/e2e/suites/common-appnetwork/kustomization.yaml
+++ b/test/e2e/suites/common-appnetwork/kustomization.yaml
@@ -4,70 +4,68 @@ kind: Kustomization
 namespace: e2e-common-appnet
 
 resources:
-- ../../../../config/default
+  - ../../../../config/default
 
 images:
-- name: controller-manager
-  newName: registry.nordix.org/cloud-native/meridio-2/controller-manager
-  newTag: latest
+  - name: controller-manager
+    newName: registry.nordix.org/cloud-native/meridio-2/controller-manager
+    newTag: latest
 
 nameSuffix: -common-appnet
 
 labels:
-- pairs:
-    e2e-suite: common-appnet
-
-
+  - pairs:
+      e2e-suite: common-appnet
 
 patches:
-- patch: |-
-    apiVersion: admissionregistration.k8s.io/v1
-    kind: ValidatingWebhookConfiguration
-    metadata:
-      name: not-important
-      annotations:
-        cert-manager.io/inject-ca-from: e2e-common-appnet/meridio-2-serving-cert-common-appnet
-    webhooks:
-    - name: vl34route-v1alpha1.kb.io
-      namespaceSelector:
-        matchLabels:
-          e2e-suite: common-appnet
-      clientConfig:
-        service:
-          name: meridio-2-webhook-service-common-appnet
-          namespace: e2e-common-appnet
-  target:
-    kind: ValidatingWebhookConfiguration
-- patch: |-
-    - op: replace
-      path: /spec/dnsNames
-      value:
-      - meridio-2-webhook-service-common-appnet.e2e-common-appnet.svc
-      - meridio-2-webhook-service-common-appnet.e2e-common-appnet.svc.cluster.local
-    - op: replace
-      path: /spec/secretName
-      value: webhook-server-cert-common-appnet
-  target:
-    group: cert-manager.io
-    kind: Certificate
-    name: serving-cert
-- patch: |-
-    apiVersion: apps/v1
-    kind: Deployment
-    metadata:
-      name: not-important
-    spec:
-      template:
-        spec:
-          containers:
-          - name: manager
-            env:
-            - name: MERIDIO_LB_SERVICE_ACCOUNT
-              value: meridio-2-stateless-load-balancer-common-appnet
-          volumes:
-          - name: webhook-certs
-            secret:
-              secretName: webhook-server-cert-common-appnet
-  target:
-    kind: Deployment
-    labelSelector: control-plane=controller-manager
+  - patch: |-
+      apiVersion: admissionregistration.k8s.io/v1
+      kind: ValidatingWebhookConfiguration
+      metadata:
+        name: not-important
+        annotations:
+          cert-manager.io/inject-ca-from: e2e-common-appnet/meridio-2-serving-cert-common-appnet
+      webhooks:
+      - name: vl34route-v1alpha1.kb.io
+        namespaceSelector:
+          matchLabels:
+            e2e-suite: common-appnet
+        clientConfig:
+          service:
+            name: meridio-2-webhook-service-common-appnet
+            namespace: e2e-common-appnet
+    target:
+      kind: ValidatingWebhookConfiguration
+  - patch: |-
+      - op: replace
+        path: /spec/dnsNames
+        value:
+        - meridio-2-webhook-service-common-appnet.e2e-common-appnet.svc
+        - meridio-2-webhook-service-common-appnet.e2e-common-appnet.svc.cluster.local
+      - op: replace
+        path: /spec/secretName
+        value: webhook-server-cert-common-appnet
+    target:
+      group: cert-manager.io
+      kind: Certificate
+      name: serving-cert
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: not-important
+      spec:
+        template:
+          spec:
+            containers:
+            - name: manager
+              env:
+              - name: MERIDIO_LB_SERVICE_ACCOUNT
+                value: meridio-2-stateless-load-balancer-common-appnet
+            volumes:
+            - name: webhook-certs
+              secret:
+                secretName: webhook-server-cert-common-appnet
+    target:
+      kind: Deployment
+      labelSelector: control-plane=controller-manager

--- a/test/e2e/suites/common-appnetwork/kustomization.yaml
+++ b/test/e2e/suites/common-appnetwork/kustomization.yaml
@@ -4,68 +4,68 @@ kind: Kustomization
 namespace: e2e-common-appnet
 
 resources:
-  - ../../../../config/default
+- ../../../../config/default
 
 images:
-  - name: controller-manager
-    newName: registry.nordix.org/cloud-native/meridio-2/controller-manager
-    newTag: latest
+- name: controller-manager
+  newName: registry.nordix.org/cloud-native/meridio-2/controller-manager
+  newTag: latest
 
 nameSuffix: -common-appnet
 
 labels:
-  - pairs:
-      e2e-suite: common-appnet
+- pairs:
+    e2e-suite: common-appnet
 
 patches:
-  - patch: |-
-      apiVersion: admissionregistration.k8s.io/v1
-      kind: ValidatingWebhookConfiguration
-      metadata:
-        name: not-important
-        annotations:
-          cert-manager.io/inject-ca-from: e2e-common-appnet/meridio-2-serving-cert-common-appnet
-      webhooks:
-      - name: vl34route-v1alpha1.kb.io
-        namespaceSelector:
-          matchLabels:
-            e2e-suite: common-appnet
-        clientConfig:
-          service:
-            name: meridio-2-webhook-service-common-appnet
-            namespace: e2e-common-appnet
-    target:
-      kind: ValidatingWebhookConfiguration
-  - patch: |-
-      - op: replace
-        path: /spec/dnsNames
-        value:
-        - meridio-2-webhook-service-common-appnet.e2e-common-appnet.svc
-        - meridio-2-webhook-service-common-appnet.e2e-common-appnet.svc.cluster.local
-      - op: replace
-        path: /spec/secretName
-        value: webhook-server-cert-common-appnet
-    target:
-      group: cert-manager.io
-      kind: Certificate
-      name: serving-cert
-  - patch: |-
-      apiVersion: apps/v1
-      kind: Deployment
-      metadata:
-        name: not-important
-      spec:
-        template:
-          spec:
-            containers:
-            - name: manager
-              env:
-              - name: MERIDIO_LB_SERVICE_ACCOUNT
-                value: meridio-2-stateless-load-balancer-common-appnet
-            volumes:
-            - name: webhook-certs
-              secret:
-                secretName: webhook-server-cert-common-appnet
-    target:
-      kind: Deployment
-      labelSelector: control-plane=controller-manager
+- patch: |-
+    apiVersion: admissionregistration.k8s.io/v1
+    kind: ValidatingWebhookConfiguration
+    metadata:
+      name: not-important
+      annotations:
+        cert-manager.io/inject-ca-from: e2e-common-appnet/meridio-2-serving-cert-common-appnet
+    webhooks:
+    - name: vl34route-v1alpha1.kb.io
+      namespaceSelector:
+        matchLabels:
+          e2e-suite: common-appnet
+      clientConfig:
+        service:
+          name: meridio-2-webhook-service-common-appnet
+          namespace: e2e-common-appnet
+  target:
+    kind: ValidatingWebhookConfiguration
+- patch: |-
+    - op: replace
+      path: /spec/dnsNames
+      value:
+      - meridio-2-webhook-service-common-appnet.e2e-common-appnet.svc
+      - meridio-2-webhook-service-common-appnet.e2e-common-appnet.svc.cluster.local
+    - op: replace
+      path: /spec/secretName
+      value: webhook-server-cert-common-appnet
+  target:
+    group: cert-manager.io
+    kind: Certificate
+    name: serving-cert
+- patch: |-
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: not-important
+    spec:
+      template:
+        spec:
+          containers:
+          - name: manager
+            env:
+            - name: MERIDIO_LB_SERVICE_ACCOUNT
+              value: meridio-2-stateless-load-balancer-common-appnet
+          volumes:
+          - name: webhook-certs
+            secret:
+              secretName: webhook-server-cert-common-appnet
+  target:
+    kind: Deployment
+    labelSelector: control-plane=controller-manager

--- a/test/e2e/suites/common-appnetwork/targets.yaml
+++ b/test/e2e/suites/common-appnetwork/targets.yaml
@@ -19,18 +19,20 @@ spec:
     spec:
       serviceAccountName: meridio-2-network-sidecar
       containers:
-      - name: ctraffic
-        image: registry.nordix.org/cloud-native/meridio/ctraffic:latest
-        command: ["/bin/sh", "-c"]
+      - name: example-target
+        image: registry.nordix.org/cloud-native/meridio-2/example-target:latest
+        imagePullPolicy: IfNotPresent
+        command: ["/bin/bash", "-c"]
         args:
         - |
-          /home/tapa-user/ctraffic -server -address [::]:5000 &
-          /home/tapa-user/ctraffic -server -udp -address [::]:5001 &
-          wait
+          screen -d -m bash -c "./ctraffic -server -address [::]:5000" ;
+          screen -d -m bash -c "./ctraffic -server -udp -address [::]:5001" ;
+          tail -f /dev/null
         securityContext:
           runAsNonRoot: true
           capabilities:
             drop: ["ALL"]
+            add: ["DAC_OVERRIDE", "NET_RAW", "SYS_PTRACE"]
       - name: network-sidecar
         image: registry.nordix.org/cloud-native/meridio-2/network-sidecar:latest
         imagePullPolicy: IfNotPresent

--- a/test/e2e/suites/low-mtu/gateway.yaml
+++ b/test/e2e/suites/low-mtu/gateway.yaml
@@ -28,9 +28,9 @@ spec:
       interface: dummy
   - type: NAD
     nad:
-      name: vlan-500
+      name: vlan-700
       namespace: e2e-low-mtu
-      interface: vlan-500
+      interface: vlan-700
   - type: NAD
     nad:
       name: app-net-mtu1200

--- a/test/e2e/suites/low-mtu/kustomization.yaml
+++ b/test/e2e/suites/low-mtu/kustomization.yaml
@@ -4,70 +4,68 @@ kind: Kustomization
 namespace: e2e-low-mtu
 
 resources:
-- ../../../../config/default
+  - ../../../../config/default
 
 images:
-- name: controller-manager
-  newName: localhost:5001/controller-manager
-  newTag: latest
+  - name: controller-manager
+    newName: registry.nordix.org/cloud-native/meridio-2/controller-manager
+    newTag: latest
 
 nameSuffix: -low-mtu
 
 labels:
-- pairs:
-    e2e-suite: low-mtu
-
-
+  - pairs:
+      e2e-suite: low-mtu
 
 patches:
-- patch: |-
-    apiVersion: admissionregistration.k8s.io/v1
-    kind: ValidatingWebhookConfiguration
-    metadata:
-      name: not-important
-      annotations:
-        cert-manager.io/inject-ca-from: e2e-low-mtu/meridio-2-serving-cert-low-mtu
-    webhooks:
-    - name: vl34route-v1alpha1.kb.io
-      namespaceSelector:
-        matchLabels:
-          e2e-suite: low-mtu
-      clientConfig:
-        service:
-          name: meridio-2-webhook-service-low-mtu
-          namespace: e2e-low-mtu
-  target:
-    kind: ValidatingWebhookConfiguration
-- patch: |-
-    - op: replace
-      path: /spec/dnsNames
-      value:
-      - meridio-2-webhook-service-low-mtu.e2e-low-mtu.svc
-      - meridio-2-webhook-service-low-mtu.e2e-low-mtu.svc.cluster.local
-    - op: replace
-      path: /spec/secretName
-      value: webhook-server-cert-low-mtu
-  target:
-    group: cert-manager.io
-    kind: Certificate
-    name: serving-cert
-- patch: |-
-    apiVersion: apps/v1
-    kind: Deployment
-    metadata:
-      name: not-important
-    spec:
-      template:
-        spec:
-          containers:
-          - name: manager
-            env:
-            - name: MERIDIO_LB_SERVICE_ACCOUNT
-              value: meridio-2-stateless-load-balancer-low-mtu
-          volumes:
-          - name: webhook-certs
-            secret:
-              secretName: webhook-server-cert-low-mtu
-  target:
-    kind: Deployment
-    labelSelector: control-plane=controller-manager
+  - patch: |-
+      apiVersion: admissionregistration.k8s.io/v1
+      kind: ValidatingWebhookConfiguration
+      metadata:
+        name: not-important
+        annotations:
+          cert-manager.io/inject-ca-from: e2e-low-mtu/meridio-2-serving-cert-low-mtu
+      webhooks:
+      - name: vl34route-v1alpha1.kb.io
+        namespaceSelector:
+          matchLabels:
+            e2e-suite: low-mtu
+        clientConfig:
+          service:
+            name: meridio-2-webhook-service-low-mtu
+            namespace: e2e-low-mtu
+    target:
+      kind: ValidatingWebhookConfiguration
+  - patch: |-
+      - op: replace
+        path: /spec/dnsNames
+        value:
+        - meridio-2-webhook-service-low-mtu.e2e-low-mtu.svc
+        - meridio-2-webhook-service-low-mtu.e2e-low-mtu.svc.cluster.local
+      - op: replace
+        path: /spec/secretName
+        value: webhook-server-cert-low-mtu
+    target:
+      group: cert-manager.io
+      kind: Certificate
+      name: serving-cert
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: not-important
+      spec:
+        template:
+          spec:
+            containers:
+            - name: manager
+              env:
+              - name: MERIDIO_LB_SERVICE_ACCOUNT
+                value: meridio-2-stateless-load-balancer-low-mtu
+            volumes:
+            - name: webhook-certs
+              secret:
+                secretName: webhook-server-cert-low-mtu
+    target:
+      kind: Deployment
+      labelSelector: control-plane=controller-manager

--- a/test/e2e/suites/low-mtu/kustomization.yaml
+++ b/test/e2e/suites/low-mtu/kustomization.yaml
@@ -4,68 +4,68 @@ kind: Kustomization
 namespace: e2e-low-mtu
 
 resources:
-  - ../../../../config/default
+- ../../../../config/default
 
 images:
-  - name: controller-manager
-    newName: registry.nordix.org/cloud-native/meridio-2/controller-manager
-    newTag: latest
+- name: controller-manager
+  newName: registry.nordix.org/cloud-native/meridio-2/controller-manager
+  newTag: latest
 
 nameSuffix: -low-mtu
 
 labels:
-  - pairs:
-      e2e-suite: low-mtu
+- pairs:
+    e2e-suite: low-mtu
 
 patches:
-  - patch: |-
-      apiVersion: admissionregistration.k8s.io/v1
-      kind: ValidatingWebhookConfiguration
-      metadata:
-        name: not-important
-        annotations:
-          cert-manager.io/inject-ca-from: e2e-low-mtu/meridio-2-serving-cert-low-mtu
-      webhooks:
-      - name: vl34route-v1alpha1.kb.io
-        namespaceSelector:
-          matchLabels:
-            e2e-suite: low-mtu
-        clientConfig:
-          service:
-            name: meridio-2-webhook-service-low-mtu
-            namespace: e2e-low-mtu
-    target:
-      kind: ValidatingWebhookConfiguration
-  - patch: |-
-      - op: replace
-        path: /spec/dnsNames
-        value:
-        - meridio-2-webhook-service-low-mtu.e2e-low-mtu.svc
-        - meridio-2-webhook-service-low-mtu.e2e-low-mtu.svc.cluster.local
-      - op: replace
-        path: /spec/secretName
-        value: webhook-server-cert-low-mtu
-    target:
-      group: cert-manager.io
-      kind: Certificate
-      name: serving-cert
-  - patch: |-
-      apiVersion: apps/v1
-      kind: Deployment
-      metadata:
-        name: not-important
-      spec:
-        template:
-          spec:
-            containers:
-            - name: manager
-              env:
-              - name: MERIDIO_LB_SERVICE_ACCOUNT
-                value: meridio-2-stateless-load-balancer-low-mtu
-            volumes:
-            - name: webhook-certs
-              secret:
-                secretName: webhook-server-cert-low-mtu
-    target:
-      kind: Deployment
-      labelSelector: control-plane=controller-manager
+- patch: |-
+    apiVersion: admissionregistration.k8s.io/v1
+    kind: ValidatingWebhookConfiguration
+    metadata:
+      name: not-important
+      annotations:
+        cert-manager.io/inject-ca-from: e2e-low-mtu/meridio-2-serving-cert-low-mtu
+    webhooks:
+    - name: vl34route-v1alpha1.kb.io
+      namespaceSelector:
+        matchLabels:
+          e2e-suite: low-mtu
+      clientConfig:
+        service:
+          name: meridio-2-webhook-service-low-mtu
+          namespace: e2e-low-mtu
+  target:
+    kind: ValidatingWebhookConfiguration
+- patch: |-
+    - op: replace
+      path: /spec/dnsNames
+      value:
+      - meridio-2-webhook-service-low-mtu.e2e-low-mtu.svc
+      - meridio-2-webhook-service-low-mtu.e2e-low-mtu.svc.cluster.local
+    - op: replace
+      path: /spec/secretName
+      value: webhook-server-cert-low-mtu
+  target:
+    group: cert-manager.io
+    kind: Certificate
+    name: serving-cert
+- patch: |-
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: not-important
+    spec:
+      template:
+        spec:
+          containers:
+          - name: manager
+            env:
+            - name: MERIDIO_LB_SERVICE_ACCOUNT
+              value: meridio-2-stateless-load-balancer-low-mtu
+          volumes:
+          - name: webhook-certs
+            secret:
+              secretName: webhook-server-cert-low-mtu
+  target:
+    kind: Deployment
+    labelSelector: control-plane=controller-manager

--- a/test/e2e/suites/low-mtu/nad.yaml
+++ b/test/e2e/suites/low-mtu/nad.yaml
@@ -26,18 +26,18 @@ spec:
       ]
   }'
 ---
-# VLAN 500 NAD for gw-m1 BGP peering
+# VLAN 700 NAD for gw-m1 BGP peering
 apiVersion: k8s.cni.cncf.io/v1
 kind: NetworkAttachmentDefinition
 metadata:
-  name: vlan-500
+  name: vlan-700
 spec:
   config: |
     {
       "cniVersion": "0.3.1",
       "type": "vlan",
       "master": "eth0",
-      "vlanId": 500,
+      "vlanId": 700,
       "ipam": {
         "type": "whereabouts",
         "ipRanges": [

--- a/test/e2e/suites/low-mtu/routing.yaml
+++ b/test/e2e/suites/low-mtu/routing.yaml
@@ -6,10 +6,10 @@ metadata:
 spec:
   gatewayRef:
     name: gw-m1
-  interface: "vlan-500"
+  interface: "vlan-700"
   address: "169.254.50.150"
   bgp:
-    localASN: 64516
+    localASN: 64518
     remoteASN: 4200000000
     localPort: 10179
     remotePort: 10179

--- a/test/e2e/suites/sctp-multihoming/dg.yaml
+++ b/test/e2e/suites/sctp-multihoming/dg.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: meridio-2.nordix.org/v1alpha1
+kind: DistributionGroup
+metadata:
+  name: sctp-dg1
+spec:
+  type: Maglev
+  selector:
+    matchLabels:
+      app: sctp-target
+  maglev:
+    maxEndpoints: 32
+  parentRefs:
+  - name: sctp-gw1
+---
+apiVersion: meridio-2.nordix.org/v1alpha1
+kind: DistributionGroup
+metadata:
+  name: sctp-dg2
+spec:
+  type: Maglev
+  selector:
+    matchLabels:
+      app: sctp-target
+  maglev:
+    maxEndpoints: 32
+  parentRefs:
+  - name: sctp-gw2

--- a/test/e2e/suites/sctp-multihoming/dg.yaml
+++ b/test/e2e/suites/sctp-multihoming/dg.yaml
@@ -2,6 +2,34 @@
 apiVersion: meridio-2.nordix.org/v1alpha1
 kind: DistributionGroup
 metadata:
+  name: sctp-dg1-control
+spec:
+  type: Maglev
+  selector:
+    matchLabels:
+      app: sctp-target
+  maglev:
+    maxEndpoints: 32
+  parentRefs:
+  - name: sctp-gw1
+---
+apiVersion: meridio-2.nordix.org/v1alpha1
+kind: DistributionGroup
+metadata:
+  name: sctp-dg1-init
+spec:
+  type: Maglev
+  selector:
+    matchLabels:
+      app: sctp-target
+  maglev:
+    maxEndpoints: 32
+  parentRefs:
+  - name: sctp-gw1
+---
+apiVersion: meridio-2.nordix.org/v1alpha1
+kind: DistributionGroup
+metadata:
   name: sctp-dg1
 spec:
   type: Maglev
@@ -12,6 +40,34 @@ spec:
     maxEndpoints: 32
   parentRefs:
   - name: sctp-gw1
+---
+apiVersion: meridio-2.nordix.org/v1alpha1
+kind: DistributionGroup
+metadata:
+  name: sctp-dg2-control
+spec:
+  type: Maglev
+  selector:
+    matchLabels:
+      app: sctp-target
+  maglev:
+    maxEndpoints: 32
+  parentRefs:
+  - name: sctp-gw2
+---
+apiVersion: meridio-2.nordix.org/v1alpha1
+kind: DistributionGroup
+metadata:
+  name: sctp-dg2-init
+spec:
+  type: Maglev
+  selector:
+    matchLabels:
+      app: sctp-target
+  maglev:
+    maxEndpoints: 32
+  parentRefs:
+  - name: sctp-gw2
 ---
 apiVersion: meridio-2.nordix.org/v1alpha1
 kind: DistributionGroup

--- a/test/e2e/suites/sctp-multihoming/gateway.yaml
+++ b/test/e2e/suites/sctp-multihoming/gateway.yaml
@@ -1,0 +1,92 @@
+---
+# Gateway SCTP-1 on VLAN 500 with shared app networks
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: sctp-gw1
+spec:
+  gatewayClassName: meridio
+  infrastructure:
+    parametersRef:
+      group: meridio-2.nordix.org
+      kind: GatewayConfiguration
+      name: sctp-gwconfig1
+  listeners:
+  - name: sctp
+    protocol: TCP
+    port: 9000
+---
+apiVersion: meridio-2.nordix.org/v1alpha1
+kind: GatewayConfiguration
+metadata:
+  name: sctp-gwconfig1
+spec:
+  networkAttachments:
+  - type: NAD
+    nad:
+      name: sysctl-tuning
+      namespace: e2e-sctp-multihoming
+      interface: dummy
+  - type: NAD
+    nad:
+      name: vlan-500
+      namespace: e2e-sctp-multihoming
+      interface: vlan-500
+  - type: NAD
+    nad:
+      name: app-net-sctp1
+      namespace: e2e-sctp-multihoming
+      interface: net1
+  networkSubnets:
+  - attachmentType: NAD
+    cidrs:
+    - "169.111.100.0/24"
+  horizontalScaling:
+    replicas: 2
+    enforceReplicas: true
+---
+# Gateway SCTP-2 on VLAN 600 with shared app networks
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: sctp-gw2
+spec:
+  gatewayClassName: meridio
+  infrastructure:
+    parametersRef:
+      group: meridio-2.nordix.org
+      kind: GatewayConfiguration
+      name: sctp-gwconfig2
+  listeners:
+  - name: sctp
+    protocol: TCP
+    port: 9000
+---
+apiVersion: meridio-2.nordix.org/v1alpha1
+kind: GatewayConfiguration
+metadata:
+  name: sctp-gwconfig2
+spec:
+  networkAttachments:
+  - type: NAD
+    nad:
+      name: sysctl-tuning
+      namespace: e2e-sctp-multihoming
+      interface: dummy
+  - type: NAD
+    nad:
+      name: vlan-600
+      namespace: e2e-sctp-multihoming
+      interface: vlan-600
+  - type: NAD
+    nad:
+      name: app-net-sctp2
+      namespace: e2e-sctp-multihoming
+      interface: net2
+  networkSubnets:
+  - attachmentType: NAD
+    cidrs:
+    - "169.111.200.0/24"
+  horizontalScaling:
+    replicas: 2
+    enforceReplicas: true

--- a/test/e2e/suites/sctp-multihoming/gateway.yaml
+++ b/test/e2e/suites/sctp-multihoming/gateway.yaml
@@ -37,10 +37,9 @@ spec:
       name: app-net-sctp1
       namespace: e2e-sctp-multihoming
       interface: net1
-  networkSubnets:
+  internalSubnets:
   - attachmentType: NAD
-    cidrs:
-    - "169.111.100.0/24"
+    cidr: "169.111.100.0/24"
   horizontalScaling:
     replicas: 2
     enforceReplicas: true
@@ -83,10 +82,9 @@ spec:
       name: app-net-sctp2
       namespace: e2e-sctp-multihoming
       interface: net2
-  networkSubnets:
+  internalSubnets:
   - attachmentType: NAD
-    cidrs:
-    - "169.111.200.0/24"
+    cidr: "169.111.200.0/24"
   horizontalScaling:
     replicas: 2
     enforceReplicas: true

--- a/test/e2e/suites/sctp-multihoming/kustomization.yaml
+++ b/test/e2e/suites/sctp-multihoming/kustomization.yaml
@@ -4,68 +4,68 @@ kind: Kustomization
 namespace: e2e-sctp-multihoming
 
 resources:
-  - ../../../../config/default
+- ../../../../config/default
 
 images:
-  - name: controller-manager
-    newName: registry.nordix.org/cloud-native/meridio-2/controller-manager
-    newTag: latest
+- name: controller-manager
+  newName: registry.nordix.org/cloud-native/meridio-2/controller-manager
+  newTag: latest
 
 nameSuffix: -sctp-multihoming
 
 labels:
-  - pairs:
-      e2e-suite: sctp-multihoming
+- pairs:
+    e2e-suite: sctp-multihoming
 
 patches:
-  - patch: |-
-      apiVersion: admissionregistration.k8s.io/v1
-      kind: ValidatingWebhookConfiguration
-      metadata:
-        name: not-important
-        annotations:
-          cert-manager.io/inject-ca-from: e2e-sctp-multihoming/meridio-2-serving-cert-sctp-multihoming
-      webhooks:
-      - name: vl34route-v1alpha1.kb.io
-        namespaceSelector:
-          matchLabels:
-            e2e-suite: sctp-multihoming
-        clientConfig:
-          service:
-            name: meridio-2-webhook-service-sctp-multihoming
-            namespace: e2e-sctp-multihoming
-    target:
-      kind: ValidatingWebhookConfiguration
-  - patch: |-
-      - op: replace
-        path: /spec/dnsNames
-        value:
-        - meridio-2-webhook-service-sctp-multihoming.e2e-sctp-multihoming.svc
-        - meridio-2-webhook-service-sctp-multihoming.e2e-sctp-multihoming.svc.cluster.local
-      - op: replace
-        path: /spec/secretName
-        value: webhook-server-cert-sctp-multihoming
-    target:
-      group: cert-manager.io
-      kind: Certificate
-      name: serving-cert
-  - patch: |-
-      apiVersion: apps/v1
-      kind: Deployment
-      metadata:
-        name: not-important
-      spec:
-        template:
-          spec:
-            containers:
-            - name: manager
-              env:
-              - name: MERIDIO_LB_SERVICE_ACCOUNT
-                value: meridio-2-stateless-load-balancer-sctp-multihoming
-            volumes:
-            - name: webhook-certs
-              secret:
-                secretName: webhook-server-cert-sctp-multihoming
-    target:
-      kind: Deployment
-      labelSelector: control-plane=controller-manager
+- patch: |-
+    apiVersion: admissionregistration.k8s.io/v1
+    kind: ValidatingWebhookConfiguration
+    metadata:
+      name: not-important
+      annotations:
+        cert-manager.io/inject-ca-from: e2e-sctp-multihoming/meridio-2-serving-cert-sctp-multihoming
+    webhooks:
+    - name: vl34route-v1alpha1.kb.io
+      namespaceSelector:
+        matchLabels:
+          e2e-suite: sctp-multihoming
+      clientConfig:
+        service:
+          name: meridio-2-webhook-service-sctp-multihoming
+          namespace: e2e-sctp-multihoming
+  target:
+    kind: ValidatingWebhookConfiguration
+- patch: |-
+    - op: replace
+      path: /spec/dnsNames
+      value:
+      - meridio-2-webhook-service-sctp-multihoming.e2e-sctp-multihoming.svc
+      - meridio-2-webhook-service-sctp-multihoming.e2e-sctp-multihoming.svc.cluster.local
+    - op: replace
+      path: /spec/secretName
+      value: webhook-server-cert-sctp-multihoming
+  target:
+    group: cert-manager.io
+    kind: Certificate
+    name: serving-cert
+- patch: |-
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: not-important
+    spec:
+      template:
+        spec:
+          containers:
+          - name: manager
+            env:
+            - name: MERIDIO_LB_SERVICE_ACCOUNT
+              value: meridio-2-stateless-load-balancer-sctp-multihoming
+          volumes:
+          - name: webhook-certs
+            secret:
+              secretName: webhook-server-cert-sctp-multihoming
+  target:
+    kind: Deployment
+    labelSelector: control-plane=controller-manager

--- a/test/e2e/suites/sctp-multihoming/kustomization.yaml
+++ b/test/e2e/suites/sctp-multihoming/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: e2e-separate-appnet
+namespace: e2e-sctp-multihoming
 
 resources:
   - ../../../../config/default
@@ -11,11 +11,11 @@ images:
     newName: registry.nordix.org/cloud-native/meridio-2/controller-manager
     newTag: latest
 
-nameSuffix: -separate-appnet
+nameSuffix: -sctp-multihoming
 
 labels:
   - pairs:
-      e2e-suite: separate-appnet
+      e2e-suite: sctp-multihoming
 
 patches:
   - patch: |-
@@ -24,27 +24,27 @@ patches:
       metadata:
         name: not-important
         annotations:
-          cert-manager.io/inject-ca-from: e2e-separate-appnet/meridio-2-serving-cert-separate-appnet
+          cert-manager.io/inject-ca-from: e2e-sctp-multihoming/meridio-2-serving-cert-sctp-multihoming
       webhooks:
       - name: vl34route-v1alpha1.kb.io
         namespaceSelector:
           matchLabels:
-            e2e-suite: separate-appnet
+            e2e-suite: sctp-multihoming
         clientConfig:
           service:
-            name: meridio-2-webhook-service-separate-appnet
-            namespace: e2e-separate-appnet
+            name: meridio-2-webhook-service-sctp-multihoming
+            namespace: e2e-sctp-multihoming
     target:
       kind: ValidatingWebhookConfiguration
   - patch: |-
       - op: replace
         path: /spec/dnsNames
         value:
-        - meridio-2-webhook-service-separate-appnet.e2e-separate-appnet.svc
-        - meridio-2-webhook-service-separate-appnet.e2e-separate-appnet.svc.cluster.local
+        - meridio-2-webhook-service-sctp-multihoming.e2e-sctp-multihoming.svc
+        - meridio-2-webhook-service-sctp-multihoming.e2e-sctp-multihoming.svc.cluster.local
       - op: replace
         path: /spec/secretName
-        value: webhook-server-cert-separate-appnet
+        value: webhook-server-cert-sctp-multihoming
     target:
       group: cert-manager.io
       kind: Certificate
@@ -61,11 +61,11 @@ patches:
             - name: manager
               env:
               - name: MERIDIO_LB_SERVICE_ACCOUNT
-                value: meridio-2-stateless-load-balancer-separate-appnet
+                value: meridio-2-stateless-load-balancer-sctp-multihoming
             volumes:
             - name: webhook-certs
               secret:
-                secretName: webhook-server-cert-separate-appnet
+                secretName: webhook-server-cert-sctp-multihoming
     target:
       kind: Deployment
       labelSelector: control-plane=controller-manager

--- a/test/e2e/suites/sctp-multihoming/nad.yaml
+++ b/test/e2e/suites/sctp-multihoming/nad.yaml
@@ -1,0 +1,114 @@
+---
+# Sysctl tuning NAD
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: sysctl-tuning
+spec:
+  config: '{
+      "cniVersion": "0.4.0",
+      "name": "sysctl-tuning",
+      "plugins": [
+        {
+          "type": "tuning",
+          "prevResult": {},
+          "sysctl": {
+            "net.ipv4.conf.all.forwarding": "1",
+            "net.ipv6.conf.all.forwarding": "1",
+            "net.ipv4.fib_multipath_hash_policy": "1",
+            "net.ipv6.fib_multipath_hash_policy": "1",
+            "net.ipv6.conf.all.accept_dad": "0"
+          }
+        }
+      ]
+  }'
+---
+# VLAN 500 NAD for SCTP multihoming path 1
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: vlan-500
+spec:
+  config: |
+    {
+      "cniVersion": "0.3.1",
+      "type": "vlan",
+      "master": "eth0",
+      "vlanId": 500,
+      "ipam": {
+        "type": "whereabouts",
+        "ipRanges": [
+          { "range": "169.254.102.0/24", "exclude": ["169.254.102.150/32"] }
+        ]
+      }
+    }
+---
+# VLAN 600 NAD for SCTP multihoming path 2
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: vlan-600
+spec:
+  config: |
+    {
+      "cniVersion": "0.3.1",
+      "type": "vlan",
+      "master": "eth0",
+      "vlanId": 600,
+      "ipam": {
+        "type": "whereabouts",
+        "ipRanges": [
+          { "range": "169.254.202.0/24", "exclude": ["169.254.202.150/32"] }
+        ]
+      }
+    }
+---
+# Internal network 1 (SLLBR ↔ app Pods)
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: app-net-sctp1
+spec:
+  config: |
+    {
+      "cniVersion": "1.0.0",
+      "name": "app-net-sctp1",
+      "plugins": [
+        {
+          "type": "macvlan",
+          "master": "eth0",
+          "mode": "bridge",
+          "ipam": {
+            "type": "whereabouts",
+            "ipRanges": [
+              { "range": "169.111.100.0/24" }
+            ]
+          }
+        }
+      ]
+    }
+---
+# Internal network 2 (SLLBR ↔ app Pods)
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: app-net-sctp2
+spec:
+  config: |
+    {
+      "cniVersion": "1.0.0",
+      "name": "app-net-sctp2",
+      "plugins": [
+        {
+          "type": "macvlan",
+          "master": "eth0",
+          "mode": "bridge",
+          "ipam": {
+            "type": "whereabouts",
+            "ipRanges": [
+              { "range": "169.111.200.0/24" }
+            ]
+          }
+        }
+      ]
+    }

--- a/test/e2e/suites/sctp-multihoming/nad.yaml
+++ b/test/e2e/suites/sctp-multihoming/nad.yaml
@@ -17,6 +17,10 @@ spec:
             "net.ipv6.conf.all.forwarding": "1",
             "net.ipv4.fib_multipath_hash_policy": "1",
             "net.ipv6.fib_multipath_hash_policy": "1",
+            "net.ipv4.conf.all.rp_filter": "2",
+            "net.ipv4.conf.default.rp_filter": "2",
+            "net.ipv4.fwmark_reflect": "1",
+            "net.ipv6.fwmark_reflect": "1",
             "net.ipv6.conf.all.accept_dad": "0"
           }
         }

--- a/test/e2e/suites/sctp-multihoming/rbac.yaml
+++ b/test/e2e/suites/sctp-multihoming/rbac.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: meridio-2-network-sidecar-sctp-multihoming
+rules:
+- apiGroups: ["meridio-2.nordix.org"]
+  resources: ["endpointnetworkconfigurations"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["meridio-2.nordix.org"]
+  resources: ["endpointnetworkconfigurations/status"]
+  verbs: ["get", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: meridio-2-network-sidecar-sctp-multihoming
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: meridio-2-network-sidecar-sctp-multihoming
+subjects:
+- kind: ServiceAccount
+  name: meridio-2-network-sidecar
+  namespace: e2e-sctp-multihoming
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: meridio-2-network-sidecar
+  namespace: e2e-sctp-multihoming

--- a/test/e2e/suites/sctp-multihoming/rbac.yaml
+++ b/test/e2e/suites/sctp-multihoming/rbac.yaml
@@ -1,28 +1,30 @@
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   name: meridio-2-network-sidecar-sctp-multihoming
+  namespace: e2e-sctp-multihoming
 rules:
-- apiGroups: ["meridio-2.nordix.org"]
-  resources: ["endpointnetworkconfigurations"]
-  verbs: ["get", "list", "watch"]
-- apiGroups: ["meridio-2.nordix.org"]
-  resources: ["endpointnetworkconfigurations/status"]
-  verbs: ["get", "update", "patch"]
+  - apiGroups: ["meridio-2.nordix.org"]
+    resources: ["endpointnetworkconfigurations"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["meridio-2.nordix.org"]
+    resources: ["endpointnetworkconfigurations/status"]
+    verbs: ["get", "update", "patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   name: meridio-2-network-sidecar-sctp-multihoming
+  namespace: e2e-sctp-multihoming
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: meridio-2-network-sidecar-sctp-multihoming
 subjects:
-- kind: ServiceAccount
-  name: meridio-2-network-sidecar
-  namespace: e2e-sctp-multihoming
+  - kind: ServiceAccount
+    name: meridio-2-network-sidecar
+    namespace: e2e-sctp-multihoming
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/test/e2e/suites/sctp-multihoming/routing.yaml
+++ b/test/e2e/suites/sctp-multihoming/routing.yaml
@@ -50,7 +50,7 @@ spec:
 apiVersion: meridio-2.nordix.org/v1alpha1
 kind: L34Route
 metadata:
-  name: sctp-gw1-tcp-control
+  name: sctp-gw1-sctp-control
 spec:
   parentRefs:
   - name: sctp-gw1
@@ -67,7 +67,7 @@ spec:
   destinationPorts:
   - "9001"
   protocols:
-  - TCP
+  - SCTP
   priority: 10
 ---
 apiVersion: meridio-2.nordix.org/v1alpha1
@@ -123,7 +123,7 @@ spec:
 apiVersion: meridio-2.nordix.org/v1alpha1
 kind: L34Route
 metadata:
-  name: sctp-gw2-tcp-control
+  name: sctp-gw2-sctp-control
 spec:
   parentRefs:
   - name: sctp-gw2
@@ -140,7 +140,7 @@ spec:
   destinationPorts:
   - "9001"
   protocols:
-  - TCP
+  - SCTP
   priority: 10
 ---
 apiVersion: meridio-2.nordix.org/v1alpha1

--- a/test/e2e/suites/sctp-multihoming/routing.yaml
+++ b/test/e2e/suites/sctp-multihoming/routing.yaml
@@ -1,0 +1,194 @@
+---
+# sctp-gw1 router (VLAN 500, ASN 64516)
+apiVersion: meridio-2.nordix.org/v1alpha1
+kind: GatewayRouter
+metadata:
+  name: sctp-gw1-router-vlan500
+spec:
+  gatewayRef:
+    name: sctp-gw1
+    namespace: e2e-sctp-multihoming
+  interface: "vlan-500"
+  address: "169.254.102.150"
+  bgp:
+    localASN: 64516
+    remoteASN: 4200000000
+    localPort: 10179
+    remotePort: 10179
+    holdTime: 24s
+    bfd:
+      switch: true
+      minTx: 300ms
+      minRx: 300ms
+      multiplier: 5
+---
+# sctp-gw2 router (VLAN 600, ASN 64517)
+apiVersion: meridio-2.nordix.org/v1alpha1
+kind: GatewayRouter
+metadata:
+  name: sctp-gw2-router-vlan600
+spec:
+  gatewayRef:
+    name: sctp-gw2
+    namespace: e2e-sctp-multihoming
+  interface: "vlan-600"
+  address: "169.254.202.150"
+  bgp:
+    localASN: 64517
+    remoteASN: 4200000000
+    localPort: 10179
+    remotePort: 10179
+    holdTime: 24s
+    bfd:
+      switch: true
+      minTx: 300ms
+      minRx: 300ms
+      multiplier: 5
+---
+# Gateway sctp-gw1 routes (→ dg-sctp-gw1)
+---
+apiVersion: meridio-2.nordix.org/v1alpha1
+kind: L34Route
+metadata:
+  name: sctp-gw1-tcp-control
+spec:
+  parentRefs:
+  - name: sctp-gw1
+  backendRefs:
+  - name: sctp-dg1
+    group: meridio-2.nordix.org
+    kind: DistributionGroup
+  destinationCIDRs:
+  - "50.0.0.1/32"
+  sourceCIDRs:
+  - "0.0.0.0/0"
+  sourcePorts:
+  - "0-65535"
+  destinationPorts:
+  - "9001"
+  protocols:
+  - TCP
+  priority: 10
+---
+apiVersion: meridio-2.nordix.org/v1alpha1
+kind: L34Route
+metadata:
+  name: sctp-gw1-sctp-init
+spec:
+  parentRefs:
+  - name: sctp-gw1
+  backendRefs:
+  - name: sctp-dg1
+    group: meridio-2.nordix.org
+    kind: DistributionGroup
+  destinationCIDRs:
+  - "50.0.0.1/32"
+  sourceCIDRs:
+  - "0.0.0.0/0"
+  sourcePorts:
+  - "0-65535"
+  destinationPorts:
+  - "9000"
+  protocols:
+  - SCTP
+  byteMatches:
+  - "sctp[8:4] = 0"
+  - "sctp[12:1] = 1"
+  priority: 20
+---
+apiVersion: meridio-2.nordix.org/v1alpha1
+kind: L34Route
+metadata:
+  name: sctp-gw1-sctp-data
+spec:
+  parentRefs:
+  - name: sctp-gw1
+  backendRefs:
+  - name: sctp-dg1
+    group: meridio-2.nordix.org
+    kind: DistributionGroup
+  destinationCIDRs:
+  - "50.0.0.1/32"
+  sourceCIDRs:
+  - "0.0.0.0/0"
+  sourcePorts:
+  - "0-65535"
+  destinationPorts:
+  - "9000"
+  protocols:
+  - SCTP
+  priority: 30
+---
+# Gateway sctp-gw2 routes (→ dg-sctp-gw2)
+---
+apiVersion: meridio-2.nordix.org/v1alpha1
+kind: L34Route
+metadata:
+  name: sctp-gw2-tcp-control
+spec:
+  parentRefs:
+  - name: sctp-gw2
+  backendRefs:
+  - name: sctp-dg2
+    group: meridio-2.nordix.org
+    kind: DistributionGroup
+  destinationCIDRs:
+  - "50.0.0.2/32"
+  sourceCIDRs:
+  - "0.0.0.0/0"
+  sourcePorts:
+  - "0-65535"
+  destinationPorts:
+  - "9001"
+  protocols:
+  - TCP
+  priority: 10
+---
+apiVersion: meridio-2.nordix.org/v1alpha1
+kind: L34Route
+metadata:
+  name: sctp-gw2-sctp-init
+spec:
+  parentRefs:
+  - name: sctp-gw2
+  backendRefs:
+  - name: sctp-dg2
+    group: meridio-2.nordix.org
+    kind: DistributionGroup
+  destinationCIDRs:
+  - "50.0.0.2/32"
+  sourceCIDRs:
+  - "0.0.0.0/0"
+  sourcePorts:
+  - "0-65535"
+  destinationPorts:
+  - "9000"
+  protocols:
+  - SCTP
+  byteMatches:
+  - "sctp[8:4] = 0"
+  - "sctp[12:1] = 1"
+  priority: 20
+---
+apiVersion: meridio-2.nordix.org/v1alpha1
+kind: L34Route
+metadata:
+  name: sctp-gw2-sctp-data
+spec:
+  parentRefs:
+  - name: sctp-gw2
+  backendRefs:
+  - name: sctp-dg2
+    group: meridio-2.nordix.org
+    kind: DistributionGroup
+  destinationCIDRs:
+  - "50.0.0.2/32"
+  sourceCIDRs:
+  - "0.0.0.0/0"
+  sourcePorts:
+  - "0-65535"
+  destinationPorts:
+  - "9000"
+  protocols:
+  - SCTP
+  priority: 30

--- a/test/e2e/suites/sctp-multihoming/routing.yaml
+++ b/test/e2e/suites/sctp-multihoming/routing.yaml
@@ -55,7 +55,7 @@ spec:
   parentRefs:
   - name: sctp-gw1
   backendRefs:
-  - name: sctp-dg1
+  - name: sctp-dg1-control
     group: meridio-2.nordix.org
     kind: DistributionGroup
   destinationCIDRs:
@@ -78,7 +78,7 @@ spec:
   parentRefs:
   - name: sctp-gw1
   backendRefs:
-  - name: sctp-dg1
+  - name: sctp-dg1-init
     group: meridio-2.nordix.org
     kind: DistributionGroup
   destinationCIDRs:
@@ -92,6 +92,7 @@ spec:
   protocols:
   - SCTP
   byteMatches:
+  - "sctp[4:4] = 0"
   - "sctp[12:1] = 1"
   priority: 30
 ---
@@ -128,7 +129,7 @@ spec:
   parentRefs:
   - name: sctp-gw2
   backendRefs:
-  - name: sctp-dg2
+  - name: sctp-dg2-control
     group: meridio-2.nordix.org
     kind: DistributionGroup
   destinationCIDRs:
@@ -151,7 +152,7 @@ spec:
   parentRefs:
   - name: sctp-gw2
   backendRefs:
-  - name: sctp-dg2
+  - name: sctp-dg2-init
     group: meridio-2.nordix.org
     kind: DistributionGroup
   destinationCIDRs:
@@ -165,6 +166,7 @@ spec:
   protocols:
   - SCTP
   byteMatches:
+  - "sctp[4:4] = 0"
   - "sctp[12:1] = 1"
   priority: 30
 ---

--- a/test/e2e/suites/sctp-multihoming/routing.yaml
+++ b/test/e2e/suites/sctp-multihoming/routing.yaml
@@ -92,9 +92,8 @@ spec:
   protocols:
   - SCTP
   byteMatches:
-  - "sctp[8:4] = 0"
   - "sctp[12:1] = 1"
-  priority: 20
+  priority: 30
 ---
 apiVersion: meridio-2.nordix.org/v1alpha1
 kind: L34Route
@@ -117,7 +116,7 @@ spec:
   - "9000"
   protocols:
   - SCTP
-  priority: 30
+  priority: 20
 ---
 # Gateway sctp-gw2 routes (→ dg-sctp-gw2)
 ---
@@ -166,9 +165,8 @@ spec:
   protocols:
   - SCTP
   byteMatches:
-  - "sctp[8:4] = 0"
   - "sctp[12:1] = 1"
-  priority: 20
+  priority: 30
 ---
 apiVersion: meridio-2.nordix.org/v1alpha1
 kind: L34Route
@@ -191,4 +189,4 @@ spec:
   - "9000"
   protocols:
   - SCTP
-  priority: 30
+  priority: 20

--- a/test/e2e/suites/sctp-multihoming/targets.yaml
+++ b/test/e2e/suites/sctp-multihoming/targets.yaml
@@ -25,7 +25,7 @@ spec:
         command: ["/bin/bash", "-c"]
         args:
         - |
-          netperfmeter 9000 --control-over-tcp
+          netperfmeter 9000 -L 0.0.0.0
         securityContext:
           runAsNonRoot: true
           runAsUser: 10011

--- a/test/e2e/suites/sctp-multihoming/targets.yaml
+++ b/test/e2e/suites/sctp-multihoming/targets.yaml
@@ -2,20 +2,20 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: target-m
+  name: sctp-target
   labels:
-    app: target-m
+    app: sctp-target
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
-      app: target-m
+      app: sctp-target
   template:
     metadata:
       labels:
-        app: target-m
+        app: sctp-target
       annotations:
-        k8s.v1.cni.cncf.io/networks: app-net-mtu1200
+        k8s.v1.cni.cncf.io/networks: app-net-sctp1, app-net-sctp2
     spec:
       serviceAccountName: meridio-2-network-sidecar
       containers:
@@ -25,14 +25,12 @@ spec:
         command: ["/bin/bash", "-c"]
         args:
         - |
-          screen -d -m bash -c "./ctraffic -server -address [::]:5000" ;
-          screen -d -m bash -c "./ctraffic -server -udp -address [::]:5001" ;
-          tail -f /dev/null
+          netperfmeter 9000 --control-over-tcp
         securityContext:
           runAsNonRoot: true
+          runAsUser: 10011
           capabilities:
             drop: ["ALL"]
-            add: ["DAC_OVERRIDE", "NET_RAW", "SYS_PTRACE"]
       - name: network-sidecar
         image: registry.nordix.org/cloud-native/meridio-2/network-sidecar:latest
         imagePullPolicy: IfNotPresent
@@ -55,6 +53,7 @@ spec:
             fieldRef:
               fieldPath: metadata.uid
         securityContext:
+          runAsNonRoot: true
           capabilities:
-            drop: ["ALL"]
             add: ["NET_ADMIN"]
+            drop: ["ALL"]

--- a/test/e2e/suites/separate-appnetwork/kustomization.yaml
+++ b/test/e2e/suites/separate-appnetwork/kustomization.yaml
@@ -4,68 +4,68 @@ kind: Kustomization
 namespace: e2e-separate-appnet
 
 resources:
-  - ../../../../config/default
+- ../../../../config/default
 
 images:
-  - name: controller-manager
-    newName: registry.nordix.org/cloud-native/meridio-2/controller-manager
-    newTag: latest
+- name: controller-manager
+  newName: registry.nordix.org/cloud-native/meridio-2/controller-manager
+  newTag: latest
 
 nameSuffix: -separate-appnet
 
 labels:
-  - pairs:
-      e2e-suite: separate-appnet
+- pairs:
+    e2e-suite: separate-appnet
 
 patches:
-  - patch: |-
-      apiVersion: admissionregistration.k8s.io/v1
-      kind: ValidatingWebhookConfiguration
-      metadata:
-        name: not-important
-        annotations:
-          cert-manager.io/inject-ca-from: e2e-separate-appnet/meridio-2-serving-cert-separate-appnet
-      webhooks:
-      - name: vl34route-v1alpha1.kb.io
-        namespaceSelector:
-          matchLabels:
-            e2e-suite: separate-appnet
-        clientConfig:
-          service:
-            name: meridio-2-webhook-service-separate-appnet
-            namespace: e2e-separate-appnet
-    target:
-      kind: ValidatingWebhookConfiguration
-  - patch: |-
-      - op: replace
-        path: /spec/dnsNames
-        value:
-        - meridio-2-webhook-service-separate-appnet.e2e-separate-appnet.svc
-        - meridio-2-webhook-service-separate-appnet.e2e-separate-appnet.svc.cluster.local
-      - op: replace
-        path: /spec/secretName
-        value: webhook-server-cert-separate-appnet
-    target:
-      group: cert-manager.io
-      kind: Certificate
-      name: serving-cert
-  - patch: |-
-      apiVersion: apps/v1
-      kind: Deployment
-      metadata:
-        name: not-important
-      spec:
-        template:
-          spec:
-            containers:
-            - name: manager
-              env:
-              - name: MERIDIO_LB_SERVICE_ACCOUNT
-                value: meridio-2-stateless-load-balancer-separate-appnet
-            volumes:
-            - name: webhook-certs
-              secret:
-                secretName: webhook-server-cert-separate-appnet
-    target:
-      kind: Deployment
-      labelSelector: control-plane=controller-manager
+- patch: |-
+    apiVersion: admissionregistration.k8s.io/v1
+    kind: ValidatingWebhookConfiguration
+    metadata:
+      name: not-important
+      annotations:
+        cert-manager.io/inject-ca-from: e2e-separate-appnet/meridio-2-serving-cert-separate-appnet
+    webhooks:
+    - name: vl34route-v1alpha1.kb.io
+      namespaceSelector:
+        matchLabels:
+          e2e-suite: separate-appnet
+      clientConfig:
+        service:
+          name: meridio-2-webhook-service-separate-appnet
+          namespace: e2e-separate-appnet
+  target:
+    kind: ValidatingWebhookConfiguration
+- patch: |-
+    - op: replace
+      path: /spec/dnsNames
+      value:
+      - meridio-2-webhook-service-separate-appnet.e2e-separate-appnet.svc
+      - meridio-2-webhook-service-separate-appnet.e2e-separate-appnet.svc.cluster.local
+    - op: replace
+      path: /spec/secretName
+      value: webhook-server-cert-separate-appnet
+  target:
+    group: cert-manager.io
+    kind: Certificate
+    name: serving-cert
+- patch: |-
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: not-important
+    spec:
+      template:
+        spec:
+          containers:
+          - name: manager
+            env:
+            - name: MERIDIO_LB_SERVICE_ACCOUNT
+              value: meridio-2-stateless-load-balancer-separate-appnet
+          volumes:
+          - name: webhook-certs
+            secret:
+              secretName: webhook-server-cert-separate-appnet
+  target:
+    kind: Deployment
+    labelSelector: control-plane=controller-manager

--- a/test/e2e/suites/separate-appnetwork/targets.yaml
+++ b/test/e2e/suites/separate-appnetwork/targets.yaml
@@ -19,18 +19,20 @@ spec:
     spec:
       serviceAccountName: meridio-2-network-sidecar
       containers:
-      - name: ctraffic
-        image: registry.nordix.org/cloud-native/meridio/ctraffic:latest
-        command: ["/bin/sh", "-c"]
+      - name: example-target
+        image: registry.nordix.org/cloud-native/meridio-2/example-target:latest
+        imagePullPolicy: IfNotPresent
+        command: ["/bin/bash", "-c"]
         args:
         - |
-          /home/tapa-user/ctraffic -server -address [::]:5000 &
-          /home/tapa-user/ctraffic -server -udp -address [::]:5001 &
-          wait
+          screen -d -m bash -c "./ctraffic -server -address [::]:5000" ;
+          screen -d -m bash -c "./ctraffic -server -udp -address [::]:5001" ;
+          tail -f /dev/null
         securityContext:
           runAsNonRoot: true
           capabilities:
             drop: ["ALL"]
+            add: ["DAC_OVERRIDE", "NET_RAW", "SYS_PTRACE"]
       - name: network-sidecar
         image: registry.nordix.org/cloud-native/meridio-2/network-sidecar:latest
         imagePullPolicy: IfNotPresent

--- a/test/e2e/utils/traffic.go
+++ b/test/e2e/utils/traffic.go
@@ -7,6 +7,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"os/exec"
+	"regexp"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -25,7 +27,7 @@ func SendTraffic(vip string, port int, protocol string, nconn int) (map[string]i
 	}
 
 	cmdStr := fmt.Sprintf(
-		"docker exec vpn-gateway /opt/ctraffic %s -address %s -nconn %d -timeout 10s -stats all",
+		"docker exec vpn-gateway ctraffic %s -address %s -nconn %d -timeout 10s -stats all",
 		protoFlag, addr, nconn,
 	)
 	cmd := exec.Command("/bin/sh", "-c", cmdStr)
@@ -171,4 +173,211 @@ func parseCtrafficOutput(output []byte) (map[string]int, int, error) {
 	}
 
 	return hostCounts, result.FailedConnects, nil
+}
+
+// NetPerfMeterConfig holds configuration for NetPerfMeter client.
+type NetPerfMeterConfig struct {
+	Target         string   // "VIP:port"
+	LocalAddrs     []string // Client local addresses for multihoming
+	Protocol       string   // "sctp", "tcp", "udp"
+	Duration       int      // Test duration in seconds
+	FrameRate      string   // e.g., "const0" (saturated), "const25"
+	FrameSize      string   // e.g., "const1400"
+	ControlOverTCP bool     // Use TCP for control channel instead of SCTP
+}
+
+// NetPerfMeterResult holds parsed NetPerfMeter output.
+type NetPerfMeterResult struct {
+	RawOutput        string
+	TransmittedBytes int64
+	ReceivedBytes    int64
+	PacketLoss       int
+	FrameLoss        int
+}
+
+// RunNetPerfMeterClient runs NetPerfMeter client from vpn-gateway container.
+func RunNetPerfMeterClient(cfg NetPerfMeterConfig) (*NetPerfMeterResult, error) {
+	localAddrsArg := ""
+	if len(cfg.LocalAddrs) > 0 {
+		localAddrsArg = fmt.Sprintf("--local=%s", strings.Join(cfg.LocalAddrs, ","))
+	}
+
+	controlOverTCPArg := ""
+	if cfg.ControlOverTCP {
+		controlOverTCPArg = "--control-over-tcp"
+	}
+
+	trafficSpec := fmt.Sprintf("%s:%s:%s:%s", cfg.FrameRate, cfg.FrameSize, cfg.FrameRate, cfg.FrameSize)
+
+	cmdStr := fmt.Sprintf(
+		"docker exec vpn-gateway netperfmeter %s %s %s -runtime=%d -%s %s",
+		cfg.Target, localAddrsArg, controlOverTCPArg, cfg.Duration, cfg.Protocol, trafficSpec,
+	)
+
+	cmd := exec.Command("/bin/sh", "-c", cmdStr)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("netperfmeter failed: %w\noutput: %s", err, string(out))
+	}
+
+	result := &NetPerfMeterResult{RawOutput: string(out)}
+	if parseErr := parseNetPerfMeterOutput(result); parseErr != nil {
+		return result, fmt.Errorf("failed to parse output: %w", parseErr)
+	}
+
+	return result, nil
+}
+
+// parseNetPerfMeterOutput extracts key metrics from NetPerfMeter output.
+func parseNetPerfMeterOutput(result *NetPerfMeterResult) error {
+	lines := strings.Split(result.RawOutput, "\n")
+
+	// Parse "Bytes: X B" (may have trailing content like "-> Y B/s")
+	bytesRe := regexp.MustCompile(`^\s*\*\s+Bytes:\s+(\d+)\s+B`)
+	// Parse "Packet Loss: X packets" or "Packets: X packets"
+	pktLossRe := regexp.MustCompile(`^\s*\*\s+Packets:\s+(\d+)\s+packets`)
+	// Parse "Frame Loss: X frames" or "Frames: X frames"
+	frameLossRe := regexp.MustCompile(`^\s*\*\s+Frames:\s+(\d+)\s+frames`)
+
+	inTransmission := false
+	inReception := false
+	inLoss := false
+
+	for _, line := range lines {
+		if strings.Contains(line, "- Transmission:") {
+			inTransmission = true
+			inReception = false
+			inLoss = false
+			continue
+		}
+		if strings.Contains(line, "- Reception:") {
+			inTransmission = false
+			inReception = true
+			inLoss = false
+			continue
+		}
+		if strings.Contains(line, "- Loss:") {
+			inTransmission = false
+			inReception = false
+			inLoss = true
+			continue
+		}
+
+		if inTransmission {
+			if match := bytesRe.FindStringSubmatch(line); match != nil {
+				val, _ := strconv.ParseInt(match[1], 10, 64)
+				result.TransmittedBytes = val
+			}
+		}
+
+		if inReception {
+			if match := bytesRe.FindStringSubmatch(line); match != nil {
+				val, _ := strconv.ParseInt(match[1], 10, 64)
+				result.ReceivedBytes = val
+			}
+		}
+
+		if inLoss {
+			if match := pktLossRe.FindStringSubmatch(line); match != nil {
+				val, _ := strconv.Atoi(match[1])
+				result.PacketLoss = val
+			}
+			if match := frameLossRe.FindStringSubmatch(line); match != nil {
+				val, _ := strconv.Atoi(match[1])
+				result.FrameLoss = val
+			}
+		}
+	}
+
+	return nil
+}
+
+// CheckSCTPAssociation checks if an SCTP association exists on vpn-gateway for the given port and local addresses.
+// Returns true if found, along with the association details.
+func CheckSCTPAssociation(port int, localAddrs []string) (bool, string, error) {
+	cmdStr := "docker exec vpn-gateway cat /proc/net/sctp/assocs"
+	cmd := exec.Command("/bin/sh", "-c", cmdStr)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return false, "", fmt.Errorf("failed to read SCTP associations: %w\noutput: %s", err, string(out))
+	}
+
+	lines := strings.Split(string(out), "\n")
+	portStr := fmt.Sprintf(" %d ", port) // Space-padded to match column format
+
+	for _, line := range lines {
+		// Skip header line
+		if strings.Contains(line, "ASSOC") && strings.Contains(line, "SOCK") {
+			continue
+		}
+
+		// Check if line contains the remote port (RPORT column)
+		if !strings.Contains(line, portStr) {
+			continue
+		}
+
+		// Check if ALL local addresses appear in LADDRS
+		allLocalAddrsFound := true
+		for _, addr := range localAddrs {
+			if !strings.Contains(line, addr) {
+				allLocalAddrsFound = false
+				break
+			}
+		}
+
+		if allLocalAddrsFound {
+			return true, line, nil
+		}
+	}
+
+	return false, "", nil
+}
+
+// CheckSCTPAssociationWithVIPs checks SCTP association and verifies both local addresses and VIPs are present.
+func CheckSCTPAssociationWithVIPs(port int, localAddrs []string, vips []string) (bool, string, error) {
+	cmdStr := "docker exec vpn-gateway cat /proc/net/sctp/assocs"
+	cmd := exec.Command("/bin/sh", "-c", cmdStr)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return false, "", fmt.Errorf("failed to read SCTP associations: %w\noutput: %s", err, string(out))
+	}
+
+	lines := strings.Split(string(out), "\n")
+	portStr := fmt.Sprintf(" %d ", port)
+
+	for _, line := range lines {
+		// Skip header line
+		if strings.Contains(line, "ASSOC") && strings.Contains(line, "SOCK") {
+			continue
+		}
+
+		// Check remote port
+		if !strings.Contains(line, portStr) {
+			continue
+		}
+
+		// Check ALL local addresses are present
+		allLocalAddrsFound := true
+		for _, addr := range localAddrs {
+			if !strings.Contains(line, addr) {
+				allLocalAddrsFound = false
+				break
+			}
+		}
+
+		// Check ALL VIPs are present
+		allVIPsFound := true
+		for _, vip := range vips {
+			if !strings.Contains(line, vip) {
+				allVIPsFound = false
+				break
+			}
+		}
+
+		if allLocalAddrsFound && allVIPsFound {
+			return true, line, nil
+		}
+	}
+
+	return false, "", nil
 }


### PR DESCRIPTION
## Summary

This PR adds a comprehensive SCTP multihoming test suite with dual-path connectivity validation and restores the low-mtu suite with updated VLAN allocation. All test suites are migrated to a unified `example-target` container image with enhanced debugging capabilities.

## Issue
#113 

## Changes

### SCTP Multihoming Test Suite
- **New test suite**: `test/e2e/e2e_suite_sctp_test.go` with NetPerfMeter traffic validation
- **Dual-path setup**: Two gateways on VLAN 500/600 (ASN 64516/64517)
- **Traffic validation**: Zero packet/frame loss verification with saturated bidirectional SCTP traffic
- **Association validation**: Verify SCTP multihoming with multiple local addresses and VIPs

### VPN Gateway Infrastructure
- **SCTP support**: Add `lksctp-tools` and `netperfmeter` to containers
- **Network topology**:
  - VLAN 500/600 for SCTP multihoming paths
  - VLAN 700 for low-mtu suite (moved from VLAN 500)
- **BIRD upgrade**: Build BIRD 3.1.2 from source for better stability
- **BGP peers**: Updated ASN allocation (64516-64518)

### Unified Test Container
- **Migrate all suites** to `example-target` image
- **Enhanced tooling**: netperfmeter, ctraffic, mconnect, ss, tcpdump, strace
- **Debugging capabilities**: Added `DAC_OVERRIDE`, `NET_RAW`, `SYS_PTRACE` capabilities for troubleshooting

### Low-MTU Suite Updates
- **VLAN migration**: VLAN 500 → VLAN 700
- **ASN update**: 64516 → 64518
- **Image migration**: Use `example-target` instead of standalone `ctraffic`

### CI/CD
- **Build pipeline**: Add `example-target` to CI and e2e build matrices
- **Test coverage**: 4 suites × 2 Kubernetes versions = 8 e2e test jobs
  - common-appnetwork
  - separate-appnetwork
  - sctp-multihoming (new)
  - low-mtu (restored)