### PR TITLE
Gateway controller: declare per-IP-family readiness gates on LB Deploy...

### DIFF
--- a/config/templates/lb-deployment.yaml
+++ b/config/templates/lb-deployment.yaml
@@ -78,6 +78,18 @@ spec:
           value: "file:/var/log/bird/bird.log:104857600:/var/log/bird/bird.log.1:all"
         - name: MERIDIO_READINESS_DIR
           value: '/var/run/meridio'
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true

--- a/internal/controller/gateway/const.go
+++ b/internal/controller/gateway/const.go
@@ -42,4 +42,8 @@ const (
 	labelGatewayName = "gateway.networking.k8s.io/gateway-name"
 	labelManagedBy   = "app.kubernetes.io/managed-by"
 	managedByValue   = "gateway-controller.meridio-2.nordix.org"
+
+	// Readiness gates for external connectivity - used by LB Deployment pods to signal connectivity status
+	ReadinessGateIPv4 = "meridio-2.nordix.org/ipv4-connectivity"
+	ReadinessGateIPv6 = "meridio-2.nordix.org/ipv6-connectivity"
 )

--- a/internal/controller/gateway/deployment.go
+++ b/internal/controller/gateway/deployment.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
+	"net"
 	"strings"
 
 	netdefv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
@@ -175,6 +176,8 @@ func reconcileDeploymentSpec(base, template *appsv1.Deployment, gw *gatewayv1.Ga
 		}
 		applyGatewayConfiguration(desired, gwConfig, templateNADAnnotation, base == nil)
 	}
+	// Inject downward API env vars for router Pod identity (POD_NAME, POD_NAMESPACE, POD_UID) - after applying GatewayConfiguration in case it changes the container spec
+	injectRouterPodIdentityEnvVars(desired)
 
 	return desired
 }
@@ -280,6 +283,9 @@ func applyGatewayConfiguration(deployment *appsv1.Deployment, gwConfig *meridio2
 
 	// Network attachments
 	applyNetworkAttachments(deployment, templateNADAnnotation, gwConfig.Spec.NetworkAttachments)
+
+	// Readiness gates (per-IP-family based on InternalSubnets)
+	applyReadinessGates(deployment, gwConfig)
 }
 
 // applyVerticalScaling applies container resources from VerticalScaling config.
@@ -479,4 +485,107 @@ func parseNetworkAnnotation(annotation string) []*netdefv1.NetworkSelectionEleme
 	}
 
 	return elements
+}
+
+// ipFamiliesFromInternalSubnets scans CIDRs in gwConfig.Spec.InternalSubnets, returns (hasIPv4, hasIPv6 bool).
+// Each InternalSubnet entry contains a single CIDR of one IP family. Dual-stack uses two separate entries.
+func ipFamiliesFromInternalSubnets(subnets []meridio2v1alpha1.InternalSubnet) (bool, bool) {
+	hasIPv4 := false
+	hasIPv6 := false
+
+	for _, subnet := range subnets {
+		ip, _, err := net.ParseCIDR(subnet.CIDR)
+		if err != nil {
+			continue
+		}
+		if ip.To4() == nil {
+			hasIPv6 = true
+		} else {
+			hasIPv4 = true
+		}
+	}
+
+	return hasIPv4, hasIPv6
+}
+
+// applyReadinessGates sets deployment.spec.Template.Spec.ReadinessGates authoritatively based on presence of IP families in GatewayConfiguration.
+// Always replaces (controller owns these gates).
+func applyReadinessGates(deployment *appsv1.Deployment, gatewayConfig *meridio2v1alpha1.GatewayConfiguration) {
+	hasIPv4, hasIPv6 := ipFamiliesFromInternalSubnets(gatewayConfig.Spec.InternalSubnets)
+
+	gates := []corev1.PodReadinessGate{}
+
+	if hasIPv4 {
+		gates = append(gates, corev1.PodReadinessGate{
+			ConditionType: ReadinessGateIPv4,
+		})
+	}
+
+	if hasIPv6 {
+		gates = append(gates, corev1.PodReadinessGate{
+			ConditionType: ReadinessGateIPv6,
+		})
+	}
+
+	deployment.Spec.Template.Spec.ReadinessGates = gates
+}
+
+// injectRouterPodIdentityEnvVars finds the router container and ensures these downward API env vars are set: POD_NAME, POD_NAMESPACE, POD_UID
+// MERIDIO_GATEWAY_NAMESPACE is the Gateway's namespace (not necessarily the Pod's namespace — cross-namespace scenarios are possible in the future).
+// The router needs its own Pod's namespace to patch its own status.
+func injectRouterPodIdentityEnvVars(deployment *appsv1.Deployment) {
+	for i := range deployment.Spec.Template.Spec.Containers {
+		container := &deployment.Spec.Template.Spec.Containers[i]
+		if container.Name == "router" {
+			// Check if env vars already exist to avoid unnecessary updates
+			hasPodName := false
+			hasPodNamespace := false
+			hasPodUID := false
+
+			for j := range container.Env {
+				switch container.Env[j].Name {
+				case "POD_NAME":
+					hasPodName = true
+				case "POD_NAMESPACE":
+					hasPodNamespace = true
+				case "POD_UID":
+					hasPodUID = true
+				}
+			}
+
+			if !hasPodName {
+				container.Env = append(container.Env, corev1.EnvVar{
+					Name: "POD_NAME",
+					ValueFrom: &corev1.EnvVarSource{
+						FieldRef: &corev1.ObjectFieldSelector{
+							FieldPath: "metadata.name",
+						},
+					},
+				})
+			}
+
+			if !hasPodNamespace {
+				container.Env = append(container.Env, corev1.EnvVar{
+					Name: "POD_NAMESPACE",
+					ValueFrom: &corev1.EnvVarSource{
+						FieldRef: &corev1.ObjectFieldSelector{
+							FieldPath: "metadata.namespace",
+						},
+					},
+				})
+			}
+
+			if !hasPodUID {
+				container.Env = append(container.Env, corev1.EnvVar{
+					Name: "POD_UID",
+					ValueFrom: &corev1.EnvVarSource{
+						FieldRef: &corev1.ObjectFieldSelector{
+							FieldPath: "metadata.uid",
+						},
+					},
+				})
+			}
+			break
+		}
+	}
 }

--- a/internal/controller/gateway/deployment_test.go
+++ b/internal/controller/gateway/deployment_test.go
@@ -346,6 +346,95 @@ func TestReconcileLBDeployment(t *testing.T) {
 		var permErr *permanentDeploymentError
 		assert.True(t, errors.As(err, &permErr))
 	})
+
+	t.Run("SetsReadinessGates_DualStack", func(t *testing.T) {
+		gwClass := newGatewayClass(testControllerName)
+		gw := newGateway(gwClass.Name)
+		gwConfig := newGatewayConfiguration()
+		gwConfig.Spec.InternalSubnets = []meridio2v1alpha1.InternalSubnet{
+			{AttachmentType: "NAD", CIDR: "192.168.100.0/24"},
+			{AttachmentType: "NAD", CIDR: "2001:db8:100::/64"},
+		}
+		attachGatewayConfiguration(gw, gwConfig)
+		reconciler, fakeClient := setupReconciler(gwClass, gw, gwConfig)
+
+		err := reconciler.reconcileLBDeployment(context.Background(), gw, gwConfig, template)
+		assert.NoError(t, err)
+
+		var deployment appsv1.Deployment
+		err = fakeClient.Get(context.Background(), client.ObjectKey{
+			Namespace: gw.Namespace, Name: "sllb-" + gw.Name,
+		}, &deployment)
+		assert.NoError(t, err)
+		assert.Equal(t, []corev1.PodReadinessGate{
+			{ConditionType: ReadinessGateIPv4},
+			{ConditionType: ReadinessGateIPv6},
+		}, deployment.Spec.Template.Spec.ReadinessGates)
+	})
+
+	t.Run("SetsReadinessGates_IPv4Only", func(t *testing.T) {
+		gwClass := newGatewayClass(testControllerName)
+		gw := newGateway(gwClass.Name)
+		gwConfig := newGatewayConfiguration()
+		gwConfig.Spec.InternalSubnets = []meridio2v1alpha1.InternalSubnet{
+			{AttachmentType: "NAD", CIDR: "192.168.100.0/24"},
+		}
+		attachGatewayConfiguration(gw, gwConfig)
+		reconciler, fakeClient := setupReconciler(gwClass, gw, gwConfig)
+
+		err := reconciler.reconcileLBDeployment(context.Background(), gw, gwConfig, template)
+		assert.NoError(t, err)
+
+		var deployment appsv1.Deployment
+		err = fakeClient.Get(context.Background(), client.ObjectKey{
+			Namespace: gw.Namespace, Name: "sllb-" + gw.Name,
+		}, &deployment)
+		assert.NoError(t, err)
+		assert.Equal(t, []corev1.PodReadinessGate{
+			{ConditionType: ReadinessGateIPv4},
+		}, deployment.Spec.Template.Spec.ReadinessGates)
+	})
+
+	t.Run("InjectsRouterPodIdentityEnvVars", func(t *testing.T) {
+		templateWithRouter := template.DeepCopy()
+		templateWithRouter.Spec.Template.Spec.Containers = append(
+			templateWithRouter.Spec.Template.Spec.Containers,
+			corev1.Container{Name: "router", Image: "registry.nordix.org/cloud-native/meridio-2/router:latest"},
+		)
+
+		gwClass := newGatewayClass(testControllerName)
+		gw := newGateway(gwClass.Name)
+		gwConfig := newGatewayConfiguration()
+		attachGatewayConfiguration(gw, gwConfig)
+		reconciler, fakeClient := setupReconciler(gwClass, gw, gwConfig)
+
+		err := reconciler.reconcileLBDeployment(context.Background(), gw, gwConfig, templateWithRouter)
+		assert.NoError(t, err)
+
+		var deployment appsv1.Deployment
+		err = fakeClient.Get(context.Background(), client.ObjectKey{
+			Namespace: gw.Namespace, Name: "sllb-" + gw.Name,
+		}, &deployment)
+		assert.NoError(t, err)
+
+		// Find router container
+		var router *corev1.Container
+		for i := range deployment.Spec.Template.Spec.Containers {
+			if deployment.Spec.Template.Spec.Containers[i].Name == "router" {
+				router = &deployment.Spec.Template.Spec.Containers[i]
+				break
+			}
+		}
+		assert.NotNil(t, router)
+
+		envMap := make(map[string]corev1.EnvVar)
+		for _, env := range router.Env {
+			envMap[env.Name] = env
+		}
+		assert.Equal(t, "metadata.name", envMap["POD_NAME"].ValueFrom.FieldRef.FieldPath)
+		assert.Equal(t, "metadata.namespace", envMap["POD_NAMESPACE"].ValueFrom.FieldRef.FieldPath)
+		assert.Equal(t, "metadata.uid", envMap["POD_UID"].ValueFrom.FieldRef.FieldPath)
+	})
 }
 
 func TestInjectGatewayEnvVars(t *testing.T) {
@@ -1025,5 +1114,217 @@ func TestNetworkAttachmentsEqual(t *testing.T) {
 		a := []*netdefv1.NetworkSelectionElement{{Name: "nad1", Namespace: "ns1", InterfaceRequest: "net1"}}
 		b := []*netdefv1.NetworkSelectionElement{{Name: "nad2", Namespace: "ns1", InterfaceRequest: "net1"}}
 		assert.False(t, networkAttachmentsEqual(a, b, "default"))
+	})
+}
+func TestIPFamiliesFromInternalSubnets(t *testing.T) {
+	tests := []struct {
+		name     string
+		subnets  []meridio2v1alpha1.InternalSubnet
+		wantIPv4 bool
+		wantIPv6 bool
+	}{
+		{
+			name: "IPv4 only",
+			subnets: []meridio2v1alpha1.InternalSubnet{
+				{CIDR: "192.168.100.0/24"},
+			},
+			wantIPv4: true, wantIPv6: false,
+		},
+		{
+			name: "IPv6 only",
+			subnets: []meridio2v1alpha1.InternalSubnet{
+				{CIDR: "2001:db8:100::/64"},
+			},
+			wantIPv4: false, wantIPv6: true,
+		},
+		{
+			name: "Dual-stack (separate subnets)",
+			subnets: []meridio2v1alpha1.InternalSubnet{
+				{CIDR: "192.168.100.0/24"},
+				{CIDR: "2001:db8:100::/64"},
+			},
+			wantIPv4: true, wantIPv6: true,
+		},
+		{
+			name: "Multiple IPv4 subnets",
+			subnets: []meridio2v1alpha1.InternalSubnet{
+				{CIDR: "192.168.100.0/24"},
+				{CIDR: "10.0.0.0/16"},
+			},
+			wantIPv4: true, wantIPv6: false,
+		},
+		{
+			name:     "Empty subnets",
+			subnets:  []meridio2v1alpha1.InternalSubnet{},
+			wantIPv4: false, wantIPv6: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hasIPv4, hasIPv6 := ipFamiliesFromInternalSubnets(tt.subnets)
+			assert.Equal(t, tt.wantIPv4, hasIPv4)
+			assert.Equal(t, tt.wantIPv6, hasIPv6)
+		})
+	}
+}
+
+func TestApplyReadinessGates(t *testing.T) {
+	tests := []struct {
+		name          string
+		gwConfig      *meridio2v1alpha1.GatewayConfiguration
+		expectedGates []corev1.PodReadinessGate
+	}{
+		{
+			name: "IPv4 only - single gate",
+			gwConfig: gwConfigWithSubnets([]meridio2v1alpha1.InternalSubnet{
+				{CIDR: "192.168.100.0/24"},
+			}),
+			expectedGates: []corev1.PodReadinessGate{
+				{ConditionType: "meridio-2.nordix.org/ipv4-connectivity"},
+			},
+		},
+		{
+			name: "IPv6 only - single gate",
+			gwConfig: gwConfigWithSubnets([]meridio2v1alpha1.InternalSubnet{
+				{CIDR: "2001:db8:100::/64"},
+			}),
+			expectedGates: []corev1.PodReadinessGate{
+				{ConditionType: "meridio-2.nordix.org/ipv6-connectivity"},
+			},
+		},
+		{
+			name: "Dual-stack - both gates",
+			gwConfig: gwConfigWithSubnets([]meridio2v1alpha1.InternalSubnet{
+				{CIDR: "192.168.100.0/24"},
+				{CIDR: "2001:db8:100::/64"},
+			}),
+			expectedGates: []corev1.PodReadinessGate{
+				{ConditionType: "meridio-2.nordix.org/ipv4-connectivity"},
+				{ConditionType: "meridio-2.nordix.org/ipv6-connectivity"},
+			},
+		},
+		{
+			name: "Replaces existing stale readiness gates",
+			gwConfig: gwConfigWithSubnets([]meridio2v1alpha1.InternalSubnet{
+				{CIDR: "192.168.100.0/24"},
+			}),
+			expectedGates: []corev1.PodReadinessGate{
+				{ConditionType: "meridio-2.nordix.org/ipv4-connectivity"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			deployment := &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{Name: "loadbalancer"}},
+						},
+					},
+				},
+			}
+			if tt.name == "Replaces existing stale readiness gates" {
+				deployment.Spec.Template.Spec.ReadinessGates = []corev1.PodReadinessGate{
+					{ConditionType: "meridio-2.nordix.org/ipv4-connectivity"},
+					{ConditionType: "meridio-2.nordix.org/ipv6-connectivity"},
+				}
+			}
+			applyReadinessGates(deployment, tt.gwConfig)
+			assert.Equal(t, tt.expectedGates, deployment.Spec.Template.Spec.ReadinessGates)
+		})
+	}
+}
+
+// Helper to create a GatewayConfiguration with specified subnets for testing
+func gwConfigWithSubnets(subnets []meridio2v1alpha1.InternalSubnet) *meridio2v1alpha1.GatewayConfiguration {
+	return &meridio2v1alpha1.GatewayConfiguration{
+		Spec: meridio2v1alpha1.GatewayConfigurationSpec{
+			InternalSubnets: subnets,
+		},
+	}
+}
+
+func TestInjectRouterPodIdentityEnvVars(t *testing.T) {
+	fieldRefEnv := func(name, fieldPath string) corev1.EnvVar {
+		return corev1.EnvVar{
+			Name: name,
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{FieldPath: fieldPath},
+			},
+		}
+	}
+
+	t.Run("InjectsPodNameNamespaceAndUID", func(t *testing.T) {
+		deployment := &appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{Name: "loadbalancer"},
+							{Name: "router", Env: []corev1.EnvVar{
+								{Name: "MERIDIO_GATEWAY_NAME", Value: "gw1"},
+							}},
+						},
+					},
+				},
+			},
+		}
+
+		injectRouterPodIdentityEnvVars(deployment)
+
+		router := deployment.Spec.Template.Spec.Containers[1]
+		assert.Contains(t, router.Env, fieldRefEnv("POD_NAME", "metadata.name"))
+		assert.Contains(t, router.Env, fieldRefEnv("POD_NAMESPACE", "metadata.namespace"))
+		assert.Contains(t, router.Env, fieldRefEnv("POD_UID", "metadata.uid"))
+	})
+
+	t.Run("NoRouterContainer_NoOp", func(t *testing.T) {
+		deployment := &appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{Name: "loadbalancer"},
+						},
+					},
+				},
+			},
+		}
+
+		injectRouterPodIdentityEnvVars(deployment) // should not panic
+
+		assert.Len(t, deployment.Spec.Template.Spec.Containers[0].Env, 0)
+	})
+
+	t.Run("AlreadyHasEnvVars_Idempotent", func(t *testing.T) {
+		deployment := &appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{Name: "router", Env: []corev1.EnvVar{
+								fieldRefEnv("POD_NAME", "metadata.name"),
+								fieldRefEnv("POD_NAMESPACE", "metadata.namespace"),
+								fieldRefEnv("POD_UID", "metadata.uid"),
+							}},
+						},
+					},
+				},
+			},
+		}
+
+		injectRouterPodIdentityEnvVars(deployment)
+		injectRouterPodIdentityEnvVars(deployment)
+
+		router := deployment.Spec.Template.Spec.Containers[0]
+		// Count occurrences — should be exactly one of each
+		count := 0
+		for _, env := range router.Env {
+			if env.Name == "POD_NAME" || env.Name == "POD_NAMESPACE" || env.Name == "POD_UID" {
+				count++
+			}
+		}
+		assert.Equal(t, 3, count)
 	})
 }


### PR DESCRIPTION
Implement step 1 of gh-90 (External Connectivity Exposure via Readiness Gates). The Gateway controller now:

- Determines required IP families from GatewayConfiguration.spec.networkSubnets
- Declares readiness gates on the LB Deployment pod template:
  - meridio-2.nordix.org/ipv4-connectivity (if IPv4 subnets configured)
  - meridio-2.nordix.org/ipv6-connectivity (if IPv6 subnets configured)
- Injects POD_NAME, POD_NAMESPACE, POD_UID Downward API env vars into the router container (needed for router to patch its own Pod status)

The gates are declared by the Gateway controller but will be set by the router controller (step 2, gh-122).

Ref: gh-121