### PR TITLE
Expose leader election parameters for controller-manager

### DIFF
--- a/cmd/controller-manager/cmd/run.go
+++ b/cmd/controller-manager/cmd/run.go
@@ -151,13 +151,17 @@ func runManager(cfg *config.ManagerConfig) error {
 	}
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
-		Scheme:                 scheme,
-		Cache:                  cacheOptions,
-		Metrics:                metricsServerOptions,
-		WebhookServer:          webhookServer,
-		HealthProbeBindAddress: cfg.ProbeAddr,
-		LeaderElection:         cfg.EnableLeaderElection,
-		LeaderElectionID:       "e9d059a3.nordix.org",
+		Scheme:                        scheme,
+		Cache:                         cacheOptions,
+		Metrics:                       metricsServerOptions,
+		WebhookServer:                 webhookServer,
+		HealthProbeBindAddress:        cfg.ProbeAddr,
+		LeaderElection:                cfg.EnableLeaderElection,
+		LeaderElectionID:              "e9d059a3.nordix.org",
+		LeaseDuration:                 &cfg.LeaseDuration,
+		RenewDeadline:                 &cfg.RenewDeadline,
+		RetryPeriod:                   &cfg.RetryPeriod,
+		LeaderElectionReleaseOnCancel: cfg.LeaderElectionReleaseOnCancel,
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")

--- a/config/controller-manager/manager.yaml
+++ b/config/controller-manager/manager.yaml
@@ -99,3 +99,12 @@ spec:
       volumes: []
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10
+      tolerations:
+        - key: "node.kubernetes.io/not-ready"
+          operator: "Exists"
+          effect: "NoExecute"
+          tolerationSeconds: 30
+        - key: "node.kubernetes.io/unreachable"
+          operator: "Exists"
+          effect: "NoExecute"
+          tolerationSeconds: 30

--- a/internal/common/config/helpers.go
+++ b/internal/common/config/helpers.go
@@ -19,6 +19,7 @@ package config
 import (
 	"os"
 	"strconv"
+	"time"
 
 	"github.com/spf13/pflag"
 )
@@ -51,6 +52,18 @@ func bindInt(fs *pflag.FlagSet, flagName, envName string, target *int) {
 	if !fs.Changed(flagName) {
 		if val := os.Getenv(envName); val != "" {
 			if parsed, err := strconv.Atoi(val); err == nil {
+				*target = parsed
+			}
+		}
+	}
+}
+
+// bindDuration binds an environment variable to a time.Duration configuration field
+// Only applies if the corresponding flag was not explicitly set
+func bindDuration(fs *pflag.FlagSet, flagName, envName string, target *time.Duration) {
+	if !fs.Changed(flagName) {
+		if val := os.Getenv(envName); val != "" {
+			if parsed, err := time.ParseDuration(val); err == nil {
 				*target = parsed
 			}
 		}

--- a/internal/common/config/manager.go
+++ b/internal/common/config/manager.go
@@ -17,6 +17,8 @@ limitations under the License.
 package config
 
 import (
+	"time"
+
 	"github.com/spf13/pflag"
 )
 
@@ -29,6 +31,12 @@ type ManagerConfig struct {
 	ProbeAddr            string
 	EnableLeaderElection bool
 	EnableWebhooks       bool
+
+	// Leader election tuning
+	LeaseDuration                 time.Duration
+	RenewDeadline                 time.Duration
+	RetryPeriod                   time.Duration
+	LeaderElectionReleaseOnCancel bool
 
 	// Security
 	SecureMetrics bool
@@ -65,6 +73,14 @@ func (c *ManagerConfig) AddFlags(fs *pflag.FlagSet) {
 		"The address the probe endpoint binds to.")
 	fs.BoolVar(&c.EnableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager.")
+	fs.DurationVar(&c.LeaseDuration, "leader-elect-lease-duration", 15*time.Second,
+		"Duration that non-leader candidates will wait to force acquire leadership.")
+	fs.DurationVar(&c.RenewDeadline, "leader-elect-renew-deadline", 10*time.Second,
+		"Duration that the acting leader will retry refreshing leadership before giving up.")
+	fs.DurationVar(&c.RetryPeriod, "leader-elect-retry-period", 2*time.Second,
+		"Duration between each leader election retry.")
+	fs.BoolVar(&c.LeaderElectionReleaseOnCancel, "leader-elect-release-on-cancel", true,
+		"Release the leader lease on graceful shutdown for faster failover.")
 	fs.BoolVar(&c.EnableWebhooks, "enable-webhooks", true,
 		"Enable webhook server. Set to false for testing.")
 	fs.BoolVar(&c.SecureMetrics, "metrics-secure", true,
@@ -102,6 +118,10 @@ func (c *ManagerConfig) BindEnv(fs *pflag.FlagSet) {
 	bindString(fs, "metrics-bind-address", "MERIDIO_METRICS_ADDR", &c.MetricsAddr)
 	bindString(fs, "health-probe-bind-address", "MERIDIO_PROBE_ADDR", &c.ProbeAddr)
 	bindBool(fs, "leader-elect", "MERIDIO_LEADER_ELECT", &c.EnableLeaderElection)
+	bindDuration(fs, "leader-elect-lease-duration", "MERIDIO_LEADER_ELECT_LEASE_DURATION", &c.LeaseDuration)
+	bindDuration(fs, "leader-elect-renew-deadline", "MERIDIO_LEADER_ELECT_RENEW_DEADLINE", &c.RenewDeadline)
+	bindDuration(fs, "leader-elect-retry-period", "MERIDIO_LEADER_ELECT_RETRY_PERIOD", &c.RetryPeriod)
+	bindBool(fs, "leader-elect-release-on-cancel", "MERIDIO_LEADER_ELECT_RELEASE_ON_CANCEL", &c.LeaderElectionReleaseOnCancel)
 	bindBool(fs, "enable-webhooks", "MERIDIO_ENABLE_WEBHOOKS", &c.EnableWebhooks)
 	bindBool(fs, "metrics-secure", "MERIDIO_METRICS_SECURE", &c.SecureMetrics)
 	bindBool(fs, "enable-http2", "MERIDIO_ENABLE_HTTP2", &c.EnableHTTP2)


### PR DESCRIPTION
This PR proposes solution for #98.

Add configurable leader election tuning parameters:
- `--leader-elect-lease-duration` (default 15s)
- `--leader-elect-renew-deadline` (default 10s)
- `--leader-elect-retry-period` (default 2s)
- `--leader-elect-release-on-cancel` (default true)

All parameters are also configurable via environment variables. 
`LeaderElectionReleaseOnCancel` defaults to `true` to enable fast failover on graceful shutdown (rolling updates, drains).

Reduce tolerationSeconds for node.kubernetes.io/not-ready and node.kubernetes.io/unreachable from the default 300s to 30s to ensure the controller-manager pod is evicted quickly when a node becomes unavailable, reducing total failover time from ~340s to ~85s.