### PR TITLE
Fix e2e and sample configs for InternalSubnet rename

### DIFF
--- a/config/samples/meridio-2_v1alpha1_gatewayconfiguration.yaml
+++ b/config/samples/meridio-2_v1alpha1_gatewayconfiguration.yaml
@@ -19,10 +19,9 @@ spec:
         name: macvlan-nad-1
         namespace: default
         interface: net1
-  networkSubnets:
+  internalSubnets:
     - attachmentType: NAD
-      cidrs:
-        - 169.111.100.0/24
+      cidr: "169.111.100.0/24"
   horizontalScaling:
     replicas: 2
     enforceReplicas: true

--- a/test/e2e/suites/common-appnetwork/gateway.yaml
+++ b/test/e2e/suites/common-appnetwork/gateway.yaml
@@ -37,10 +37,9 @@ spec:
       name: app-net-b
       namespace: e2e-common-appnet
       interface: net-b
-  networkSubnets:
+  internalSubnets:
   - attachmentType: NAD
-    cidrs:
-    - "169.111.100.0/24"
+    cidr: "169.111.100.0/24"
   horizontalScaling:
     replicas: 2
 ---
@@ -82,9 +81,8 @@ spec:
       name: app-net-b
       namespace: e2e-common-appnet
       interface: net-b
-  networkSubnets:
+  internalSubnets:
   - attachmentType: NAD
-    cidrs:
-    - "169.111.100.0/24"
+    cidr: "169.111.100.0/24"
   horizontalScaling:
     replicas: 2

--- a/test/e2e/suites/low-mtu/gateway.yaml
+++ b/test/e2e/suites/low-mtu/gateway.yaml
@@ -36,9 +36,8 @@ spec:
       name: app-net-mtu1200
       namespace: e2e-low-mtu
       interface: net-m
-  networkSubnets:
+  internalSubnets:
   - attachmentType: NAD
-    cidrs:
-    - "169.111.50.0/24"
+    cidr: "169.111.50.0/24"
   horizontalScaling:
     replicas: 1

--- a/test/e2e/suites/separate-appnetwork/gateway.yaml
+++ b/test/e2e/suites/separate-appnetwork/gateway.yaml
@@ -37,10 +37,9 @@ spec:
       name: app-net-a1
       namespace: e2e-separate-appnet
       interface: net-a1
-  networkSubnets:
+  internalSubnets:
   - attachmentType: NAD
-    cidrs:
-    - "169.111.100.0/24"
+    cidr: "169.111.100.0/24"
   horizontalScaling:
     replicas: 2
 ---
@@ -82,9 +81,8 @@ spec:
       name: app-net-a2
       namespace: e2e-separate-appnet
       interface: net-a2
-  networkSubnets:
+  internalSubnets:
   - attachmentType: NAD
-    cidrs:
-    - "169.111.200.0/24"
+    cidr: "169.111.200.0/24"
   horizontalScaling:
     replicas: 2


### PR DESCRIPTION
Update YAML configuration files missed by PR #120:
- networkSubnets → internalSubnets
- cidrs (list) → cidr (scalar)

Ref: gh-120