### PR TITLE
Router controller: add connectivity classification and gate discovery

### DIFF
--- a/cmd/router/cmd/run.go
+++ b/cmd/router/cmd/run.go
@@ -20,15 +20,16 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"time"
 
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
@@ -175,7 +176,7 @@ func runRouter(ctx context.Context, cfg *config.RouterConfig) error {
 	})
 
 	g.Go(func() error {
-		return monitorConnectivity(ctx, mgr, birdInstance, cfg.MonitorInterval)
+		return monitorConnectivity(ctx, mgr, birdInstance, cfg)
 	})
 
 	g.Go(func() error {
@@ -190,8 +191,10 @@ func runRouter(ctx context.Context, cfg *config.RouterConfig) error {
 	return nil
 }
 
-// monitorConnectivity monitors BGP connectivity and logs status changes
-func monitorConnectivity(ctx context.Context, mgr ctrl.Manager, birdInstance *bird.Bird, interval time.Duration) error {
+// monitorConnectivity monitors BGP connectivity and manages readiness gates
+func monitorConnectivity(
+	ctx context.Context, mgr ctrl.Manager, birdInstance *bird.Bird, cfg *config.RouterConfig,
+) error {
 	log := ctrl.Log.WithName("monitor")
 
 	// Wait for manager cache to sync
@@ -199,12 +202,34 @@ func monitorConnectivity(ctx context.Context, mgr ctrl.Manager, birdInstance *bi
 		return fmt.Errorf("failed to wait for cache sync")
 	}
 
+	// Initialize connectivity gate manager (if Pod identity is configured)
+	var gateMgr *router.ConnectivityGateManager
+	if cfg.PodName != "" && cfg.PodNamespace != "" {
+		gateMgr = router.NewConnectivityGateManager(
+			mgr.GetClient(), cfg.PodName, cfg.PodNamespace,
+			types.UID(cfg.PodUID), cfg.ConnectivityHoldTime,
+		)
+		if err := gateMgr.DiscoverGates(ctx); err != nil {
+			log.Error(err, "failed to discover readiness gates, continuing without gate management")
+			gateMgr = nil
+		} else if gateMgr.HasIPv4Gate() || gateMgr.HasIPv6Gate() {
+			log.Info("readiness gates discovered", "ipv4", gateMgr.HasIPv4Gate(), "ipv6", gateMgr.HasIPv6Gate())
+			if err := gateMgr.SetAllGatesFalse(ctx); err != nil {
+				log.Error(err, "failed to set gates to False on startup")
+			}
+		} else {
+			gateMgr = nil // No gates declared, skip gate management
+		}
+	}
+
 	// Start monitoring with configured interval
-	statusCh, err := birdInstance.Monitor(ctx, interval)
+	statusCh, err := birdInstance.Monitor(ctx, cfg.MonitorInterval)
 	if err != nil {
 		return fmt.Errorf("failed to start monitoring: %w", err)
 	}
 
+	// Build family map from GatewayRouters (refreshed on each status update)
+	var familyMap map[string]string
 	var lastCount int
 	firstUpdate := true
 
@@ -229,12 +254,50 @@ func monitorConnectivity(ctx context.Context, mgr ctrl.Manager, birdInstance *bi
 				} else {
 					log.Info("Gateway connectivity lost", "status", status.StatusString())
 				}
-
 				lastCount = count
 				firstUpdate = false
 			}
+
+			// Update readiness gates
+			if gateMgr != nil {
+				// Rebuild family map if nil or if protocols exist but map yields no matches
+				// (handles late GatewayRouter creation)
+				if familyMap == nil || (len(status.Protocols) > 0 && len(familyMap) == 0) {
+					routers, err := getGatewayRoutersFromCache(ctx, mgr.GetClient(), cfg.GatewayName, cfg.GatewayNamespace)
+					if err == nil && len(routers) > 0 {
+						familyMap = router.BuildFamilyMap(routers)
+					}
+				}
+				if familyMap != nil {
+					ipv4, ipv6 := router.ClassifyConnectivityByFamily(status.Protocols, familyMap)
+					if err := gateMgr.OnStatusUpdate(ctx, ipv4, ipv6); err != nil {
+						log.Error(err, "failed to update readiness gates")
+					}
+				}
+			}
 		}
 	}
+}
+
+func getGatewayRoutersFromCache(
+	ctx context.Context, c client.Client, gatewayName, gatewayNamespace string,
+) ([]*meridio2v1alpha1.GatewayRouter, error) {
+	list := &meridio2v1alpha1.GatewayRouterList{}
+	if err := c.List(ctx, list, client.InNamespace(gatewayNamespace)); err != nil {
+		return nil, err
+	}
+	var result []*meridio2v1alpha1.GatewayRouter
+	for i := range list.Items {
+		ref := list.Items[i].Spec.GatewayRef
+		ns := list.Items[i].Namespace
+		if ref.Namespace != nil {
+			ns = string(*ref.Namespace)
+		}
+		if string(ref.Name) == gatewayName && ns == gatewayNamespace {
+			result = append(result, &list.Items[i])
+		}
+	}
+	return result, nil
 }
 
 func protocolsUp(protocols []bird.ProtocolStatus) int {

--- a/cmd/router/cmd/run.go
+++ b/cmd/router/cmd/run.go
@@ -262,8 +262,12 @@ func monitorConnectivity(
 				// Rebuild family map on every tick — reads from informer cache (no API call)
 				// and BuildFamilyMap is a trivial loop. Handles GatewayRouter add/remove/replace.
 				routers, err := getGatewayRoutersFromCache(ctx, mgr.GetClient(), cfg.GatewayName, cfg.GatewayNamespace)
-				if err == nil && len(routers) > 0 {
-					ipv4, ipv6 := router.ClassifyConnectivityByFamily(status.Protocols, router.BuildFamilyMap(routers))
+				if err == nil {
+					var ipv4, ipv6 bool
+					if len(routers) > 0 {
+						ipv4, ipv6 = router.ClassifyConnectivityByFamily(status.Protocols, router.BuildFamilyMap(routers))
+					}
+					// When no routers exist, ipv4/ipv6 stay false — gates set to False
 					if err := gateMgr.OnStatusUpdate(ctx, ipv4, ipv6); err != nil {
 						log.Error(err, "failed to update readiness gates")
 					}

--- a/cmd/router/cmd/run.go
+++ b/cmd/router/cmd/run.go
@@ -229,7 +229,6 @@ func monitorConnectivity(
 	}
 
 	// Build family map from GatewayRouters (refreshed on each status update)
-	var familyMap map[string]string
 	var lastCount int
 	firstUpdate := true
 
@@ -260,16 +259,11 @@ func monitorConnectivity(
 
 			// Update readiness gates
 			if gateMgr != nil {
-				// Rebuild family map if nil or if protocols exist but map yields no matches
-				// (handles late GatewayRouter creation)
-				if familyMap == nil || (len(status.Protocols) > 0 && len(familyMap) == 0) {
-					routers, err := getGatewayRoutersFromCache(ctx, mgr.GetClient(), cfg.GatewayName, cfg.GatewayNamespace)
-					if err == nil && len(routers) > 0 {
-						familyMap = router.BuildFamilyMap(routers)
-					}
-				}
-				if familyMap != nil {
-					ipv4, ipv6 := router.ClassifyConnectivityByFamily(status.Protocols, familyMap)
+				// Rebuild family map on every tick — reads from informer cache (no API call)
+				// and BuildFamilyMap is a trivial loop. Handles GatewayRouter add/remove/replace.
+				routers, err := getGatewayRoutersFromCache(ctx, mgr.GetClient(), cfg.GatewayName, cfg.GatewayNamespace)
+				if err == nil && len(routers) > 0 {
+					ipv4, ipv6 := router.ClassifyConnectivityByFamily(status.Protocols, router.BuildFamilyMap(routers))
 					if err := gateMgr.OnStatusUpdate(ctx, ipv4, ipv6); err != nil {
 						log.Error(err, "failed to update readiness gates")
 					}

--- a/config/rbac/lb-serviceaccount.yaml
+++ b/config/rbac/lb-serviceaccount.yaml
@@ -51,6 +51,21 @@ rules:
   - get
   - list
   - watch
+# Router controller patches its own Pod status (readiness gates)
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - pods/status
+  verbs:
+  - get
+  - update
+  - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/docs/controllers/router.md
+++ b/docs/controllers/router.md
@@ -168,7 +168,7 @@ The monitoring goroutine sets per-IP-family Pod readiness gate conditions based 
   - `meridio-2.nordix.org/ipv6-connectivity` — set if IPv6 subnets are configured
 - **Gate lifecycle**:
   1. Router starts → sets all declared gates to `False` (defense-in-depth)
-  2. BGP session established → after hold time (default 10s), sets gate to `True`
+  2. BGP session established → after hold time (default 3s), sets gate to `True`
   3. BGP session drops → sets gate to `False` immediately (no damping)
 - **Damping**: Up transitions are damped (configurable via `--connectivity-hold-time`) to avoid flapping. Down transitions are immediate for fast failure detection.
 - **Gate discovery**: Router reads its own Pod's `spec.readinessGates` to determine which gates to manage. Only manages declared gates.

--- a/docs/controllers/router.md
+++ b/docs/controllers/router.md
@@ -159,13 +159,22 @@ All flags support environment variable overrides following the precedence: flags
 
 - **Startup readiness window**: `running` is set to `true` after `cmd.Start()` (fork), not after BIRD's control socket is ready. A reconcile during this window will attempt `birdc configure` and fail. Self-heals via controller-runtime requeue, but produces noisy error logs at startup.
 
-### Connectivity Signaling (post-MVP)
+### Connectivity Signaling via Readiness Gates
 
-The monitoring goroutine will evolve from log-only to a data source for the controller manager:
+The monitoring goroutine sets per-IP-family Pod readiness gate conditions based on BGP session state:
 
-- **Pod readiness gates**: Router sets per-IP-family readiness conditions (e.g., `ipv4-ready`, `ipv6-ready`) based on BGP session state
-- **Controller manager consumes**: Watches LB Pods, reads readiness gates, builds next-hop lists for `EndpointNetworkConfiguration` from only Pods with relevant gates set to `True`
-- **Why readiness gates, not CR status**: GatewayRouter is a shared cluster resource — N LB Pods reconcile the same CRs. Per-Pod connectivity state belongs on the Pod, not the CR.
+- **Gate condition types**:
+  - `meridio-2.nordix.org/ipv4-connectivity` — set if IPv4 subnets are configured
+  - `meridio-2.nordix.org/ipv6-connectivity` — set if IPv6 subnets are configured
+- **Gate lifecycle**:
+  1. Router starts → sets all declared gates to `False` (defense-in-depth)
+  2. BGP session established → after hold time (default 10s), sets gate to `True`
+  3. BGP session drops → sets gate to `False` immediately (no damping)
+- **Damping**: Up transitions are damped (configurable via `--connectivity-hold-time`) to avoid flapping. Down transitions are immediate for fast failure detection.
+- **Gate discovery**: Router reads its own Pod's `spec.readinessGates` to determine which gates to manage. Only manages declared gates.
+- **Per-IP-family independence**: IPv4 and IPv6 gates are managed independently with separate hold timers.
+- **Configuration**: Requires `POD_NAME`, `POD_NAMESPACE`, `POD_UID` environment variables (Downward API, injected by Gateway controller in LB Deployment template).
+- **RBAC**: Requires `pods/get` + `pods/status/update` (configured in `config/rbac/lb-serviceaccount.yaml`).
 
 ### Metrics and Route Monitoring (post-MVP)
 

--- a/docs/operations/constraints-and-limitations.md
+++ b/docs/operations/constraints-and-limitations.md
@@ -54,9 +54,9 @@ The LB controller assigns fwmarks and routing table IDs dynamically per Distribu
 
 The router now gates VIP advertisement on LB readiness. The collocated LB controller writes `lb-ready-<distGroupName>` files to a shared directory when a DistributionGroup has ready targets. The router watches this directory via fsnotify and suppresses VIPs until at least one readiness file exists. Configurable via `--readiness-dir` / `MERIDIO_READINESS_DIR` (default: `/var/run/meridio`).
 
-**11. No connectivity-based readiness signaling to the controller-manager**
+**11. No connectivity-based readiness signaling to the controller-manager** *(partially resolved)*
 
-The router only logs BGP state changes — it does not set Pod readiness gates or signal the controller-manager about external connectivity status. As a result, the ENC controller cannot react to a running LB Pod losing external connectivity. The network sidecar's next-hop list will not be updated when an LB Pod's BGP sessions go down, meaning application Pods may continue routing return traffic through an LB that has lost external connectivity.
+The router now sets per-IP-family Pod readiness gates (`meridio-2.nordix.org/ipv4-connectivity`, `meridio-2.nordix.org/ipv6-connectivity`) based on BGP session state (PR #142). However, the ENC controller does not yet consume these gates to filter next-hop lists (gh-123). Until step 3 is implemented, application Pods may still route return traffic through an LB that has lost external connectivity.
 
 **12. BIRD error propagation missing**
 

--- a/internal/common/config/router.go
+++ b/internal/common/config/router.go
@@ -64,7 +64,7 @@ func (c *RouterConfig) AddFlags(fs *pflag.FlagSet) {
 		"Pod namespace (from Downward API)")
 	fs.StringVar(&c.PodUID, "pod-uid", "",
 		"Pod UID (from Downward API)")
-	fs.DurationVar(&c.ConnectivityHoldTime, "connectivity-hold-time", 10*time.Second,
+	fs.DurationVar(&c.ConnectivityHoldTime, "connectivity-hold-time", 3*time.Second,
 		"Hold time before setting connectivity gate to True after BGP session establishes")
 	fs.StringVar(&c.ProbeAddr, "health-probe-bind-address", ":8082",
 		"The address the probe endpoint binds to.")

--- a/internal/common/config/router.go
+++ b/internal/common/config/router.go
@@ -28,24 +28,28 @@ import (
 
 // RouterConfig holds configuration for the router
 type RouterConfig struct {
-	GatewayName        string
-	GatewayNamespace   string
-	ProbeAddr          string
-	LogLevel           string
-	MetricsAddr        string
-	SecureMetrics      bool
-	MetricsCertPath    string
-	MetricsCertName    string
-	MetricsCertKey     string
-	EnableHTTP2        bool
-	BirdLogs           bird.BirdLogParams
-	BirdKernelScanTime int
-	LBReadinessDir     string
-	TableID            int
-	RulePriority       int
-	BirdSocket         string
-	BirdConfig         string
-	MonitorInterval    time.Duration
+	GatewayName          string
+	GatewayNamespace     string
+	PodName              string
+	PodNamespace         string
+	PodUID               string
+	ConnectivityHoldTime time.Duration
+	ProbeAddr            string
+	LogLevel             string
+	MetricsAddr          string
+	SecureMetrics        bool
+	MetricsCertPath      string
+	MetricsCertName      string
+	MetricsCertKey       string
+	EnableHTTP2          bool
+	BirdLogs             bird.BirdLogParams
+	BirdKernelScanTime   int
+	LBReadinessDir       string
+	TableID              int
+	RulePriority         int
+	BirdSocket           string
+	BirdConfig           string
+	MonitorInterval      time.Duration
 }
 
 // AddFlags adds configuration flags to the provided FlagSet
@@ -54,6 +58,14 @@ func (c *RouterConfig) AddFlags(fs *pflag.FlagSet) {
 		"Name of the Gateway resource to watch (required)")
 	fs.StringVar(&c.GatewayNamespace, "gateway-namespace", "default",
 		"Namespace of the Gateway resource")
+	fs.StringVar(&c.PodName, "pod-name", "",
+		"Pod name (from Downward API)")
+	fs.StringVar(&c.PodNamespace, "pod-namespace", "",
+		"Pod namespace (from Downward API)")
+	fs.StringVar(&c.PodUID, "pod-uid", "",
+		"Pod UID (from Downward API)")
+	fs.DurationVar(&c.ConnectivityHoldTime, "connectivity-hold-time", 10*time.Second,
+		"Hold time before setting connectivity gate to True after BGP session establishes")
 	fs.StringVar(&c.ProbeAddr, "health-probe-bind-address", ":8082",
 		"The address the probe endpoint binds to.")
 	fs.StringVar(&c.LogLevel, "log-level", "info",
@@ -112,6 +124,10 @@ func (c *RouterConfig) AddFlags(fs *pflag.FlagSet) {
 func (c *RouterConfig) BindEnv(fs *pflag.FlagSet) {
 	bindString(fs, "gateway-name", "MERIDIO_GATEWAY_NAME", &c.GatewayName)
 	bindString(fs, "gateway-namespace", "MERIDIO_GATEWAY_NAMESPACE", &c.GatewayNamespace)
+	bindString(fs, "pod-name", "POD_NAME", &c.PodName)
+	bindString(fs, "pod-namespace", "POD_NAMESPACE", &c.PodNamespace)
+	bindString(fs, "pod-uid", "POD_UID", &c.PodUID)
+	bindDuration(fs, "connectivity-hold-time", "MERIDIO_CONNECTIVITY_HOLD_TIME", &c.ConnectivityHoldTime)
 	bindString(fs, "health-probe-bind-address", "MERIDIO_PROBE_ADDR", &c.ProbeAddr)
 	bindString(fs, "log-level", "MERIDIO_LOG_LEVEL", &c.LogLevel)
 	bindString(fs, "metrics-bind-address", "MERIDIO_METRICS_ADDR", &c.MetricsAddr)

--- a/internal/controller/router/connectivity.go
+++ b/internal/controller/router/connectivity.go
@@ -18,6 +18,7 @@ package router
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -171,27 +172,32 @@ func (cgm *ConnectivityGateManager) patchGateCondition(ctx context.Context, cond
 
 // SetAllGatesFalse(ctx) error — called on startup (defense-in-depth)
 func (cgm *ConnectivityGateManager) SetAllGatesFalse(ctx context.Context) error {
+	var errFinal error
 	if cgm.ipv4Gate != nil {
 		if err := cgm.patchGateCondition(ctx, ReadinessGateIPv4, false); err != nil {
-			return fmt.Errorf("error patching IPv4 gate: %w", err)
+			errFinal = errors.Join(errFinal, err)
 		}
 	}
 	if cgm.ipv6Gate != nil {
 		if err := cgm.patchGateCondition(ctx, ReadinessGateIPv6, false); err != nil {
-			return fmt.Errorf("error patching IPv6 gate: %w", err)
+			errFinal = errors.Join(errFinal, err)
 		}
 	}
-	return nil
+	return errFinal
 }
 
 // OnStatusUpdate handles per-IP-family connectivity changes with damping.
 // Down transitions are immediate. Up transitions require holdTime to elapse
 // with continuous connectivity before the gate is set to True.
 func (cgm *ConnectivityGateManager) OnStatusUpdate(ctx context.Context, ipv4Connected, ipv6Connected bool) error {
+	var errFinal error
 	if err := cgm.handleGate(ctx, cgm.ipv4Gate, ipv4Connected, &cgm.ipv4UpSince, ReadinessGateIPv4); err != nil {
-		return err
+		errFinal = errors.Join(errFinal, err)
 	}
-	return cgm.handleGate(ctx, cgm.ipv6Gate, ipv6Connected, &cgm.ipv6UpSince, ReadinessGateIPv6)
+	if err := cgm.handleGate(ctx, cgm.ipv6Gate, ipv6Connected, &cgm.ipv6UpSince, ReadinessGateIPv6); err != nil {
+		errFinal = errors.Join(errFinal, err)
+	}
+	return errFinal
 }
 
 func (cgm *ConnectivityGateManager) handleGate(ctx context.Context, gate *bool, connected bool, upSince *time.Time, conditionType string) error {

--- a/internal/controller/router/connectivity.go
+++ b/internal/controller/router/connectivity.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
+	"net"
 	"time"
 
 	meridio2v1alpha1 "github.com/nordix/meridio-2/api/v1alpha1"
@@ -43,6 +43,9 @@ type ConnectivityGateManager struct {
 	// Current gate states (last written to API)
 	ipv4Gate *bool // nil = not declared, true/false = current value
 	ipv6Gate *bool
+	// Dirty flags: force unconditional write on next tick after any failure
+	ipv4Dirty bool
+	ipv6Dirty bool
 	// Damping: timestamp when connectivity first came up (zero = not up)
 	ipv4UpSince time.Time
 	ipv6UpSince time.Time
@@ -119,55 +122,40 @@ func ClassifyConnectivityByFamily(protocols []bird.ProtocolStatus, familyMap map
 	return
 }
 
-// buildFamilyMap creates a mapping from protocol names to IP families based on the provided GatewayRouters.
+// BuildFamilyMap creates a mapping from protocol names to IP families based on the provided GatewayRouters.
 func BuildFamilyMap(gatewayRouters []*meridio2v1alpha1.GatewayRouter) map[string]string {
 	familyMap := make(map[string]string)
 	for _, gr := range gatewayRouters {
-		address := gr.Spec.Address
-		protocol := "IPv4"
-		if strings.Contains(address, ":") {
-			protocol = "IPv6"
+		family := "IPv4"
+		if ip := net.ParseIP(gr.Spec.Address); ip != nil && ip.To4() == nil {
+			family = "IPv6"
 		}
-		protoName := fmt.Sprintf("NBR-%s", gr.Name)
-		familyMap[protoName] = protocol
+		familyMap[fmt.Sprintf("NBR-%s", gr.Name)] = family
 	}
 	return familyMap
 }
 
-// patchGateCondition(ctx, conditionType, status) error — patches Pod status
+// patchGateCondition patches a single Pod status condition using a strategic merge patch.
+// No Get required — always writes unconditionally. The caller decides whether to call it.
 func (cgm *ConnectivityGateManager) patchGateCondition(ctx context.Context, conditionType string, status bool) error {
-	pod := &corev1.Pod{}
-	if err := cgm.client.Get(ctx, types.NamespacedName{Name: cgm.podName, Namespace: cgm.podNamespace}, pod); err != nil {
-		return fmt.Errorf("error fetching pod for patching: %w", err)
-	}
-
-	newStatus := corev1.ConditionFalse
+	condStatus := corev1.ConditionFalse
 	if status {
-		newStatus = corev1.ConditionTrue
+		condStatus = corev1.ConditionTrue
 	}
 
-	// Find or create the condition
-	found := false
-	for i := range pod.Status.Conditions {
-		if string(pod.Status.Conditions[i].Type) == conditionType {
-			if pod.Status.Conditions[i].Status == newStatus {
-				return nil // No change needed
-			}
-			pod.Status.Conditions[i].Status = newStatus
-			pod.Status.Conditions[i].LastTransitionTime = metav1.Now()
-			found = true
-			break
-		}
-	}
-	if !found {
-		pod.Status.Conditions = append(pod.Status.Conditions, corev1.PodCondition{
-			Type:               corev1.PodConditionType(conditionType),
-			Status:             newStatus,
-			LastTransitionTime: metav1.Now(),
-		})
-	}
+	now := metav1.Now().Format(time.RFC3339)
+	patchJSON := fmt.Sprintf(
+		`{"status":{"conditions":[{"type":%q,"status":%q,"lastTransitionTime":%q}]}}`,
+		conditionType, string(condStatus), now,
+	)
 
-	return cgm.client.Status().Update(ctx, pod)
+	pod := &corev1.Pod{}
+	pod.Name = cgm.podName
+	pod.Namespace = cgm.podNamespace
+
+	return cgm.client.Status().Patch(ctx, pod, client.RawPatch(
+		types.StrategicMergePatchType, []byte(patchJSON),
+	))
 }
 
 // SetAllGatesFalse(ctx) error — called on startup (defense-in-depth)
@@ -205,21 +193,25 @@ func (cgm *ConnectivityGateManager) handleGate(ctx context.Context, gate *bool, 
 		return nil // Gate not declared
 	}
 
+	dirty := cgm.getDirty(conditionType)
+
 	if !connected {
 		// Down: immediate
 		*upSince = time.Time{} // Reset hold timer
-		if *gate {
+		if *gate || *dirty {
 			if err := cgm.patchGateCondition(ctx, conditionType, false); err != nil {
+				*dirty = true
 				return err
 			}
 			*gate = false
+			*dirty = false
 		}
 		return nil
 	}
 
 	// Connected
-	if *gate {
-		return nil // Already True, no-op
+	if *gate && !*dirty {
+		return nil // Already True, no pending write
 	}
 
 	// Start hold timer if not already started
@@ -232,10 +224,19 @@ func (cgm *ConnectivityGateManager) handleGate(ctx context.Context, gate *bool, 
 	// Check if hold time has elapsed
 	if now.Sub(*upSince) >= cgm.holdTime {
 		if err := cgm.patchGateCondition(ctx, conditionType, true); err != nil {
+			*dirty = true
 			return err
 		}
 		*gate = true
+		*dirty = false
 	}
 
 	return nil
+}
+
+func (cgm *ConnectivityGateManager) getDirty(conditionType string) *bool {
+	if conditionType == ReadinessGateIPv4 {
+		return &cgm.ipv4Dirty
+	}
+	return &cgm.ipv6Dirty
 }

--- a/internal/controller/router/connectivity.go
+++ b/internal/controller/router/connectivity.go
@@ -1,0 +1,125 @@
+/*
+Copyright (c) 2026 OpenInfra Foundation Europe. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package router
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	meridio2v1alpha1 "github.com/nordix/meridio-2/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/nordix/meridio-2/internal/bird"
+)
+
+// ConnectivityGateManager manages Pod readiness gate conditions
+type ConnectivityGateManager struct {
+	client       client.Client
+	podName      string
+	podNamespace string
+	podUID       types.UID
+	holdTime     time.Duration
+	// Current gate states (last written to API)
+	ipv4Gate *bool // nil = not declared, true/false = current value
+	ipv6Gate *bool
+}
+
+// NewConnectivityGateManager creates a new instance of ConnectivityGateManager
+func NewConnectivityGateManager(c client.Client, podName, podNamespace string, podUID types.UID, holdTime time.Duration) *ConnectivityGateManager {
+	cgm := &ConnectivityGateManager{
+		client:       c,
+		podName:      podName,
+		podNamespace: podNamespace,
+		podUID:       podUID,
+		holdTime:     holdTime,
+	}
+	return cgm
+}
+
+// DiscoverGates checks the Pod's readiness gates and initializes internal state
+func (cgm *ConnectivityGateManager) DiscoverGates(ctx context.Context) error {
+	pod := &corev1.Pod{}
+	if err := cgm.client.Get(ctx, types.NamespacedName{Name: cgm.podName, Namespace: cgm.podNamespace}, pod); err != nil {
+		if apierrors.IsNotFound(err) {
+			return fmt.Errorf("pod %s/%s not found: %w", cgm.podNamespace, cgm.podName, err)
+		}
+		return fmt.Errorf("error fetching pod %s/%s: %w", cgm.podNamespace, cgm.podName, err)
+	}
+
+	for _, gate := range pod.Spec.ReadinessGates {
+		switch gate.ConditionType {
+		case ReadinessGateIPv4:
+			cgm.ipv4Gate = new(bool) // declared but initial value unknown
+		case ReadinessGateIPv6:
+			cgm.ipv6Gate = new(bool)
+		}
+	}
+	return nil
+}
+
+// HasIPv4Gate returns true if the Pod has the IPv4 connectivity gate declared
+func (cgm *ConnectivityGateManager) HasIPv4Gate() bool {
+	return cgm.ipv4Gate != nil
+}
+
+// HasIPv6Gate returns true if the Pod has the IPv6 connectivity gate declared
+func (cgm *ConnectivityGateManager) HasIPv6Gate() bool {
+	return cgm.ipv6Gate != nil
+}
+
+// classifyConnectivityByFamily determines per-IP-family connectivity from protocol statuses.
+// Returns true for each family if at least one protocol of that family is established.
+// Protocols not in familyMap are ignored.
+func classifyConnectivityByFamily(protocols []bird.ProtocolStatus, familyMap map[string]string) (ipv4Connected, ipv6Connected bool) {
+	for _, p := range protocols {
+		if !p.IsEstablished() {
+			continue
+		}
+		switch familyMap[p.Name] {
+		case "IPv4":
+			ipv4Connected = true
+		case "IPv6":
+			ipv6Connected = true
+		}
+	}
+	return
+}
+
+// buildFamilyMap creates a mapping from protocol names to IP families based on the provided GatewayRouters.
+func buildFamilyMap(gatewayRouters []*meridio2v1alpha1.GatewayRouter) map[string]string {
+	familyMap := make(map[string]string)
+	for _, gr := range gatewayRouters {
+		address := gr.Spec.Address
+		protocol := "IPv4"
+		if strings.Contains(address, ":") {
+			protocol = "IPv6"
+		}
+		protoName := fmt.Sprintf("NBR-%s", gr.Name)
+		familyMap[protoName] = protocol
+	}
+	return familyMap
+}
+
+// TODO
+// - OnStatusUpdate(ipv4Connected, ipv6Connected bool) — called on each monitor tick, handles damping and patches
+// - SetAllGatesFalse(ctx) error — called on startup (defense-in-depth)
+// - patchGateCondition(ctx, conditionType, status) error — patches Pod status

--- a/internal/controller/router/connectivity.go
+++ b/internal/controller/router/connectivity.go
@@ -25,6 +25,7 @@ import (
 	meridio2v1alpha1 "github.com/nordix/meridio-2/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -119,7 +120,42 @@ func buildFamilyMap(gatewayRouters []*meridio2v1alpha1.GatewayRouter) map[string
 	return familyMap
 }
 
+// patchGateCondition(ctx, conditionType, status) error — patches Pod status
+func (cgm *ConnectivityGateManager) patchGateCondition(ctx context.Context, conditionType string, status bool) error {
+	pod := &corev1.Pod{}
+	if err := cgm.client.Get(ctx, types.NamespacedName{Name: cgm.podName, Namespace: cgm.podNamespace}, pod); err != nil {
+		return fmt.Errorf("error fetching pod for patching: %w", err)
+	}
+
+	newStatus := corev1.ConditionFalse
+	if status {
+		newStatus = corev1.ConditionTrue
+	}
+
+	// Find or create the condition
+	found := false
+	for i := range pod.Status.Conditions {
+		if string(pod.Status.Conditions[i].Type) == conditionType {
+			if pod.Status.Conditions[i].Status == newStatus {
+				return nil // No change needed
+			}
+			pod.Status.Conditions[i].Status = newStatus
+			pod.Status.Conditions[i].LastTransitionTime = metav1.Now()
+			found = true
+			break
+		}
+	}
+	if !found {
+		pod.Status.Conditions = append(pod.Status.Conditions, corev1.PodCondition{
+			Type:               corev1.PodConditionType(conditionType),
+			Status:             newStatus,
+			LastTransitionTime: metav1.Now(),
+		})
+	}
+
+	return cgm.client.Status().Update(ctx, pod)
+}
+
 // TODO
 // - OnStatusUpdate(ipv4Connected, ipv6Connected bool) — called on each monitor tick, handles damping and patches
 // - SetAllGatesFalse(ctx) error — called on startup (defense-in-depth)
-// - patchGateCondition(ctx, conditionType, status) error — patches Pod status

--- a/internal/controller/router/connectivity.go
+++ b/internal/controller/router/connectivity.go
@@ -42,6 +42,9 @@ type ConnectivityGateManager struct {
 	// Current gate states (last written to API)
 	ipv4Gate *bool // nil = not declared, true/false = current value
 	ipv6Gate *bool
+	// Damping: timestamp when connectivity first came up (zero = not up)
+	ipv4UpSince time.Time
+	ipv6UpSince time.Time
 }
 
 // NewConnectivityGateManager creates a new instance of ConnectivityGateManager
@@ -69,9 +72,19 @@ func (cgm *ConnectivityGateManager) DiscoverGates(ctx context.Context) error {
 	for _, gate := range pod.Spec.ReadinessGates {
 		switch gate.ConditionType {
 		case ReadinessGateIPv4:
-			cgm.ipv4Gate = new(bool) // declared but initial value unknown
+			cgm.ipv4Gate = new(bool)
+			for _, c := range pod.Status.Conditions {
+				if string(c.Type) == ReadinessGateIPv4 {
+					*cgm.ipv4Gate = c.Status == corev1.ConditionTrue
+				}
+			}
 		case ReadinessGateIPv6:
 			cgm.ipv6Gate = new(bool)
+			for _, c := range pod.Status.Conditions {
+				if string(c.Type) == ReadinessGateIPv6 {
+					*cgm.ipv6Gate = c.Status == corev1.ConditionTrue
+				}
+			}
 		}
 	}
 	return nil
@@ -90,7 +103,7 @@ func (cgm *ConnectivityGateManager) HasIPv6Gate() bool {
 // classifyConnectivityByFamily determines per-IP-family connectivity from protocol statuses.
 // Returns true for each family if at least one protocol of that family is established.
 // Protocols not in familyMap are ignored.
-func classifyConnectivityByFamily(protocols []bird.ProtocolStatus, familyMap map[string]string) (ipv4Connected, ipv6Connected bool) {
+func ClassifyConnectivityByFamily(protocols []bird.ProtocolStatus, familyMap map[string]string) (ipv4Connected, ipv6Connected bool) {
 	for _, p := range protocols {
 		if !p.IsEstablished() {
 			continue
@@ -106,7 +119,7 @@ func classifyConnectivityByFamily(protocols []bird.ProtocolStatus, familyMap map
 }
 
 // buildFamilyMap creates a mapping from protocol names to IP families based on the provided GatewayRouters.
-func buildFamilyMap(gatewayRouters []*meridio2v1alpha1.GatewayRouter) map[string]string {
+func BuildFamilyMap(gatewayRouters []*meridio2v1alpha1.GatewayRouter) map[string]string {
 	familyMap := make(map[string]string)
 	for _, gr := range gatewayRouters {
 		address := gr.Spec.Address
@@ -156,6 +169,67 @@ func (cgm *ConnectivityGateManager) patchGateCondition(ctx context.Context, cond
 	return cgm.client.Status().Update(ctx, pod)
 }
 
-// TODO
-// - OnStatusUpdate(ipv4Connected, ipv6Connected bool) — called on each monitor tick, handles damping and patches
-// - SetAllGatesFalse(ctx) error — called on startup (defense-in-depth)
+// SetAllGatesFalse(ctx) error — called on startup (defense-in-depth)
+func (cgm *ConnectivityGateManager) SetAllGatesFalse(ctx context.Context) error {
+	if cgm.ipv4Gate != nil {
+		if err := cgm.patchGateCondition(ctx, ReadinessGateIPv4, false); err != nil {
+			return fmt.Errorf("error patching IPv4 gate: %w", err)
+		}
+	}
+	if cgm.ipv6Gate != nil {
+		if err := cgm.patchGateCondition(ctx, ReadinessGateIPv6, false); err != nil {
+			return fmt.Errorf("error patching IPv6 gate: %w", err)
+		}
+	}
+	return nil
+}
+
+// OnStatusUpdate handles per-IP-family connectivity changes with damping.
+// Down transitions are immediate. Up transitions require holdTime to elapse
+// with continuous connectivity before the gate is set to True.
+func (cgm *ConnectivityGateManager) OnStatusUpdate(ctx context.Context, ipv4Connected, ipv6Connected bool) error {
+	if err := cgm.handleGate(ctx, cgm.ipv4Gate, ipv4Connected, &cgm.ipv4UpSince, ReadinessGateIPv4); err != nil {
+		return err
+	}
+	return cgm.handleGate(ctx, cgm.ipv6Gate, ipv6Connected, &cgm.ipv6UpSince, ReadinessGateIPv6)
+}
+
+func (cgm *ConnectivityGateManager) handleGate(ctx context.Context, gate *bool, connected bool, upSince *time.Time, conditionType string) error {
+	if gate == nil {
+		return nil // Gate not declared
+	}
+
+	if !connected {
+		// Down: immediate
+		*upSince = time.Time{} // Reset hold timer
+		if *gate {
+			if err := cgm.patchGateCondition(ctx, conditionType, false); err != nil {
+				return err
+			}
+			*gate = false
+		}
+		return nil
+	}
+
+	// Connected
+	if *gate {
+		return nil // Already True, no-op
+	}
+
+	// Start hold timer if not already started
+	now := time.Now()
+	if upSince.IsZero() {
+		*upSince = now
+		return nil // Wait for hold time
+	}
+
+	// Check if hold time has elapsed
+	if now.Sub(*upSince) >= cgm.holdTime {
+		if err := cgm.patchGateCondition(ctx, conditionType, true); err != nil {
+			return err
+		}
+		*gate = true
+	}
+
+	return nil
+}

--- a/internal/controller/router/connectivity.go
+++ b/internal/controller/router/connectivity.go
@@ -214,6 +214,12 @@ func (cgm *ConnectivityGateManager) handleGate(ctx context.Context, gate *bool, 
 		return nil // Already True, no pending write
 	}
 
+	// Note: if gate is True on API but dirty (failed False write), and connectivity
+	// recovers, the hold timer runs but the gate never went False on the API.
+	// This bypasses damping for one cycle. Acceptable: the LB has connectivity
+	// (it recovered), traffic is safe, and the scenario requires both a failed API
+	// write AND immediate recovery within one tick — extremely narrow window.
+
 	// Start hold timer if not already started
 	now := time.Now()
 	if upSince.IsZero() {

--- a/internal/controller/router/connectivity_test.go
+++ b/internal/controller/router/connectivity_test.go
@@ -101,7 +101,7 @@ func TestClassifyConnectivityByFamily(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ipv4, ipv6 := classifyConnectivityByFamily(tt.protocols, tt.familyMap)
+			ipv4, ipv6 := ClassifyConnectivityByFamily(tt.protocols, tt.familyMap)
 			assert.Equal(t, tt.wantIPv4, ipv4, "IPv4 connectivity")
 			assert.Equal(t, tt.wantIPv6, ipv6, "IPv6 connectivity")
 		})
@@ -157,7 +157,7 @@ func TestBuildFamilyMap(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := buildFamilyMap(tt.routers)
+			result := BuildFamilyMap(tt.routers)
 			assert.Equal(t, tt.expected, result)
 		})
 	}
@@ -337,5 +337,309 @@ func TestPatchGateCondition(t *testing.T) {
 				assert.Equal(t, corev1.ConditionTrue, c.Status)
 			}
 		}
+	})
+}
+
+func TestSetAllGatesFalse(t *testing.T) {
+	t.Run("SetsAllDeclaredGatesToFalse", func(t *testing.T) {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default", UID: "uid-1"},
+			Spec: corev1.PodSpec{
+				ReadinessGates: []corev1.PodReadinessGate{
+					{ConditionType: "meridio-2.nordix.org/ipv4-connectivity"},
+					{ConditionType: "meridio-2.nordix.org/ipv6-connectivity"},
+				},
+			},
+		}
+		fakeClient := fake.NewClientBuilder().
+			WithObjects(pod).
+			WithStatusSubresource(pod).
+			Build()
+
+		mgr := NewConnectivityGateManager(fakeClient, "test-pod", "default", "uid-1", 10*time.Second)
+		err := mgr.DiscoverGates(context.Background())
+		assert.NoError(t, err)
+
+		err = mgr.SetAllGatesFalse(context.Background())
+		assert.NoError(t, err)
+
+		// Verify both conditions are False
+		updated := &corev1.Pod{}
+		err = fakeClient.Get(context.Background(), types.NamespacedName{Name: "test-pod", Namespace: "default"}, updated)
+		assert.NoError(t, err)
+
+		for _, condType := range []string{"meridio-2.nordix.org/ipv4-connectivity", "meridio-2.nordix.org/ipv6-connectivity"} {
+			var found bool
+			for _, c := range updated.Status.Conditions {
+				if string(c.Type) == condType {
+					assert.Equal(t, corev1.ConditionFalse, c.Status)
+					found = true
+				}
+			}
+			assert.True(t, found, "condition %s should be set", condType)
+		}
+	})
+
+	t.Run("IPv4Only_SetsOnlyIPv4Gate", func(t *testing.T) {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default", UID: "uid-1"},
+			Spec: corev1.PodSpec{
+				ReadinessGates: []corev1.PodReadinessGate{
+					{ConditionType: "meridio-2.nordix.org/ipv4-connectivity"},
+				},
+			},
+		}
+		fakeClient := fake.NewClientBuilder().
+			WithObjects(pod).
+			WithStatusSubresource(pod).
+			Build()
+
+		mgr := NewConnectivityGateManager(fakeClient, "test-pod", "default", "uid-1", 10*time.Second)
+		err := mgr.DiscoverGates(context.Background())
+		assert.NoError(t, err)
+
+		err = mgr.SetAllGatesFalse(context.Background())
+		assert.NoError(t, err)
+
+		updated := &corev1.Pod{}
+		err = fakeClient.Get(context.Background(), types.NamespacedName{Name: "test-pod", Namespace: "default"}, updated)
+		assert.NoError(t, err)
+		assert.Len(t, updated.Status.Conditions, 1)
+		assert.Equal(t, corev1.PodConditionType("meridio-2.nordix.org/ipv4-connectivity"), updated.Status.Conditions[0].Type)
+		assert.Equal(t, corev1.ConditionFalse, updated.Status.Conditions[0].Status)
+	})
+
+	t.Run("IPv6Only_SetsOnlyIPv6Gate", func(t *testing.T) {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default", UID: "uid-1"},
+			Spec: corev1.PodSpec{
+				ReadinessGates: []corev1.PodReadinessGate{
+					{ConditionType: "meridio-2.nordix.org/ipv6-connectivity"},
+				},
+			},
+		}
+		fakeClient := fake.NewClientBuilder().
+			WithObjects(pod).
+			WithStatusSubresource(pod).
+			Build()
+
+		mgr := NewConnectivityGateManager(fakeClient, "test-pod", "default", "uid-1", 10*time.Second)
+		err := mgr.DiscoverGates(context.Background())
+		assert.NoError(t, err)
+
+		err = mgr.SetAllGatesFalse(context.Background())
+		assert.NoError(t, err)
+
+		updated := &corev1.Pod{}
+		err = fakeClient.Get(context.Background(), types.NamespacedName{Name: "test-pod", Namespace: "default"}, updated)
+		assert.NoError(t, err)
+		assert.Len(t, updated.Status.Conditions, 1)
+		assert.Equal(t, corev1.PodConditionType("meridio-2.nordix.org/ipv6-connectivity"), updated.Status.Conditions[0].Type)
+		assert.Equal(t, corev1.ConditionFalse, updated.Status.Conditions[0].Status)
+	})
+
+	t.Run("NoGatesDeclared_NoOp", func(t *testing.T) {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default", UID: "uid-1"},
+			Spec:       corev1.PodSpec{},
+		}
+		fakeClient := fake.NewClientBuilder().
+			WithObjects(pod).
+			WithStatusSubresource(pod).
+			Build()
+
+		mgr := NewConnectivityGateManager(fakeClient, "test-pod", "default", "uid-1", 10*time.Second)
+		err := mgr.DiscoverGates(context.Background())
+		assert.NoError(t, err)
+
+		err = mgr.SetAllGatesFalse(context.Background())
+		assert.NoError(t, err)
+
+		// No conditions should be set
+		updated := &corev1.Pod{}
+		err = fakeClient.Get(context.Background(), types.NamespacedName{Name: "test-pod", Namespace: "default"}, updated)
+		assert.NoError(t, err)
+		assert.Empty(t, updated.Status.Conditions)
+	})
+}
+
+func TestDamping(t *testing.T) {
+	t.Run("DownTransition_Immediate", func(t *testing.T) {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default", UID: "uid-1"},
+			Spec: corev1.PodSpec{
+				ReadinessGates: []corev1.PodReadinessGate{
+					{ConditionType: "meridio-2.nordix.org/ipv4-connectivity"},
+				},
+			},
+		}
+		fakeClient := fake.NewClientBuilder().
+			WithObjects(pod).
+			WithStatusSubresource(pod).
+			Build()
+
+		mgr := NewConnectivityGateManager(fakeClient, "test-pod", "default", "uid-1", 100*time.Millisecond)
+		_ = mgr.DiscoverGates(context.Background())
+		_ = mgr.SetAllGatesFalse(context.Background())
+
+		// Bring connectivity up: first tick starts timer, wait holdTime, second tick sets True
+		_ = mgr.OnStatusUpdate(context.Background(), true, false)
+		time.Sleep(150 * time.Millisecond)
+		_ = mgr.OnStatusUpdate(context.Background(), true, false)
+
+		// Verify gate is True
+		updated := &corev1.Pod{}
+		_ = fakeClient.Get(context.Background(), types.NamespacedName{Name: "test-pod", Namespace: "default"}, updated)
+		for _, c := range updated.Status.Conditions {
+			if string(c.Type) == ReadinessGateIPv4 {
+				assert.Equal(t, corev1.ConditionTrue, c.Status, "gate should be True before drop")
+			}
+		}
+
+		// Connectivity drops — gate should be False immediately (no 100ms damping applied)
+		err := mgr.OnStatusUpdate(context.Background(), false, false)
+		assert.NoError(t, err)
+
+		_ = fakeClient.Get(context.Background(), types.NamespacedName{Name: "test-pod", Namespace: "default"}, updated)
+		for _, c := range updated.Status.Conditions {
+			if string(c.Type) == ReadinessGateIPv4 {
+				assert.Equal(t, corev1.ConditionFalse, c.Status, "gate should be False immediately on down (no damping)")
+			}
+		}
+	})
+
+	t.Run("UpTransition_Damped", func(t *testing.T) {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default", UID: "uid-1"},
+			Spec: corev1.PodSpec{
+				ReadinessGates: []corev1.PodReadinessGate{
+					{ConditionType: "meridio-2.nordix.org/ipv4-connectivity"},
+				},
+			},
+		}
+		fakeClient := fake.NewClientBuilder().
+			WithObjects(pod).
+			WithStatusSubresource(pod).
+			Build()
+
+		mgr := NewConnectivityGateManager(fakeClient, "test-pod", "default", "uid-1", 100*time.Millisecond)
+		_ = mgr.DiscoverGates(context.Background())
+		_ = mgr.SetAllGatesFalse(context.Background())
+
+		// Connectivity comes up — gate should NOT be True yet (hold time not elapsed)
+		err := mgr.OnStatusUpdate(context.Background(), true, false)
+		assert.NoError(t, err)
+
+		updated := &corev1.Pod{}
+		_ = fakeClient.Get(context.Background(), types.NamespacedName{Name: "test-pod", Namespace: "default"}, updated)
+		for _, c := range updated.Status.Conditions {
+			if string(c.Type) == ReadinessGateIPv4 {
+				assert.Equal(t, corev1.ConditionFalse, c.Status, "gate should still be False during hold time")
+			}
+		}
+
+		// Wait for hold time to elapse
+		time.Sleep(150 * time.Millisecond)
+
+		// Call again — now it should be True
+		err = mgr.OnStatusUpdate(context.Background(), true, false)
+		assert.NoError(t, err)
+
+		_ = fakeClient.Get(context.Background(), types.NamespacedName{Name: "test-pod", Namespace: "default"}, updated)
+		for _, c := range updated.Status.Conditions {
+			if string(c.Type) == ReadinessGateIPv4 {
+				assert.Equal(t, corev1.ConditionTrue, c.Status, "gate should be True after hold time")
+			}
+		}
+	})
+
+	t.Run("UpTransition_FlapDuringHold_ResetsTimer", func(t *testing.T) {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default", UID: "uid-1"},
+			Spec: corev1.PodSpec{
+				ReadinessGates: []corev1.PodReadinessGate{
+					{ConditionType: "meridio-2.nordix.org/ipv4-connectivity"},
+				},
+			},
+		}
+		fakeClient := fake.NewClientBuilder().
+			WithObjects(pod).
+			WithStatusSubresource(pod).
+			Build()
+
+		mgr := NewConnectivityGateManager(fakeClient, "test-pod", "default", "uid-1", 100*time.Millisecond)
+		_ = mgr.DiscoverGates(context.Background())
+		_ = mgr.SetAllGatesFalse(context.Background())
+
+		// Connectivity up
+		_ = mgr.OnStatusUpdate(context.Background(), true, false)
+
+		// Flap down during hold — should reset timer and set False
+		time.Sleep(50 * time.Millisecond)
+		_ = mgr.OnStatusUpdate(context.Background(), false, false)
+
+		// Wait past original hold time
+		time.Sleep(80 * time.Millisecond)
+
+		// Gate should still be False (timer was reset by the flap)
+		updated := &corev1.Pod{}
+		_ = fakeClient.Get(context.Background(), types.NamespacedName{Name: "test-pod", Namespace: "default"}, updated)
+		for _, c := range updated.Status.Conditions {
+			if string(c.Type) == ReadinessGateIPv4 {
+				assert.Equal(t, corev1.ConditionFalse, c.Status, "gate should remain False after flap")
+			}
+		}
+	})
+
+	t.Run("NoChange_NoPatch", func(t *testing.T) {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default", UID: "uid-1"},
+			Spec: corev1.PodSpec{
+				ReadinessGates: []corev1.PodReadinessGate{
+					{ConditionType: "meridio-2.nordix.org/ipv4-connectivity"},
+				},
+			},
+		}
+		fakeClient := fake.NewClientBuilder().
+			WithObjects(pod).
+			WithStatusSubresource(pod).
+			Build()
+
+		mgr := NewConnectivityGateManager(fakeClient, "test-pod", "default", "uid-1", 100*time.Millisecond)
+		_ = mgr.DiscoverGates(context.Background())
+		_ = mgr.SetAllGatesFalse(context.Background())
+
+		// Connectivity still down — no change, should be no-op
+		err := mgr.OnStatusUpdate(context.Background(), false, false)
+		assert.NoError(t, err)
+	})
+
+	t.Run("GateNotDeclared_Ignored", func(t *testing.T) {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default", UID: "uid-1"},
+			Spec: corev1.PodSpec{
+				ReadinessGates: []corev1.PodReadinessGate{
+					{ConditionType: "meridio-2.nordix.org/ipv4-connectivity"},
+				},
+			},
+		}
+		fakeClient := fake.NewClientBuilder().
+			WithObjects(pod).
+			WithStatusSubresource(pod).
+			Build()
+
+		mgr := NewConnectivityGateManager(fakeClient, "test-pod", "default", "uid-1", 100*time.Millisecond)
+		_ = mgr.DiscoverGates(context.Background())
+		_ = mgr.SetAllGatesFalse(context.Background())
+
+		// IPv6 connectivity changes but IPv6 gate not declared — should be ignored
+		err := mgr.OnStatusUpdate(context.Background(), false, true)
+		assert.NoError(t, err)
+
+		// Only IPv4 condition should exist (set to False by SetAllGatesFalse)
+		updated := &corev1.Pod{}
+		_ = fakeClient.Get(context.Background(), types.NamespacedName{Name: "test-pod", Namespace: "default"}, updated)
+		assert.Len(t, updated.Status.Conditions, 1)
+		assert.Equal(t, corev1.PodConditionType(ReadinessGateIPv4), updated.Status.Conditions[0].Type)
 	})
 }

--- a/internal/controller/router/connectivity_test.go
+++ b/internal/controller/router/connectivity_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -233,4 +234,108 @@ func TestDiscoverGates(t *testing.T) {
 			assert.Equal(t, tt.wantIPv6Gate, mgr.HasIPv6Gate())
 		})
 	}
+}
+
+func TestPatchGateCondition(t *testing.T) {
+	t.Run("SetsConditionTrue", func(t *testing.T) {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default", UID: "uid-1"},
+			Spec: corev1.PodSpec{
+				ReadinessGates: []corev1.PodReadinessGate{
+					{ConditionType: "meridio-2.nordix.org/ipv4-connectivity"},
+				},
+			},
+		}
+		fakeClient := fake.NewClientBuilder().
+			WithObjects(pod).
+			WithStatusSubresource(pod).
+			Build()
+
+		mgr := NewConnectivityGateManager(fakeClient, "test-pod", "default", "uid-1", 10*time.Second)
+		err := mgr.patchGateCondition(context.Background(), ReadinessGateIPv4, true)
+		assert.NoError(t, err)
+
+		// Verify condition was set
+		updated := &corev1.Pod{}
+		err = fakeClient.Get(context.Background(), types.NamespacedName{Name: "test-pod", Namespace: "default"}, updated)
+		assert.NoError(t, err)
+
+		var found bool
+		for _, c := range updated.Status.Conditions {
+			if c.Type == corev1.PodConditionType(ReadinessGateIPv4) {
+				assert.Equal(t, corev1.ConditionTrue, c.Status)
+				found = true
+			}
+		}
+		assert.True(t, found, "condition should be set")
+	})
+
+	t.Run("SetsConditionFalse", func(t *testing.T) {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default", UID: "uid-1"},
+			Spec: corev1.PodSpec{
+				ReadinessGates: []corev1.PodReadinessGate{
+					{ConditionType: "meridio-2.nordix.org/ipv6-connectivity"},
+				},
+			},
+		}
+		fakeClient := fake.NewClientBuilder().
+			WithObjects(pod).
+			WithStatusSubresource(pod).
+			Build()
+
+		mgr := NewConnectivityGateManager(fakeClient, "test-pod", "default", "uid-1", 10*time.Second)
+		err := mgr.patchGateCondition(context.Background(), ReadinessGateIPv6, false)
+		assert.NoError(t, err)
+
+		updated := &corev1.Pod{}
+		err = fakeClient.Get(context.Background(), types.NamespacedName{Name: "test-pod", Namespace: "default"}, updated)
+		assert.NoError(t, err)
+
+		var found bool
+		for _, c := range updated.Status.Conditions {
+			if c.Type == corev1.PodConditionType(ReadinessGateIPv6) {
+				assert.Equal(t, corev1.ConditionFalse, c.Status)
+				found = true
+			}
+		}
+		assert.True(t, found, "condition should be set")
+	})
+
+	t.Run("UpdatesExistingCondition", func(t *testing.T) {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default", UID: "uid-1"},
+			Spec: corev1.PodSpec{
+				ReadinessGates: []corev1.PodReadinessGate{
+					{ConditionType: "meridio-2.nordix.org/ipv4-connectivity"},
+				},
+			},
+			Status: corev1.PodStatus{
+				Conditions: []corev1.PodCondition{
+					{
+						Type:   corev1.PodConditionType(ReadinessGateIPv4),
+						Status: corev1.ConditionFalse,
+					},
+				},
+			},
+		}
+		fakeClient := fake.NewClientBuilder().
+			WithObjects(pod).
+			WithStatusSubresource(pod).
+			Build()
+
+		mgr := NewConnectivityGateManager(fakeClient, "test-pod", "default", "uid-1", 10*time.Second)
+		err := mgr.patchGateCondition(context.Background(), ReadinessGateIPv4, true)
+		assert.NoError(t, err)
+
+		updated := &corev1.Pod{}
+		err = fakeClient.Get(context.Background(), types.NamespacedName{Name: "test-pod", Namespace: "default"}, updated)
+		assert.NoError(t, err)
+
+		for _, c := range updated.Status.Conditions {
+			if c.Type == corev1.PodConditionType(ReadinessGateIPv4) {
+				assert.Equal(t, corev1.ConditionTrue, c.Status)
+			}
+		}
+	})
 }

--- a/internal/controller/router/connectivity_test.go
+++ b/internal/controller/router/connectivity_test.go
@@ -1,0 +1,236 @@
+/*
+Copyright (c) 2026 OpenInfra Foundation Europe. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package router
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	meridio2v1alpha1 "github.com/nordix/meridio-2/api/v1alpha1"
+	"github.com/nordix/meridio-2/internal/bird"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestClassifyConnectivityByFamily(t *testing.T) {
+	tests := []struct {
+		name      string
+		protocols []bird.ProtocolStatus
+		familyMap map[string]string // protocolName → "IPv4"/"IPv6"
+		wantIPv4  bool
+		wantIPv6  bool
+	}{
+		{
+			name: "dual-stack both established",
+			protocols: []bird.ProtocolStatus{
+				{Name: "NBR-gw-v4", State: bird.ProtocolStateUp, Info: "Established"},
+				{Name: "NBR-gw-v6", State: bird.ProtocolStateUp, Info: "Established"},
+			},
+			familyMap: map[string]string{"NBR-gw-v4": "IPv4", "NBR-gw-v6": "IPv6"},
+			wantIPv4:  true, wantIPv6: true,
+		},
+		{
+			name: "IPv4 up, IPv6 down",
+			protocols: []bird.ProtocolStatus{
+				{Name: "NBR-gw-v4", State: bird.ProtocolStateUp, Info: "Established"},
+				{Name: "NBR-gw-v6", State: bird.ProtocolStateDown, Info: "Connection closed"},
+			},
+			familyMap: map[string]string{"NBR-gw-v4": "IPv4", "NBR-gw-v6": "IPv6"},
+			wantIPv4:  true, wantIPv6: false,
+		},
+		{
+			name: "IPv6 up, IPv4 down",
+			protocols: []bird.ProtocolStatus{
+				{Name: "NBR-gw-v4", State: bird.ProtocolStateDown, Info: "Connection closed"},
+				{Name: "NBR-gw-v6", State: bird.ProtocolStateUp, Info: "Established"},
+			},
+			familyMap: map[string]string{"NBR-gw-v4": "IPv4", "NBR-gw-v6": "IPv6"},
+			wantIPv4:  false, wantIPv6: true,
+		},
+		{
+			name: "both down",
+			protocols: []bird.ProtocolStatus{
+				{Name: "NBR-gw-v4", State: bird.ProtocolStateDown, Info: "Connection closed"},
+				{Name: "NBR-gw-v6", State: bird.ProtocolStateDown, Info: "Connection closed"},
+			},
+			familyMap: map[string]string{"NBR-gw-v4": "IPv4", "NBR-gw-v6": "IPv6"},
+			wantIPv4:  false, wantIPv6: false,
+		},
+		{
+			name: "unknown protocol ignored",
+			protocols: []bird.ProtocolStatus{
+				{Name: "NBR-unknown", State: bird.ProtocolStateUp, Info: "Established"},
+			},
+			familyMap: map[string]string{},
+			wantIPv4:  false, wantIPv6: false,
+		},
+		{
+			name: "multiple IPv4 peers, one established suffices",
+			protocols: []bird.ProtocolStatus{
+				{Name: "NBR-gw1", State: bird.ProtocolStateDown, Info: "Connection closed"},
+				{Name: "NBR-gw2", State: bird.ProtocolStateUp, Info: "Established"},
+			},
+			familyMap: map[string]string{"NBR-gw1": "IPv4", "NBR-gw2": "IPv4"},
+			wantIPv4:  true, wantIPv6: false,
+		},
+		{
+			name:      "empty protocols",
+			protocols: []bird.ProtocolStatus{},
+			familyMap: map[string]string{},
+			wantIPv4:  false, wantIPv6: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ipv4, ipv6 := classifyConnectivityByFamily(tt.protocols, tt.familyMap)
+			assert.Equal(t, tt.wantIPv4, ipv4, "IPv4 connectivity")
+			assert.Equal(t, tt.wantIPv6, ipv6, "IPv6 connectivity")
+		})
+	}
+}
+
+func TestBuildFamilyMap(t *testing.T) {
+	tests := []struct {
+		name     string
+		routers  []*meridio2v1alpha1.GatewayRouter
+		expected map[string]string
+	}{
+		{
+			name: "IPv4 router",
+			routers: []*meridio2v1alpha1.GatewayRouter{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "gw-v4"},
+					Spec:       meridio2v1alpha1.GatewayRouterSpec{Address: "169.254.100.150"},
+				},
+			},
+			expected: map[string]string{"NBR-gw-v4": "IPv4"},
+		},
+		{
+			name: "IPv6 router",
+			routers: []*meridio2v1alpha1.GatewayRouter{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "gw-v6"},
+					Spec:       meridio2v1alpha1.GatewayRouterSpec{Address: "100:100::150"},
+				},
+			},
+			expected: map[string]string{"NBR-gw-v6": "IPv6"},
+		},
+		{
+			name: "dual-stack two routers",
+			routers: []*meridio2v1alpha1.GatewayRouter{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "gw-v4"},
+					Spec:       meridio2v1alpha1.GatewayRouterSpec{Address: "169.254.100.150"},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "gw-v6"},
+					Spec:       meridio2v1alpha1.GatewayRouterSpec{Address: "100:100::150"},
+				},
+			},
+			expected: map[string]string{"NBR-gw-v4": "IPv4", "NBR-gw-v6": "IPv6"},
+		},
+		{
+			name:     "empty routers",
+			routers:  []*meridio2v1alpha1.GatewayRouter{},
+			expected: map[string]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := buildFamilyMap(tt.routers)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestDiscoverGates(t *testing.T) {
+	tests := []struct {
+		name         string
+		pod          *corev1.Pod
+		wantIPv4Gate bool
+		wantIPv6Gate bool
+	}{
+		{
+			name: "both gates declared",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+				Spec: corev1.PodSpec{
+					ReadinessGates: []corev1.PodReadinessGate{
+						{ConditionType: "meridio-2.nordix.org/ipv4-connectivity"},
+						{ConditionType: "meridio-2.nordix.org/ipv6-connectivity"},
+					},
+				},
+			},
+			wantIPv4Gate: true,
+			wantIPv6Gate: true,
+		},
+		{
+			name: "only IPv4 declared",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+				Spec: corev1.PodSpec{
+					ReadinessGates: []corev1.PodReadinessGate{
+						{ConditionType: "meridio-2.nordix.org/ipv4-connectivity"},
+					},
+				},
+			},
+			wantIPv4Gate: true,
+			wantIPv6Gate: false,
+		},
+		{
+			name: "only IPv6 declared",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+				Spec: corev1.PodSpec{
+					ReadinessGates: []corev1.PodReadinessGate{
+						{ConditionType: "meridio-2.nordix.org/ipv6-connectivity"},
+					},
+				},
+			},
+			wantIPv4Gate: false,
+			wantIPv6Gate: true,
+		},
+		{
+			name: "no gates declared",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+				Spec:       corev1.PodSpec{},
+			},
+			wantIPv4Gate: false,
+			wantIPv6Gate: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeClient := fake.NewClientBuilder().
+				WithObjects(tt.pod).
+				Build()
+
+			mgr := NewConnectivityGateManager(fakeClient, tt.pod.Name, tt.pod.Namespace, tt.pod.UID, 10*time.Second)
+			err := mgr.DiscoverGates(context.Background())
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantIPv4Gate, mgr.HasIPv4Gate())
+			assert.Equal(t, tt.wantIPv6Gate, mgr.HasIPv6Gate())
+		})
+	}
+}

--- a/internal/controller/router/constants.go
+++ b/internal/controller/router/constants.go
@@ -1,0 +1,6 @@
+package router
+
+const (
+	ReadinessGateIPv4 = "meridio-2.nordix.org/ipv4-connectivity"
+	ReadinessGateIPv6 = "meridio-2.nordix.org/ipv6-connectivity"
+)


### PR DESCRIPTION
Implement first steps of gh-122 (Router connectivity status exposure):
- classifyConnectivityByFamily: determines per-IP-family connectivity from BIRD protocol statuses and a protocol-to-family mapping
- buildFamilyMap: maps NBR-<name> protocol names to IP families based on GatewayRouter spec.address
- ConnectivityGateManager with DiscoverGates: reads Pod readinessGates to determine which connectivity gates to manage

Ref: gh-122