### PR TITLE
Fix Maglev ID allocation: shared per-DG per-Gateway

### DIFF
--- a/docs/controllers/distributiongroup.md
+++ b/docs/controllers/distributiongroup.md
@@ -14,7 +14,9 @@ The DistributionGroup controller manages EndpointSlices for secondary network en
 - Subnet CIDR (e.g., `192.168.100.0/24`)
 - Attachment type (`NAD` for Multus, `DRA` for Dynamic Resource Allocation)
 
-**Maglev ID**: A stable integer (0-31 by default) assigned to each Pod for consistent hashing. Stored in EndpointSlice's `zone` field as `maglev:<id>`. Scoped per DistributionGroup and per network context (a Pod may have different IDs in different DGs or networks).
+**Maglev ID**: A stable integer (0-31 by default) assigned to each Pod for consistent hashing. Stored in EndpointSlice's `zone` field as `maglev:<id>`. Scoped per DistributionGroup and per Gateway — the same Pod gets the same ID across all networks (IPv4/IPv6) within a Gateway, but may have different IDs in different DGs.
+
+**Why shared allocation across networks:** The LoadBalancer uses a single NFQLB hash table per DistributionGroup. This hash table maps identifiers to fwmarks, and fwmarks determine routing tables. If different networks assigned different IDs to the same Pod, the single hash table would have conflicting entries — one Pod's route would overwrite another's, causing non-deterministic routing and cross-Pod identifier collisions. Shared allocation ensures each identifier maps to exactly one Pod across all IP families, and the LB creates per-family routes under the same fwmark (IPv4 and IPv6 routing tables are independent in Linux). See [#70](https://github.com/Nordix/Meridio-2/issues/70) for full problem description and [#106](https://github.com/Nordix/Meridio-2/issues/106) for related cross-component contract considerations.
 
 ### Design Principles
 
@@ -42,7 +44,7 @@ Gateway
 └── spec.infrastructure.parametersRef → GatewayConfiguration
 
 GatewayConfiguration
-└── spec.networkSubnets → Network contexts (CIDR + attachment type)
+└── spec.internalSubnets → Network contexts (CIDR + attachment type)
 
 EndpointSlice (owned by DistributionGroup via ownerReference)
 ├── metadata.ownerReferences → DistributionGroup (controller=true)
@@ -93,14 +95,21 @@ Only process Gateways with `Accepted=True` condition set by the Gateway controll
   - Are managed by our controller (not another implementation)
 - Gateways without `Accepted=True` are ignored (no network context extracted, no EndpointSlices created)
 
-### 5. Extract Network Contexts
+### 5. Enforce Single-Gateway Restriction
+If more than one accepted Gateway references the DG (directly or via L34Routes):
+- Set `Ready=False` with reason `MultipleGateways`
+- Skip reconciliation (existing EndpointSlices are preserved/frozen)
+- The operator must resolve the conflict by removing one Gateway's reference
+
+### 6. Extract Network Contexts (per Gateway)
 For each accepted Gateway:
 - Fetch referenced GatewayConfiguration
-- Extract subnet CIDRs and attachment types from `spec.networkSubnets`
+- Extract subnet CIDRs and attachment types from `spec.internalSubnets`
 - Normalize CIDRs to canonical form (e.g., `192.168.1.5/24` → `192.168.1.0/24`)
+- Group results per Gateway (namespaced name) to scope Maglev allocation per Gateway
 
-### 6. Filter Pods by Network
-For each network context:
+### 7. Filter Pods by Network
+For each network context within the Gateway:
 - Scrape secondary IP from Pod based on attachment type:
   - **NAD**: Parse Multus `k8s.v1.cni.cncf.io/network-status` annotation
   - **DRA**: (Future implementation)
@@ -108,20 +117,28 @@ For each network context:
 - Skip Pods without IPs in the target subnet
 - Skip primary interface IPs (only secondary networks)
 
-### 7. Assign Maglev IDs (if Type=Maglev)
-**Per network context (CIDR) within this DistributionGroup:**
-- Extract existing Pod→ID mappings from current EndpointSlices for this network
+### 8. Assign Maglev IDs (if Type=Maglev)
+**Per Gateway, across all network contexts (CIDRs) within this DistributionGroup:**
+- Merge all Pods by UID across the Gateway's networks (a dual-stack Pod is counted once)
+- Extract existing Pod→ID mappings from all current EndpointSlices for this Gateway
 - Preserve existing assignments (stability)
 - Assign new IDs from available pool (0 to `maxEndpoints-1`)
 - Sort new Pods by CreationTimestamp (deterministic assignment)
 - Enforce capacity limit: exclude Pods beyond `maxEndpoints`
+- Distribute the shared IDs to per-network EndpointSlices
+- No gatekeeping: Pods are not required to have IPs in all configured Gateway subnets.
+  A Pod with only an IPv4 address gets an ID and appears in the IPv4 slice but not the IPv6 slice.
 
 **Maglev ID Scoping:**
 
-Maglev IDs are scoped **per DistributionGroup** and **per network context**. A Pod may have different IDs in different scenarios:
+Maglev IDs are scoped **per DistributionGroup** and **per Gateway**. The same Pod gets the same ID across all networks (IPv4/IPv6) within a Gateway:
 
-- **Same Pod, different networks**: Pod-A might be ID `5` in `192.168.1.0/24` (IPv4) and ID `12` in `2001:db8::/64` (IPv6)
-- **Same Pod, different DistributionGroups**: Pod-A might be ID `3` in DG-1 and ID `7` in DG-2 (even for the same network)
+- **Same Pod, same Gateway, different networks**: Pod-A has ID `5` in both `192.168.1.0/24` (IPv4) and `2001:db8::/64` (IPv6) EndpointSlices
+- **Same Pod, different DistributionGroups**: Pod-A might be ID `3` in DG-1 and ID `7` in DG-2
+
+**Immutability enforcement:**
+
+`maxEndpoints` is immutable (enforced via CEL validation). To change capacity, create a new DistributionGroup.
 
 **Why this matters for the LoadBalancer controller:**
 
@@ -135,14 +152,12 @@ The LoadBalancer controller uses **ID offsets per DistributionGroup** to differe
   - Require offset reallocation for all DGs (unless fixed spacing like 1024 is used)
   - Break active connections for this DG and potentially others
 
-**Immutability enforcement:**
-
-`maxEndpoints` is immutable (enforced via CEL validation). To change capacity, create a new DistributionGroup.
-
-### 8. Create EndpointSlices
+### 9. Create EndpointSlices
 **Per network context:**
 - Group endpoints by network (one or more slices per CIDR)
-- Preserve existing slice structure (minimize churn)
+- Preserve existing slice structure (endpoints stay in their original slice when possible)
+- Compact: move endpoints from later slices into earlier slices with free capacity to avoid fragmentation after scale-in
+- Remove empty slices after compaction
 - Split into multiple slices if > 100 endpoints
 - Set labels:
   - `endpointslice.kubernetes.io/managed-by: distributiongroup-controller.meridio-2.nordix.org`
@@ -158,7 +173,7 @@ The LoadBalancer controller uses **ID offsets per DistributionGroup** to differe
 - Matches Kubernetes core EndpointSlice controller behavior
 - Ensures traffic only goes to fully ready Pods
 
-### 9. Reconcile EndpointSlices
+### 10. Reconcile EndpointSlices
 - Create new slices
 - Update existing slices if endpoints/labels changed (semantic equality check)
 - Delete orphaned slices
@@ -183,7 +198,7 @@ The LoadBalancer controller uses **ID offsets per DistributionGroup** to differe
   - Solution: Deploy one controller per namespace (documented constraint)
 - Trade-off: Slightly higher memory usage vs operational simplicity
 
-### 10. Update DistributionGroup Status
+### 11. Update DistributionGroup Status
 **Ready condition:**
 - `True` if EndpointSlices exist
 - `False` if no endpoints available, with specific reason:
@@ -192,6 +207,7 @@ The LoadBalancer controller uses **ID offsets per DistributionGroup** to differe
   - "No accepted Gateways found (Gateways may not exist or lack Accepted=True status condition)"
   - "No network context available..."
   - "No endpoints available" (default - Pods have no secondary IPs)
+  - "DistributionGroup is referenced by multiple Gateways..." (reason: `MultipleGateways`)
 
 **CapacityExceeded condition (Maglev only):**
 - `True` if Pods were excluded due to capacity limits
@@ -226,8 +242,9 @@ The controller reconciles when:
 # User adds IPv6 network to existing config
 GatewayConfiguration:
   spec:
-    networkSubnets:
-    - cidrs: ["192.168.1.0/24", "2001:db8::/64"]  # IPv6 added
+    internalSubnets:
+    - cidr: "192.168.1.0/24"
+    - cidr: "2001:db8::/64"  # IPv6 added
 ```
 
 **Without GatewayConfiguration watch:**
@@ -248,7 +265,7 @@ GatewayConfiguration:
 # User breaks config
 GatewayConfiguration:
   spec:
-    networkSubnets: []  # Empty - invalid!
+    internalSubnets: []  # Empty - invalid!
 ```
 
 **Race condition:**
@@ -271,8 +288,8 @@ GatewayConfiguration:
 # User fixes config
 GatewayConfiguration:
   spec:
-    networkSubnets:
-    - cidrs: ["192.168.1.0/24"]  # Fixed!
+    internalSubnets:
+    - cidr: "192.168.1.0/24"  # Fixed!
 ```
 
 **Race condition:**
@@ -440,11 +457,9 @@ metadata:
   namespace: meridio-2
 spec:
   networkAttachments: []
-  networkSubnets:
-    - attachmentType: NAD
-      cidrs:
-        - "192.168.100.0/24"
-        - "2001:db8:100::/64"
+  internalSubnets:
+    - cidr: "192.168.100.0/24"
+    - cidr: "2001:db8:100::/64"
   horizontalScaling:
     replicas: 1
     enforceReplicas: false
@@ -462,9 +477,9 @@ spec:
       kind: GatewayConfiguration
       name: test-gwconfig
   listeners:
-    - name: default
-      protocol: TCP
-      port: 80
+    - name: all
+      protocol: ALL
+      port: 0
 ---
 apiVersion: meridio-2.nordix.org/v1alpha1
 kind: DistributionGroup
@@ -506,7 +521,7 @@ spec:
 EOF
 ```
 
-Mark Gateway as accepted (simulates Gateway controller):
+Mark Gateway as accepted (only needed when testing DG controller standalone, without the Gateway controller running):
 
 ```bash
 kubectl patch gateway test-gateway -n meridio-2 --type=merge --subresource=status --patch '

--- a/docs/design/maglev-id-shared-allocation.md
+++ b/docs/design/maglev-id-shared-allocation.md
@@ -1,0 +1,994 @@
+# Study: Maglev ID Allocation and Dual-Stack Support
+
+**Issue:** [#70 — Maglev ID allocation must be shared within a DistributionGroup](https://github.com/Nordix/Meridio-2/issues/70)
+
+---
+
+## Problem Statement
+
+*This section describes the original problem that motivated this study.*
+
+The DistributionGroup (DG) controller assigned Maglev IDs independently per network/CIDR.
+Each call to `assignMaglevIDs()` operated on a per-CIDR subset of Pods, meaning the same
+Pod could receive different Maglev IDs in the IPv4 and IPv6 EndpointSlices for the same DG.
+Furthermore, different Pods could be assigned the same Maglev ID in different EndpointSlices.
+
+The LoadBalancer (LB) controller creates a single NFQLB shared-memory hash table per DG.
+When it iterated EndpointSlices, it built a target map keyed by identifier
+(`newTargets[identifier] = endpoint.Addresses`). Since this was a plain map assignment,
+the last-processed slice overwrote the previous entry. This caused:
+
+- **Non-deterministic routing**: Race of EndpointSlice updates; order of items after
+  list operation was undefined.
+- **Cross-Pod identifier collision**: Pod-A got `maglev:3` in IPv4, Pod-B got `maglev:3`
+  in IPv6 — one overwrote the other.
+- **Broken target removal**: Deactivating an identifier removed it for all IP families.
+
+Creating multiple NFQLB hash tables per DG (e.g., one per IP family) is not viable. NFQLB
+uses user-defined selectors and priorities to steer packets to hash tables, and these
+selectors correspond to DG-level traffic classification criteria visible to external packets.
+Splitting a DG into sub-tables would require fine-grained selector criteria based on
+cluster-internal details (IP family, network attachment) that are not meaningful at the
+external traffic classification level.
+
+---
+
+## Prior Art
+
+### Meridio v1
+
+The NSP server handled identifier allocation centrally. A Pod registered with all its IPs
+(IPv4 + IPv6) under a single identifier. The LB learned the target from NSP and created
+fwmark routes for each IP under the same fwmark/routing table. IPv4 and IPv6 routing tables
+are independent in the Linux kernel, so this works without conflict.
+
+The NSP used a keepalive mechanism: Pods periodically re-registered (default refresh cycle
+~1s, timeout 60s configurable via `NSP_ENTRY_TIMEOUT`). If a Pod stopped refreshing (e.g.,
+node failure), NSP removed the target after the timeout. This provided faster failure
+detection (~60s) compared to Kubernetes Pod eviction (~5m40s with default tolerations).
+
+Key design principle: IP connectivity was a prerequisite for identifier allocation, and one
+identifier covered all IP families for a given Pod.
+
+### Meridio 2.x POC
+
+The POC followed the same principle as v1: it built separate IPv4 and IPv6 EndpointSlices,
+merged them by Pod UID into a single view (`MergeEndpointSlices`), assigned identifiers once
+on the merged set, then split back into per-family slices (`SplitEndpointSlices`) preserving
+the shared identifiers.
+
+---
+
+## Design Dimensions
+
+The following aspects influence the design space for Maglev ID allocation. Each option
+in this document makes different trade-offs across these dimensions.
+
+### DG-to-Gateway cardinality
+
+Can a DistributionGroup be linked to multiple Gateways?
+
+- **Single Gateway per DG** (current `parentRefs maxItems=1`): Simplifies everything —
+  no Gateway context needed on EndpointSlices, no cross-Gateway coordination.
+- **Multiple Gateways per DG**: Requires encoding Gateway context on EndpointSlices (or
+  in DG status), and handling shared vs exclusive EndpointSlice organization. Users can
+  achieve the same effect with multiple DGs using the same label selector.
+- **Indirect multi-Gateway**: Even with `parentRefs maxItems=1`, a DG can indirectly serve
+  multiple Gateways if multiple L34Routes from different Gateways reference it as a
+  backendRef. This must be detected and handled.
+
+### Maglev ID scoping
+
+At what level are Maglev IDs assigned? This is related to but independent of DG-to-Gateway
+cardinality and EndpointSlice organization — cardinality determines the relationship model,
+slice organization determines how data is structured, and ID scoping determines where IDs
+are unique.
+
+- **Per DG, per network**: Independent allocation per CIDR. Same Pod can get different IDs
+  across IP families. This was the initial implementation, which was broken due to the
+  NFQLB architecture (single hash table per DG cannot handle different IDs for the same
+  Pod across IP families).
+- **Per DG**: One ID per Pod UID across all networks within a DG. Requires merging Pod
+  lists across CIDRs before assignment. If the DG serves multiple Gateways, all Gateways
+  share the same ID assignments.
+- **Per DG, per Gateway**: Each Gateway gets its own independent ID space for the same DG.
+  Different Gateways can assign different IDs to the same Pod. Only relevant if
+  multi-Gateway DGs are to be supported.
+
+### Namespace scoping
+
+Can DGs and Gateways reside in different namespaces?
+
+- **Same namespace** (current LB implementation): LB cache scoped to `GatewayNamespace`.
+  DGs, L34Routes, EndpointSlices, and Gateway all in the same namespace.
+- **Cross-namespace**: DG in namespace B, Gateway in namespace A. OwnerReferences cannot
+  cross namespace boundaries (Kubernetes constraint). Labels, DG status-based discovery,
+  or a custom resource with explicit `gatewayRef` field could address this.
+- **Cluster-wide controller-manager**: The controller process can manage objects across
+  all namespaces (just API calls). The namespace constraint is on ownerReference
+  relationships and LB cache scoping, not on the controller process itself.
+
+### EndpointSlice organization
+
+How are EndpointSlices structured and associated with Gateways? This is independent of
+Maglev ID scoping — the same ID scoping can be implemented with different slice
+organizations.
+
+- **Per network only** (current): One set of slices per CIDR, no Gateway dimension.
+- **Per Gateway, per network** (exclusive): Separate slices per (DG, Gateway) pair, even
+  if Gateways share the same network. Duplicate data but simple and independent.
+- **Shared across Gateways**: Single slice serves multiple Gateways when they share a
+  network. Fewer objects but requires multi-Gateway association metadata on slices.
+
+### LB discovery mechanism
+
+How does the LB find the EndpointSlices relevant to its Gateway?
+
+- **Label-based** (current): Filter by `distribution-group` label.
+- **Gateway labels on EndpointSlices**: Fixed or dynamic label keys encoding Gateway
+  name/namespace. Subject to label length limits and multi-value challenges.
+- **Gateway ownerReferences**: Limited to same-namespace. GC semantics complicate dual
+  ownership.
+- **DG status index**: DG status lists EndpointSlices and their Gateway associations.
+  Extensible, cross-namespace capable, supports gradual migration.
+
+### Endpoint representation format
+
+What object type carries endpoint data?
+
+- **Kubernetes EndpointSlice** (current): Core type, fixed schema. Single `addressType`
+  per slice forces separate IPv4/IPv6 slices. `Zone` field abused for Maglev IDs.
+- **Custom resource**: Purpose-built schema with dual-stack addresses, explicit Maglev ID
+  field, native Gateway references.
+
+### Network degradation policy
+
+What happens when a Pod's network state degrades? See "Network Degradation and Activation
+Policy" section for full analysis.
+
+- **Gatekeeper for new Pods**: Only add Pods with all expected IPs.
+- **Existing Pod degradation**: DG keeps Pod in remaining slices (truthful mirror); LB
+  decides activation policy (deactivate entirely or keep working family).
+
+### Upgrade and backward compatibility
+
+How do schema changes propagate across independently deployed components? See Appendix
+for full analysis.
+
+- Cannot simultaneously have arbitrary rollback, zero consumer code debt, and independent
+  deployment ordering.
+
+---
+
+## Chosen Direction
+
+Restrict each DG to a single Gateway. Merge all network contexts (IPv4/IPv6) within the DG
+before Maglev ID assignment, producing one ID per Pod UID. The LB accumulates IPs per
+identifier across EndpointSlices.
+
+Proposed complementary mechanisms (explored in later sections, not necessarily implemented):
+- DG gatekeeper: only add new Pods when they have all expected IPs
+- LB activation policy: skip incomplete new targets, deactivate degraded existing targets
+- NetworkConsistency condition: alert operators to partial network presence
+
+**Pros:**
+- Simplest model — no Gateway dimension on EndpointSlices
+- No Gateway label or ownerReference needed; all EndpointSlices owned by a DG serve its
+  single Gateway
+- EndpointSlice naming unchanged: `<dg>-<hashCIDR>-<index>`
+- Maglev IDs are just per-DG
+- Future-proof for cross-namespace: if the LB is extended to watch other namespaces, it
+  finds the DG and all its EndpointSlices are unambiguously for its Gateway. No label
+  disambiguation needed.
+- The `parentRefs` field already has `maxItems: 1` in the CRD
+- Users who need the same Pods behind multiple Gateways create multiple DGs with the same
+  selector — trivial, explicit, no hidden coupling
+
+**Indirect multi-Gateway detection:**
+
+A DG can indirectly serve multiple Gateways if multiple L34Routes from different Gateways
+reference the same DG as a backendRef (the `parentRefs maxItems=1` only restricts the direct
+reference). The DG controller handles this by:
+
+1. Resolving all Gateways for the DG (direct parentRef + indirect via L34Routes)
+2. If more than one Gateway is found: set `Ready=False, Reason=MultipleGatewaysDetected,
+   Message="DistributionGroup is referenced by multiple Gateways; only a single Gateway
+   is supported"` and skip reconciliation. Existing EndpointSlices are preserved (no
+   teardown — avoids disrupting traffic if the conflict is transient or accidental).
+3. If exactly one Gateway: proceed normally
+4. If zero Gateways: existing behavior (no EndpointSlices, status reflects no referenced
+   Gateways)
+
+**Trade-off — asymmetric network presence:**
+
+With shared allocation, a Pod that has IPs in only a subset of the DG's networks still
+consumes an ID slot globally. For example, if Pod-A has only an IPv4 address and gets
+`maglev:5`, that ID is reserved across all networks — no other Pod can use `maglev:5` in
+the IPv6 EndpointSlice. Pod-A simply won't appear in the IPv6 slice.
+
+In the NFQLB hash table, `maglev:5` is still a valid entry. When an IPv6 packet hashes to
+a bucket pointing to identifier 5, the LB sets the corresponding fwmark, but no IPv6 route
+exists in that routing table. The packet gets dropped — a localized blackhole for that hash
+bucket in IPv6.
+
+Severity depends on the degree of asymmetry:
+- **All Pods dual-stack** (expected case): No impact. Every identifier has routes for both
+  families.
+- **One Pod missing IPv6 out of 32**: ~3% of IPv6 hash buckets blackhole. Maglev distributes
+  buckets roughly evenly, so the impact is proportional to the fraction of Pods missing from
+  that family.
+- **Disjoint sets** (e.g., 16 IPv4-only + 16 IPv6-only): ~50% blackholing in each family.
+  Severe misconfiguration.
+
+This is an inherent trade-off of a single hash table serving multiple IP families. In
+practice, Pods selected by a DG should have identical network attachments (same Deployment
+template, same NAD annotations), making asymmetry an operator misconfiguration. The DG
+controller could detect this and surface a status condition warning (e.g.,
+`NetworkConsistency=False`) when Pod sets diverge across networks (see [#141](https://github.com/Nordix/Meridio-2/issues/141)).
+
+**Verdict:** Chosen direction. Minimal complexity, solves the dual-stack problem,
+future-proof for cross-namespace.
+
+---
+
+## Alternatives Considered
+
+### Option A: Per-IP-family NFQLB hash tables
+
+Split each DG into an IPv4 and IPv6 NFQLB instance, with L34Route flows split per IP version.
+
+**Pros:**
+- No change to DG controller's per-CIDR allocation model
+- Each hash table is internally consistent
+- Natively supports DG-to-multi-Gateway linkage — EndpointSlices are scoped per network
+  only, with no Gateway context needed. The LB splits them by IP family internally.
+
+**Problems:**
+- Doubles the number of NFQLB hash tables and associated flows
+- Per-packet overhead in nfqlb's matching path (more selectors to evaluate per packet).
+  The whole point of Maglev is one hash decision per packet; doubling tables adds runtime
+  cost for every packet rather than a one-time configuration cost.
+- NFQLB uses user-defined selectors and priorities tied to DG-level traffic classification.
+  Splitting a DG into sub-tables would require fine-grained selector criteria based on
+  cluster-internal details (IP family) that are not meaningful at the external traffic
+  classification level.
+- L34Routes can match both IPv4 and IPv6 packets while referencing a single DG — splitting
+  would require duplicating or rewriting route logic on the nfqlb level.
+
+**Verdict:** Not desirable. Adds per-packet runtime overhead instead of one-time
+configuration overhead.
+
+### Option B: Encoding Gateway context on EndpointSlices
+
+B1 and B2 encode Gateway context directly on EndpointSlices (via labels or ownerRefs),
+differing in whether slices are exclusive to a Gateway or shared across multiple Gateways.
+
+#### B1: Exclusive per-Gateway EndpointSlices
+
+Each EndpointSlice belongs to exactly one Gateway. The DG controller maintains separate
+EndpointSlices per (DG, Gateway) pair, even if two Gateways share the same internal network.
+
+**Gateway association:** Two fixed-key labels on each EndpointSlice:
+- `meridio-2.nordix.org/gateway-name: <name>`
+- `meridio-2.nordix.org/gateway-namespace: <namespace>`
+
+No multi-value problem since each slice serves exactly one Gateway. LBs filter by both
+labels to find their slices.
+
+Alternatively, ownerReferences can encode the Gateway relationship (see common issues
+below), with the same namespace constraint.
+
+**Pros:**
+- Natively supports DG-to-multi-Gateway setup — each Gateway gets its own set of slices
+  with independent Maglev IDs
+- Supports DG and Gateway in different namespaces without label length limitations — two
+  fixed-key labels with namespace and name as values (label values allow up to 63
+  characters each, no need to encode both into a single key)
+- Simple labeling — fixed keys, no dynamic label names
+- ID allocation naturally scoped per Gateway
+- No cross-Gateway coordination needed
+- Adding/removing a Gateway from a DG doesn't reshuffle IDs for other Gateways
+
+**Cons:**
+- Duplicate EndpointSlices when Gateways share internal networks (same Pod IPs, same
+  network, but separate slices with potentially different Maglev IDs per Gateway)
+- More objects to manage (proportional to number of Gateways per DG)
+- EndpointSlice naming must ensure uniqueness across Gateways, e.g.,
+  `<dg>-<gw>-<hashCIDR>-<index>` or an alternative convention that prevents collisions
+  (see general naming consideration below)
+
+#### B2: Shared EndpointSlices with multi-Gateway association
+
+A single EndpointSlice can serve multiple Gateways when they share the same internal
+network. The slice carries association metadata indicating which Gateways it belongs to.
+
+**Gateway association — labeling challenges:**
+
+Labels are flat key-value pairs. Encoding a one-to-many relationship (EndpointSlice →
+multiple Gateways) doesn't map cleanly:
+
+- A single label key `meridio-2.nordix.org/gateway: <name>` can only hold one value, so
+  it cannot represent multiple Gateways on a shared EndpointSlice
+- Dynamic label keys like `meridio-2.nordix.org/gateway-<namespace>-<name>: ""` work for
+  multiple Gateways (one label per Gateway) but are unusual, length-limited (63 chars
+  after prefix), and harder to query
+- Cross-namespace Gateways compound the problem — the label key must encode both namespace
+  and name
+
+**Pros:**
+- Fewer EndpointSlice objects when Gateways share internal networks
+- Single source of truth for endpoint data per network
+
+**Cons:**
+- Complex labeling for multi-Gateway association
+- Sharing an EndpointSlice across Gateways forces Maglev ID allocation to cross Gateway
+  boundaries: if any internal network is shared between two Gateways, the shared slice
+  must use the same IDs for both, which means ID allocation can no longer be independent
+  per Gateway. This applies regardless of IP family mode (IPv4-only, IPv6-only, or
+  dual-stack). In dual-stack mode, if only one family's network is shared while the other
+  is separate, the constraint is amplified — the shared family's IDs dictate allocation
+  for the non-shared family too (the LB expects one ID per Pod across all families),
+  pulling more networks into the cross-Gateway coordination scope.
+- Updating a shared slice affects all Gateways using it — larger blast radius
+- Dynamic label keys are harder to query and validate
+
+#### Common issues for B1 and B2
+
+**OwnerReference approach (alternative to labels):**
+
+Adding the Gateway as a second owner on EndpointSlices was considered but has fundamental
+problems:
+- GC requires all owners to be gone before deleting dependents — DG deletion alone won't
+  clean up EndpointSlices if Gateway still exists
+- Kubernetes requires ownerReferences to point to objects in the same namespace — cross-
+  namespace Gateway-to-DG linking is impossible via ownerReferences
+- LBs still need DG context first, so ownerReference is an additional filter, not a
+  replacement for the DG-first discovery flow
+
+**Upgrade and backward compatibility:**
+
+Introducing Gateway markings on EndpointSlices (labels or ownerRefs) creates upgrade
+challenges: old and new LBs coexist during rollout, and must handle both marked and
+unmarked slices. Three mitigations were considered:
+- *Fallback*: New LBs fall back to old behavior if markings absent. Fragile for multi-
+  Gateway scenarios where old format is ambiguous.
+- *Versioning*: Version label on slices tells LBs which semantics to apply. Risk limited
+  to upgrade window.
+- *CM-migrates-first*: CM augments existing slices with new markings before LB rollout.
+  Requires cleanup step; rollout ordering cannot be controlled.
+
+All three accumulate backward-compatibility debt over time. See Appendix for the general
+schema evolution framework and fundamental trade-off.
+
+#### Option B verdict
+
+B1 and B2 add complexity for multi-Gateway DG support. B1 (exclusive per-Gateway slices)
+is simpler than B2 (shared slices), which forces cross-Gateway Maglev ID coordination when
+any internal network is shared. Both require Gateway association metadata directly on
+EndpointSlices and face upgrade challenges when introducing or changing the marking scheme.
+
+Multi-Gateway DG support has limited practical benefit: users who need the same Pods behind
+multiple Gateways can create separate DGs (one per Gateway) with the same `spec.selector`,
+achieving the same effect without any of the complexity above. This is why the
+single-Gateway restriction was selected for the current implementation.
+
+### Option C: DG status-based discovery
+
+An alternative to encoding Gateway context on EndpointSlices (Option B). Instead of
+marking EndpointSlices with labels or ownerReferences, the DG's `status` field serves as
+a discovery index, listing which EndpointSlices exist and which Gateways they serve.
+Option C supports both exclusive and shared EndpointSlice organization internally — the
+DG controller can change its strategy without affecting how LBs discover slices.
+
+The DG controller maintains this index as part of its normal status updates.
+
+**Example:**
+```yaml
+status:
+  endpointSlices:
+    - name: dg-1-abc123-0
+      gateways:
+        - name: gw-a
+          namespace: ns-1
+    - name: dg-1-def456-0
+      gateways:
+        - name: gw-a
+          namespace: ns-1
+        - name: gw-b
+          namespace: ns-2
+```
+
+The LB would: get DG → read `status.endpointSlices` → filter entries by its own Gateway
+→ fetch those specific EndpointSlices by name.
+
+**Pros:**
+- No labels or ownerReferences needed for Gateway association on EndpointSlices
+- DG status is a custom resource — full schema control, no Kubernetes API constraints
+- Supports multi-Gateway and cross-namespace natively (status can reference Gateways in
+  any namespace — no ownerReference same-namespace constraint)
+- No label key length limits or dynamic key conventions
+- Agnostic to EndpointSlice organization — natively supports both exclusive (one Gateway
+  per entry) and shared (multiple Gateways per entry) approaches. The DG controller can
+  change its internal strategy without affecting how LBs discover slices. The status is
+  the stable contract.
+- No GC interference (status is data, not an ownership relationship)
+- LB discovery is a direct lookup by name (no list+filter on EndpointSlices)
+- Dynamic expansion supported naturally — adding/removing Gateways, EndpointSlice splits
+  due to capacity, network changes all handled through the normal reconcile cycle. The
+  status is rebuilt from actual state each reconcile.
+- Extensible — the DG status can be extended with new fields (e.g., schema version,
+  Maglev ID extraction hints, per-slice metadata) without changing EndpointSlice format.
+  New fields don't break old consumers (they ignore unknown fields), and new consumers
+  can fall back when fields are absent. This makes Option C the most upgrade-resilient
+  discovery mechanism.
+- Can serve as a universal discovery layer across different endpoint representations. By
+  including a `kind` and `apiGroup` per entry, the DG status can direct LBs to fetch
+  EndpointSlices, a future custom resource (see Option D), or a mix of both. This
+  decouples the LB from the underlying endpoint representation entirely. See
+  "Combining Option C with Option D" below for details on how this enables gradual
+  migration.
+
+**Cons:**
+- Unconventional pattern — using status as a discovery index rather than purely
+  informational reporting. Not prohibited, but unusual. No known Kubernetes project uses
+  status as a lookup table for owned resources; the standard pattern is labels +
+  ownerReferences. There may be undocumented reasons why this pattern hasn't been adopted
+  in the ecosystem.
+- DG controller must keep status in sync with actual EndpointSlices — another thing to
+  reconcile (though the DG controller already maintains status)
+- Transient staleness: the DG controller updates EndpointSlices and status in separate
+  API calls, so there's a brief window where the status references an EndpointSlice that
+  doesn't exist yet (or still references a deleted one). LBs must handle NotFound
+  gracefully. Self-healing on next DG reconcile.
+- Status update frequency increases with the number of EndpointSlices and Gateways —
+  every EndpointSlice change triggers a status update on the DG, increasing conflict
+  probability and API server load. Practically manageable (status entries are small,
+  ~200 bytes each), but a consideration at scale.
+- Reduced motivation with a custom resource (Option D): Option C's primary value is for
+  the EndpointSlice world where custom fields cannot be added. With a custom resource,
+  `gatewayRef` and `distributionGroup` fields can be added directly to the resource and
+  queried via field selectors — making the DG status index unnecessary for discovery.
+  Option C retains value only for gradual migration scenarios (see Combining Option C
+  with Option D).
+
+**Verdict:** Option C avoids the labeling and ownerReference challenges of B1/B2 by moving
+Gateway association to the DG status. It is a discovery mechanism rather than an
+EndpointSlice organization strategy — it can be combined with either exclusive slices
+(B1-style) or shared slices (B2-style). However, shared slices retain the cross-Gateway
+Maglev ID coordination problem regardless of how discovery works, making Option C combined
+with exclusive slices the natural combination. Option C is the most extensible and
+upgrade-resilient discovery mechanism, but introduces an unconventional pattern (status as
+discovery index) and adds status update overhead.
+
+### Option D: Custom EndpointSlice replacement
+
+Replace Kubernetes EndpointSlices with a dedicated Meridio-2 custom resource designed for
+the specific requirements of the system.
+
+**Motivation:** Many of the challenges in the selected approach and Options A and B stem
+from EndpointSlice being a Kubernetes core type with a fixed schema. The `addressType`
+field forces separate slices per IP family. The `Zone` field is abused to carry Maglev IDs.
+There is no Gateway association field. Labels and ownerReferences are the only extensibility
+mechanisms, each with limitations. A purpose-built resource eliminates these constraints.
+
+**Example schema:**
+```yaml
+apiVersion: meridio-2.nordix.org/v1alpha1
+kind: LoadBalancerEndpointSlice
+metadata:
+  name: dg-1-abc123-0
+  namespace: default
+  ownerReferences:
+    - apiVersion: meridio-2.nordix.org/v1alpha1
+      kind: DistributionGroup
+      name: dg-1
+      controller: true
+spec:
+  distributionGroup: dg-1
+  gatewayRefs:                    # cross-namespace, following Gateway API conventions, native multi-Gateway support
+    - name: gw-a
+      namespace: ns-1
+    - name: gw-b
+      namespace: ns-2
+  endpoints:
+    - podRef:
+        name: app-pod-1
+        uid: abc-123
+      addresses:
+        - ip: "192.168.1.10"
+          family: IPv4
+        - ip: "2001:db8::10"
+          family: IPv6
+      maglevID: 5                 # optional, explicit field
+      ready: true
+    - podRef:
+        name: app-pod-2
+        uid: def-456
+      addresses:
+        - ip: "192.168.1.11"
+          family: IPv4
+        - ip: "2001:db8::11"
+          family: IPv6
+      maglevID: 12
+      ready: true
+```
+
+**Pros:**
+- **Dual-stack in a single object**: Both IPv4 and IPv6 addresses per endpoint (as a list
+  with explicit family field), eliminating the split-slice race condition entirely. No
+  inter-API-call window for the LB to worry about.
+- **Explicit Maglev ID field**: No Zone field abuse. The field is optional, supporting
+  future distribution types that don't use Maglev.
+- **Native Gateway references**: `gatewayRefs` with namespace support, following Gateway
+  API conventions. Supports multi-Gateway DGs and cross-namespace linking without labels
+  or ownerReference hacks.
+- **Full schema control**: Can be extended with new fields (network context metadata,
+  per-endpoint hints) without Kubernetes API constraints. Additive field changes are the
+  standard CRD evolution approach.
+- **Capacity splitting supported**: Multiple objects per DG when endpoint count exceeds a
+  single object's practical capacity (etcd size limits, watch event size). The "Slice"
+  naming convention signals this. A Pod's dual-stack addresses always reside in the same
+  object — splitting is by endpoint count, not by IP family.
+- **Cleaner LB consumption**: LB reads one object type with all information needed —
+  addresses, IDs, readiness. No multi-slice correlation for IP families, no Zone parsing.
+- **Field-selector-based discovery**: The `spec.distributionGroup` field can be indexed
+  for server-side filtering, avoiding the 63-character label value limit that constrains
+  label-based discovery. Works with arbitrary-length DG names.
+
+**Cons:**
+- **New CRD to maintain**: Additional API surface, documentation, validation, versioning.
+- **No ecosystem tooling**: Kubernetes tooling (kubectl, dashboards) understands
+  EndpointSlices natively. A custom resource requires custom tooling or printer columns
+  for visibility.
+- **Migration from EndpointSlices**: If introduced after the initial release, requires the
+  same upgrade challenges as any schema change (see upgrade discussion above). Best
+  introduced early.
+- **LB controller changes**: Must be rewritten to consume the new type instead of
+  EndpointSlices. The DG controller must produce the new type instead of EndpointSlices.
+- **Consumer impact**: Any current or future component that reads endpoint data would need
+  to understand the new type. However, the per-consumer-type architecture (see
+  `meridio2-endpoint-producer-consumer-architecture.md`) addresses this by design — each
+  consumer class gets a tailored resource, so the `LoadBalancerEndpointSlice` is the LB's
+  dedicated contract, not a generic endpoint store that all consumers must parse.
+
+**Verdict:** The cleanest long-term solution. Eliminates the root cause of most problems
+discussed in this document (split slices, Zone abuse, Gateway association). The cost is a
+new CRD and migration effort. Best introduced early before EndpointSlice usage is deeply
+entrenched. Can be combined with Option C (DG status index) for Gateway discovery, gradual
+migration between endpoint representations, and as a universal discovery layer that
+decouples LBs from the underlying endpoint format (see Combining Option C with Option D below).
+
+#### Combining Option C with Option D: Gradual migration
+
+*Note: This section is relevant only if Option D is introduced after EndpointSlices are
+already in production use. If Option D is adopted from the start (the recommended path),
+no migration is needed and this section is purely informational.*
+
+Option C's status-based discovery can serve as the bridge between EndpointSlices and a custom
+resource, enabling gradual migration without a hard cutover. The DG status index would
+include type information per entry, allowing the DG controller to maintain both old and
+new representations simultaneously during the transition:
+
+```yaml
+status:
+  endpointGroups:
+    - preferred:                          # new format, used by upgraded LBs
+        name: dg-1-abc123-0
+        kind: LoadBalancerEndpointSlice
+        apiGroup: meridio-2.nordix.org
+      legacy:                             # old format, kept for non-upgraded LBs
+        - name: dg-1-ipv4-0
+          kind: EndpointSlice
+          apiGroup: discovery.k8s.io
+        - name: dg-1-ipv6-0
+          kind: EndpointSlice
+          apiGroup: discovery.k8s.io
+      gateways:
+        - name: gw-a
+          namespace: ns-1
+```
+
+**Migration flow:**
+
+The mechanism works regardless of upgrade ordering (CM first or LBs first):
+- New CM produces both formats (custom resource + EndpointSlices) and populates the status
+  with `preferred`/`legacy` entries linking them.
+- Old LBs continue using label-based EndpointSlice discovery (unaffected by status changes).
+- New LBs read the DG status: use `preferred` if present, fall back to label-based
+  EndpointSlice discovery if not.
+- Post-upgrade cleanup: CM stops producing `legacy` entries and deletes old EndpointSlices.
+
+**Key properties:**
+- Ordering doesn't matter — `preferred` is only populated when the new-format object
+  exists; absence means "use old path"
+- Old LBs never read the DG status — completely unaffected
+- The CM bears the cost of dual-write during migration
+
+**Limitations:**
+- New LBs need interpretation code for both old and new formats during migration (LB code
+  debt). Option C makes discovery explicit but doesn't eliminate interpretation logic.
+- Rollback requires old-format EndpointSlices to still exist (skip cleanup step before
+  rolling back). If already cleaned up, the old CM must regenerate them from scratch.
+- See Appendix for the general schema evolution trade-off framework.
+
+---
+
+## GatewayConfiguration: Proposed Schema Improvements
+
+### Consider adding ipFamily field
+
+Consider adding an explicit `ipFamily` field (`IPv4` / `IPv6`) to each InternalSubnet entry:
+- Makes intent explicit — no guessing from CIDR format
+- Enables CEL validation for duplicate detection and cross-validation
+- Consistent with `NetworkDomain.ipFamily` in the EndpointNetworkConfiguration API
+
+### Schema Tightening
+
+**Enforce limits:**
+- Max 2 `InternalSubnet` entries (one per IP family)
+- Exactly 1 CIDR per `InternalSubnet`
+
+**CEL validation rules:**
+- Each InternalSubnet must represent a different IP family
+
+**Why max 1 CIDR per InternalSubnet:**
+
+The architecture requires flat L2 networks (constraint #7). Multiple CIDRs in a single
+InternalSubnet would imply multiple L2 segments or routed subnets, which are not supported.
+If someone needs to operate on the primary network, they must use Multus + NAD to create
+an overlay achieving a flat internal network. External traffic attraction is fundamentally
+different from what Kubernetes offers for primary networks.
+
+**Why max 2 InternalSubnets (one per IP family):**
+
+Future attachment types (beyond NAD) may require different configuration per IP family.
+Keeping separate entries per family preserves this flexibility. But within a single family,
+only one subnet makes sense given the flat L2 requirement.
+
+---
+
+## LB Controller: Explored Changes
+
+*This section documents explored directions for the LB controller.*
+
+### Accumulate IPs per Identifier
+
+The original code used a plain map assignment (`newTargets[identifier] = endpoint.Addresses`)
+which caused last-writer-wins when the same identifier appeared in multiple EndpointSlices.
+The fix is to accumulate addresses across slices for the same identifier, or to classify
+them by IP family using the EndpointSlice's `AddressType`.
+
+### Route per IP Family
+
+The original code created one route per fwmark using only `ips[0]`. The fix is to create
+routes for all IPs under the identifier. IPv4 and IPv6 routing tables are independent in
+the Linux kernel, so a single fwmark can have both an IPv4 and IPv6 route without conflict.
+
+### IP Family Awareness
+
+*This topic is deferred to [#128](https://github.com/Nordix/Meridio-2/issues/128).*
+
+The LB needs awareness of which IP families it should expect per target to:
+- Mitigate race conditions when IPv4 and IPv6 endpoint data arrives non-atomically
+  (avoid premature activation with incomplete routing)
+- Set up blackhole safety nets for fwmarked traffic that has no target route
+  (prevent packets from leaking to the main routing table)
+- Handle mode transitions (cleanup stale routes when a family is removed)
+
+How this awareness is provided (startup config, DG status field, endpoint resource field)
+remains an open question. Requiring the LB to resolve GatewayConfiguration directly was
+considered but conflicts with the "dumb consumer" principle — the LB should process
+whatever endpoints it receives without understanding the upstream configuration chain.
+
+---
+
+## Network Degradation and Activation Policy (explored)
+
+*This section explores how the system should handle partial network presence and endpoint
+readiness. These are proposals — no decisions have been committed.*
+
+### The Fundamental Tension
+
+Maglev's value is connection stickiness — once a flow is assigned to a target, it stays
+there. Withdrawing a target from the hash table reshuffles ~1/N of all buckets, disrupting
+existing connections for other Pods. Keeping a broken target preserves stickiness for
+everyone else but blackholes traffic for that slot.
+
+The key distinction is: **can traffic physically reach the target?**
+- If no (IP gone, route impossible) → deactivate (correctness, no alternative)
+- If yes but Pod may be unhealthy (readiness change) → keep (stability, minimize blast
+  radius)
+
+**Trade-off:** Localized blackhole for one target's buckets vs distributed disruption
+across all targets' connections (twice) for a transient event.
+
+For long-lived connections (the primary Maglev use case), the conservative approach
+(ignore readiness, keep target in hash table) is preferable — it sacrifices new connections
+to the failed target but preserves all existing connections to healthy targets.
+
+This trade-off is specific to consistent hashing. For round-robin (future distribution
+type), deactivating a target has no cascading effect — there's no hash table to reshuffle.
+
+### Degradation Scenarios
+
+**Partial IP family loss** (Pod loses one IP family):
+- The route for the lost family physically cannot work — no IP to route to
+- Keeping the target means guaranteed blackhole for that family's traffic in that bucket
+- Deactivating causes one reshuffle but redirects traffic to targets that can serve it
+
+**Single-network degradation** (Pod loses its only IP/interface):
+- Same as above — no route possible
+
+**Pod readiness change** (PodReady=False, but IPs still present):
+- The route still exists — traffic might still work
+- Deactivating causes two reshuffles (deactivate + reactivate on recovery), disrupting
+  other targets' connections twice
+- Keeping it means new connections to that target may fail, but all other targets are
+  unaffected
+
+**GatewayConfiguration change** (CIDR changed or removed):
+- An operational decision, not a failure
+
+**Practical likelihood:** With static secondary network configuration (Multus thin plugin),
+losing an interface or IP on a running Pod is extremely unlikely — interfaces are created
+at Pod startup and persist for the Pod's lifetime. The realistic scenarios are Pod startup
+(IP not yet assigned), config changes, and node failure (Pod stays "ready" with stale
+status until Kubernetes eviction ~5m40s with default tolerations). Note: Multus thick
+plugin supports dynamic interface changes at runtime, which would make degradation
+scenarios more realistic. Currently, only static secondary configuration is supported.
+
+### DG Controller Role
+
+The DG controller currently acts as a truthful mirror of Pod network state — it sets the
+`Ready` field based on actual Pod readiness and includes Pods in EndpointSlices based on
+their actual IPs, without policy decisions about partial presence.
+
+**Gatekeeper proposal:** The DG controller could restrict adding *new* Pods to
+EndpointSlices until they have IPs in all configured InternalSubnets. This would prevent
+wasting Maglev ID slots on partially-configured Pods and ensure the LB never sees a
+brand-new identifier with incomplete families. Existing Pods that lose a family would
+remain in the slices where they still have IPs. Like the LB's activation policy, this
+behavior could be policy-driven per DG if required in the future.
+
+**NetworkConsistency condition proposal** (see [#141](https://github.com/Nordix/Meridio-2/issues/141)):
+The DG controller could surface a status condition when any Pod has partial network
+presence, alerting operators without taking disruptive action.
+
+### LB Controller Role
+
+The LB manages the data plane and would be responsible for activation/deactivation
+decisions based on endpoint state.
+
+**Possible policy for new targets** (identifier not active in hash table):
+- If all expected IP families are present: activate with routes for all families
+- If incomplete: skip activation until complete
+
+**Possible policy for existing targets** (identifier already active):
+- If a family was lost: deactivate entirely (correctness over stability)
+- If all families present: update routes as needed
+- If Pod readiness changed but IPs unchanged: ignore (for Maglev)
+
+**Policy-driven approach:** Both readiness and network degradation handling could be
+policy-driven per DG. The LB would ship with sensible defaults (deactivate on degradation,
+ignore readiness for Maglev) that can be overridden via an optional policy field on the DG
+CRD if demand arises. This keeps the initial implementation simple while allowing per-DG
+tuning later (e.g., keep degraded targets for a DG where partial service is preferable to
+reshuffling). The DG CRD can be extended with the policy block without breaking existing
+DGs.
+
+**Policy should be data-driven, not code-driven:** The policy should be explicit in
+configuration, not implicit in the LB code version. This ensures all LB replicas behave
+consistently regardless of software version during rolling upgrades.
+
+### Alternative: Graceful Degradation (keep working family)
+
+An alternative where the LB keeps a degraded target active for the remaining family, only
+removing the broken family's route. The DG controller would also participate: removing the
+Pod only from the broken family's EndpointSlice while preserving its Maglev ID in the
+remaining family's slice.
+
+**Pros:**
+- No disruption to the working family's traffic
+- No Maglev reshuffling for the remaining family
+- Finer granularity than v1's all-or-nothing approach
+
+**Cons:**
+- Silent blackhole for the missing family's traffic — harder to diagnose
+- Requires the DG controller to make policy decisions about partial presence
+- Operator mistakes would not disrupt the working family but the broken family's
+  blackhole could go unnoticed
+
+Both approaches are viable. The simpler approach (deactivate entirely) has cleaner failure
+semantics. Graceful degradation could be revisited if operational experience shows that
+partial family loss is common and reshuffling impact is unacceptable.
+
+---
+
+## Same-Namespace Restriction
+
+### Current State
+
+The LB controller's cache is scoped to `GatewayNamespace` via
+`cache.Options.DefaultNamespaces` in `cmd/stateless-load-balancer/cmd/run.go`. All list
+operations use `client.InNamespace(c.GatewayNamespace)`. DGs, L34Routes, EndpointSlices,
+and the Gateway are all expected to reside in the same namespace.
+
+The `endpointSliceEnqueue` mapper explicitly rejects events from other namespaces:
+```go
+if obj.GetNamespace() != c.GatewayNamespace {
+    return nil
+}
+```
+
+The DG's `ParentReference` type includes an optional `Namespace` field, allowing
+cross-namespace Gateway references at the API level. However, the LB controller cannot
+discover DGs or EndpointSlices outside its own namespace.
+
+### Recommendation
+
+Document as a current implementation limitation, not an architectural constraint. The
+`ParentReference.Namespace` field is preserved for future use.
+
+The path to cross-namespace support is clear:
+1. LB finds relevant DGs via L34Routes (which already resolve cross-namespace backendRefs
+   — the code checks `backendRef.Namespace` and compares against `distGroup.Namespace`)
+2. For each DG, the LB knows the DG's namespace from the backendRef
+3. It lists EndpointSlices in that namespace filtered by the DG name label
+4. The only changes needed: extend the LB's cache scope and replace hardcoded
+   `InNamespace(c.GatewayNamespace)` calls with the DG's actual namespace
+
+The single-Gateway restriction ensures EndpointSlices are unambiguous regardless of
+namespace topology — all slices owned by a DG serve exactly one Gateway.
+
+Note: DGs are namespace-scoped and their label selector only matches Pods in the same
+namespace. So even with cross-namespace DG-to-Gateway references, application Pods must
+reside in the DG's namespace. This mirrors how Kubernetes Services select Pods only within
+their own namespace.
+
+**OwnerReference constraint for cross-namespace:** If multi-Gateway DG support were added
+via Gateway ownerReferences on EndpointSlices (see Option B), this would only work when
+the Gateway is in the same namespace as the DG and its EndpointSlices. Kubernetes requires
+ownerReferences to point to objects in the same namespace as the dependent. A cluster-wide
+controller-manager can manage objects across namespaces (it's just API calls), but the
+ownerReference relationship itself is namespace-scoped. This means cross-namespace
+Gateway-to-DG linking via ownerReferences is fundamentally impossible — labels or another
+discovery mechanism would be required.
+
+---
+
+## EndpointSlice Cleanup on DG Deletion
+
+### Current Behavior
+
+When a DG is deleted and the reconciler is triggered (via `.Owns()` watch on EndpointSlices),
+the `r.Get()` call returns NotFound. The current code calls `client.IgnoreNotFound(err)` and
+returns nil — it does **not** actively delete EndpointSlices. Cleanup relies entirely on
+Kubernetes GC via the DG's ownerReference (`controller: true`).
+
+The `deleteAllOwnedSlices` function is only called when the DG exists but has zero matching
+Pods — it is not part of the deletion path.
+
+### Improvement idea
+
+Add active cleanup on the NotFound path using label-based lookup. The reconcile request
+carries `req.Name` and `req.Namespace` (the DG's identity), and EndpointSlices have the
+`meridio-2.nordix.org/distribution-group: <name>` label:
+
+```go
+if err := r.Get(ctx, req.NamespacedName, &dg); err != nil {
+    if apierrors.IsNotFound(err) {
+        // DG gone — clean up orphaned EndpointSlices by label
+        return r.deleteSlicesByLabel(ctx, req.Namespace, req.Name)
+    }
+    return ctrl.Result{}, err
+}
+```
+
+This is a defense-in-depth improvement that works regardless of the ownership model. It
+ensures cleanup even if GC is delayed, and it would be essential if a future change adds
+additional owners (e.g., Gateway) that would prevent GC from acting when only the DG is
+deleted.
+
+---
+
+## EndpointSlice Naming and Length Limits
+
+Kubernetes object names are limited to 253 characters, and label values are limited to 63
+characters. Since DG names are used as label values on EndpointSlices
+(`meridio-2.nordix.org/distribution-group: <dg-name>`), the practical DG name limit is 63
+characters — not 253. This is currently an implicit limitation, not enforced at the CRD/API
+level. Gateway names would be subject to the same limitation if used as label values (e.g.,
+in Option B1).
+
+With this constraint, the current naming convention (`<dg>-<hashCIDR>-<index>`) stays well
+under 253 characters. Multi-Gateway conventions (e.g., `<dg>-<gw>-<hashCIDR>-<index>` as
+discussed in Option B1) would also fit comfortably (~140 chars with two 63-char names).
+
+For robustness, a truncate-and-hash approach can be used:
+`<truncated-prefix>-<hash(full-inputs)>-<index>`. The hash guarantees uniqueness regardless
+of truncation. This is a general best practice but not strictly necessary given the 63-char
+label constraint on input names.
+
+**Note on Option D (custom resource):** With a custom resource replacing EndpointSlices,
+the DG name would be stored in a spec field (e.g., `spec.distributionGroup`) rather than a
+label, removing the 63-character label value limitation. However, the object naming
+challenge remains — multiple custom endpoint objects may coexist per DG (due to capacity
+splitting), requiring a naming convention that ensures uniqueness across slices.
+
+---
+
+## Multi-Gateway DG Support
+
+If multi-Gateway DG support is needed in the future, see Option B for EndpointSlice-based
+approaches and Option D (custom resource replacing EndpointSlices) which is the intended
+mid-term direction regardless of multi-Gateway needs. Option C (DG status-based discovery)
+was explored as a possible migration bridge between EndpointSlices and Option D.
+
+---
+
+## Note on Data Footprint vs Simplicity
+
+The core Kubernetes EndpointSlice controller creates separate EndpointSlices per Service,
+even when two Services select the exact same Pods. There is no deduplication or sharing
+across Services — each Service owns its own set of slices independently. Kubernetes chose
+clear ownership and simplicity over data footprint optimization.
+
+This precedent supports the same trade-off in Meridio-2: exclusive per-DG (and potentially
+per-Gateway) endpoint objects with duplicate data are acceptable. Investing effort in
+shared-slice optimization (e.g., Option B2) sacrifices simplicity for marginal storage
+savings that Kubernetes itself does not pursue.
+
+---
+
+## Appendix: Schema Evolution with Independent Deployment Lifecycles
+
+The upgrade and migration challenges discussed throughout this document (B1/B2 upgrade
+mitigations, Option C+D gradual migration, rollback concerns) are instances of a well-known
+distributed systems problem: **schema evolution when producers and consumers have
+independent deployment lifecycles**.
+
+The same challenge exists in Kubernetes API versioning (storage versions with conversion
+webhooks), message queues (Kafka schema registry, Avro/Protobuf evolution rules), and
+microservices (API versioning, backward/forward compatibility contracts).
+
+### Established Patterns
+
+**1. Additive-only changes (the Kubernetes API way):**
+Never remove or rename fields — only add new ones. Old consumers ignore unknown fields.
+New consumers use new fields if present, fall back if not. Rollback is safe because old
+producers still write the fields old consumers need.
+*Limitation:* Fields accumulate forever.
+
+**2. Conversion layer (the Kubernetes storage version way):**
+Store data in one canonical format. A conversion webhook translates between versions on
+the fly. Consumers always see their expected version.
+*Limitation:* Requires a running conversion webhook. Not applicable to core Kubernetes
+types (EndpointSlices), but viable with custom resources (Option D).
+
+**3. Dual-write with explicit contract (what Option C+D proposes):**
+The producer writes both old and new formats and advertises what's available via an
+explicit contract. Consumers pick the format they understand.
+*Limitation:* Producer complexity during migration. Rollback requires old-format data to
+still exist.
+
+**4. Consumer-side adaptation (the pragmatic approach):**
+Accept that consumers must handle N format versions. Keep N small (current + previous).
+*Limitation:* Does not inherently guarantee rollback — once old-format data is removed,
+rolling back the producer leaves a gap until it regenerates. Consumers accumulate legacy
+interpretation code over time.
+
+### The Fundamental Trade-off
+
+There is no solution that simultaneously provides arbitrary rollback, zero consumer code
+debt, and independent deployment ordering. You pick two:
+
+| Choice | Consequence |
+|--------|-------------|
+| Independent ordering + zero code debt | No rollback support |
+| Rollback + zero code debt | Coordinated ordering required |
+| Rollback + independent ordering | Consumer code debt (support N formats) |
+
+For Meridio-2, the practical recommendation is: support upgrade and rollback within one
+version only (N and N-1), accept temporary dual-format support in consumers during
+migration windows, and document that multi-version jumps are not supported without
+intermediate steps.

--- a/docs/operations/constraints-and-limitations.md
+++ b/docs/operations/constraints-and-limitations.md
@@ -6,9 +6,9 @@ Items marked *(architectural constraint)* reflect deliberate design decisions th
 
 ## Architecture / Cross-Controller
 
-**1. Dual-stack internal networking not supported (IPv4 + IPv6 simultaneously)**
+**1. Dual-stack internal networking partially supported (IPv4 + IPv6 simultaneously)**
 
-The DistributionGroup controller assigns Maglev IDs independently per network/IP family, while the LB controller uses a single NFQLB hash table per DG. Using both IPv4 and IPv6 CIDRs in `GatewayConfiguration.spec.networkSubnets` simultaneously causes identifier collisions across EndpointSlices, leading to incorrect traffic distribution and broken target removal. Workaround: use only IPv4 or only IPv6 for internal networking within a Gateway.
+The DistributionGroup controller assigns Maglev IDs per DG per Gateway, shared across all networks (IPv4/IPv6) — the allocation side is complete. However, the LB controller's dual-stack route handling is pending refactor and not yet production-ready. See [#70](https://github.com/Nordix/Meridio-2/issues/70).
 
 **2. ~~RBAC uses ClusterRole instead of namespace-scoped Roles (controller-manager)~~ (Resolved)**
 
@@ -24,7 +24,7 @@ No metrics are exposed by any component. Future metrics should include traffic-r
 
 **5. Network subnet CIDRs must uniquely identify a single interface IP per Pod** *(architectural constraint)*
 
-Each CIDR in `GatewayConfiguration.spec.networkSubnets` must match exactly one secondary interface IP within application Pods. The DistributionGroup controller uses these subnets to select the correct IP from Multus network-status annotations when building EndpointSlices — if multiple interfaces match, the selected IP is ambiguous. Similarly, the network sidecar discovers the target interface by matching the subnet against interface addresses, and would apply VIPs and routing rules to the wrong interface if multiple interfaces match.
+Each CIDR in `GatewayConfiguration.spec.internalSubnets` must match exactly one secondary interface IP within application Pods. The DistributionGroup controller uses these subnets to select the correct IP from Multus network-status annotations when building EndpointSlices — if multiple interfaces match, the selected IP is ambiguous. Similarly, the network sidecar discovers the target interface by matching the subnet against interface addresses, and would apply VIPs and routing rules to the wrong interface if multiple interfaces match.
 
 To avoid ambiguity, the default network (`0.0.0.0/0`, `::/0`) and `fe80::/10` link-local addresses are explicitly not accepted.
 

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -365,6 +365,12 @@ table inet meridio-lb {
 		meta l4proto icmp ip daddr @ipv4-vips counter packets 0 bytes 0 queue to 0-3
 		meta l4proto ipv6-icmp ip6 daddr @ipv6-vips counter packets 0 bytes 0 queue to 0-3
 	}
+
+	chain snat-local {
+		type route hook output priority raw; policy accept;
+		meta mark != 0x00000000/8 ip daddr != @ipv4-vips ip saddr != @ipv4-vips icmp type destination-unreachable icmp code frag-needed @th,192,32 @ipv4-vips counter packets 0 bytes 0 ip saddr set @th,192,32 meta mark set 0x00000000
+		meta mark != 0x00000000/8 ip6 daddr != @ipv6-vips ip6 saddr != @ipv6-vips icmpv6 type packet-too-big @th,256,128 @ipv6-vips counter packets 0 bytes 0 ip6 saddr set @th,256,128 meta mark set 0x00000000
+	}
 }
 ```
 
@@ -529,7 +535,7 @@ Expected: default route with next-hops pointing to SLLBR Pod IPs (ECMP if multip
 ### Sidecar in backoff
 
 If the sidecar logs show repeated `InterfaceNotFoundError`, the ENC contains a domain for a subnet where the Pod has no matching interface. This triggers exponential backoff retries. Check:
-- Pod's Multus network-status annotation matches the GatewayConfiguration networkSubnets
+- Pod's Multus network-status annotation matches the GatewayConfiguration internalSubnets
 - The secondary interface exists and has an IP in the expected subnet
 
 ## Gateway and CRD Status
@@ -579,8 +585,9 @@ Two condition types are used:
   - `"No Pods match selector"` — no Pods match the DG's label selector.
   - `"No Gateways reference this DistributionGroup"` — no L34Route links this DG to a Gateway (check `parentRefs` or L34Route `backendRefs`).
   - `"No accepted Gateways found"` — referenced Gateways don't have `Accepted=True` (Gateway may not exist or GatewayConfiguration is invalid).
-  - `"No network context available"` — the GatewayConfiguration has no `networkSubnets` configured.
+  - `"No network context available"` — the GatewayConfiguration has no `internalSubnets` configured.
   - `"No endpoints available"` — Pods exist but none have an IP matching the network subnets.
+- `Ready=False`, reason `MultipleGateways` — the DG is referenced by more than one accepted Gateway. Reconciliation is skipped until the conflict is resolved.
 
 **`CapacityExceeded`** (Maglev only) — present only when the number of matching Pods exceeds `maxEndpoints`:
 - `CapacityExceeded=True`, reason `MaglevCapacityExceeded` — some Pods were excluded from EndpointSlices because the Maglev table is full. The message lists affected networks with counts (e.g., `"10.0.0.0/24: 5/37 pods excluded (32 capacity)"`).
@@ -614,7 +621,7 @@ Each endpoint should have:
 If EndpointSlices are missing:
 - Check the DistributionGroup status conditions for the specific reason (see "Check DistributionGroup status" above)
 - Verify Pods have the expected secondary network IP via Multus annotation: `kubectl get pod <name> -o jsonpath='{.metadata.annotations.k8s\.v1\.cni\.cncf\.io/network-status}'`
-- Verify the Pod IP falls within a `GatewayConfiguration.spec.networkSubnets` CIDR
+- Verify the Pod IP falls within a `GatewayConfiguration.spec.internalSubnets` CIDR
 
 ### Verify GatewayConfiguration network setup
 
@@ -626,6 +633,6 @@ kubectl get gatewayconfiguration -n <ns> <name> -o yaml
 
 Check:
 - `spec.networkAttachments` — lists the secondary network interfaces (NADs) attached to LB Pods. Must include both the external interface (towards the gateway router) and the internal interface(s) (towards application Pods). Network attachments may also be defined in the LB deployment template; the GatewayConfiguration entries are merged on top.
-- `spec.networkSubnets` — lists the CIDRs of the internal network(s) where application Pod IPs reside. Used by the DistributionGroup controller to select the correct Pod IP when building EndpointSlices. Must cover all application Pod secondary IPs.
+- `spec.internalSubnets` — lists the CIDRs of the internal network(s) where application Pod IPs reside. Used by the DistributionGroup controller to select the correct Pod IP when building EndpointSlices. Must cover all application Pod secondary IPs.
 
 Missing or misconfigured entries here are a common cause of traffic issues even when all resources show healthy status.

--- a/internal/controller/distributiongroup/const.go
+++ b/internal/controller/distributiongroup/const.go
@@ -47,6 +47,7 @@ const (
 	// Status condition reasons
 	reasonEndpointsAvailable     = "EndpointsAvailable"
 	reasonNoEndpoints            = "NoEndpoints"
+	reasonMultipleGateways       = "MultipleGateways"
 	reasonMaglevCapacityExceeded = "MaglevCapacityExceeded"
 
 	// Status condition messages
@@ -56,4 +57,5 @@ const (
 	messageNoReferencedGateways = "No Gateways reference this DistributionGroup (check parentRefs or L34Route backendRefs)"
 	messageNoAcceptedGateways   = "No accepted Gateways found (Gateways may not exist or lack Accepted=True status condition)"
 	messageNoNetworkContext     = "No network context available (check GatewayConfiguration internalSubnets)"
+	messageMultipleGateways     = "DistributionGroup is referenced by multiple Gateways; only a single Gateway is supported"
 )

--- a/internal/controller/distributiongroup/controller.go
+++ b/internal/controller/distributiongroup/controller.go
@@ -134,25 +134,39 @@ func (r *DistributionGroupReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	}
 	log.Info("found accepted gateways", "count", len(acceptedGateways))
 
-	// 7. For each accepted Gateway, fetch GatewayConfiguration to determine network context
-	networkContexts, err := r.getNetworkContexts(ctx, acceptedGateways)
+	// 7. Enforce single-Gateway restriction
+	if len(acceptedGateways) > 1 {
+		if err := r.updateStatus(ctx, &dg, false, nil, messageMultipleGateways); err != nil {
+			if apierrors.IsConflict(err) {
+				return ctrl.Result{Requeue: true}, nil
+			}
+			log.Error(err, "failed to update status")
+			return ctrl.Result{}, err
+		}
+		log.Info("DistributionGroup references multiple Gateways, skipping reconciliation",
+			"gateways", len(acceptedGateways))
+		return ctrl.Result{}, nil
+	}
+
+	// 8. For each accepted Gateway, fetch GatewayConfiguration to determine network context
+	gwContexts, err := r.getNetworkContexts(ctx, acceptedGateways)
 	if err != nil {
 		log.Error(err, "failed to get network contexts")
 		return ctrl.Result{}, err
 	}
-	log.Info("extracted network contexts", "contexts", networkContexts)
+	log.Info("extracted network contexts", "gatewayCount", len(gwContexts))
 
-	// 8. List existing EndpointSlices owned by this DG
+	// 9. List existing EndpointSlices owned by this DG
 	existingSlices, err := r.listOwnedSlices(ctx, &dg)
 	if err != nil {
 		log.Error(err, "failed to list owned endpointslices")
 		return ctrl.Result{}, err
 	}
 
-	// 9. Calculate desired EndpointSlices
-	desiredSlices, capacityInfo := r.calculateDesiredSlices(ctx, &dg, pods, networkContexts, existingSlices)
+	// 10. Calculate desired EndpointSlices
+	desiredSlices, capacityInfo := r.calculateDesiredSlices(ctx, &dg, pods, gwContexts, existingSlices)
 
-	// 10. Reconcile EndpointSlices (create/update/delete)
+	// 11. Reconcile EndpointSlices (create/update/delete)
 	if err := r.reconcileSlices(ctx, &dg, desiredSlices, existingSlices); err != nil {
 		if apierrors.IsConflict(err) {
 			return ctrl.Result{Requeue: true}, nil
@@ -161,7 +175,7 @@ func (r *DistributionGroupReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return ctrl.Result{}, err
 	}
 
-	// 11. Update DG status
+	// 12. Update DG status
 	msg := ""
 	if len(desiredSlices) == 0 {
 		// Determine specific reason for no endpoints
@@ -169,7 +183,7 @@ func (r *DistributionGroupReconciler) Reconcile(ctx context.Context, req ctrl.Re
 			msg = messageNoReferencedGateways
 		} else if len(acceptedGateways) == 0 {
 			msg = messageNoAcceptedGateways
-		} else if len(networkContexts) == 0 {
+		} else if len(gwContexts) == 0 {
 			msg = messageNoNetworkContext
 		}
 		// If msg still empty, Pods probably have no secondary IPs (leave default message)

--- a/internal/controller/distributiongroup/controller_test.go
+++ b/internal/controller/distributiongroup/controller_test.go
@@ -321,6 +321,34 @@ func TestReconcile_NoReferencedGateways(t *testing.T) {
 	assert.Equal(t, messageNoReferencedGateways, cond.Message)
 }
 
+func TestReconcile_MultipleGateways_SkipsReconciliation(t *testing.T) {
+	dg := newDG()
+	gw1 := newGateway(true)
+	gw2 := newGateway(true)
+	gw2.Name = "second-gateway"
+	gwConfig := newGatewayConfig()
+	route1 := newL34Route(testGatewayName, testDGName)
+	route2 := newL34Route("second-gateway", testDGName)
+	route2.Name = "route-2"
+	pod := newPod("pod-1", "192.168.100.10", true)
+
+	r, c := setupReconciler(dg, gw1, gw2, gwConfig, route1, route2, pod)
+	result, err := r.Reconcile(context.Background(), reconcileRequest())
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	updated := getDGStatus(t, c)
+	cond := findCondition(updated.Status.Conditions, conditionTypeReady)
+	require.NotNil(t, cond)
+	assert.Equal(t, metav1.ConditionFalse, cond.Status)
+	assert.Equal(t, reasonMultipleGateways, cond.Reason)
+	assert.Equal(t, messageMultipleGateways, cond.Message)
+
+	// No EndpointSlices created
+	slices := listEndpointSlices(t, c)
+	assert.Empty(t, slices)
+}
+
 func TestReconcile_HappyPath_CreatesEndpointSlice(t *testing.T) {
 	dg := newDG()
 	gw := newGateway(true)

--- a/internal/controller/distributiongroup/controller_test.go
+++ b/internal/controller/distributiongroup/controller_test.go
@@ -18,6 +18,7 @@ package distributiongroup
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"testing"
 
@@ -139,7 +140,7 @@ func newGateway(accepted bool) *gatewayv1.Gateway {
 			Infrastructure: &gatewayv1.GatewayInfrastructure{
 				ParametersRef: &gatewayv1.LocalParametersReference{
 					Group: gatewayv1.Group(meridio2v1alpha1.GroupVersion.Group),
-					Kind:  "GatewayConfiguration",
+					Kind:  kindGatewayConfiguration,
 					Name:  testGWConfigName,
 				},
 			},
@@ -176,7 +177,7 @@ func newGatewayConfig() *meridio2v1alpha1.GatewayConfiguration {
 
 func newL34Route(gatewayName, dgName string) *meridio2v1alpha1.L34Route {
 	dgGroup := meridio2v1alpha1.GroupVersion.Group
-	dgKind := "DistributionGroup"
+	dgKind := kindDistributionGroup
 	return &meridio2v1alpha1.L34Route{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-route",
@@ -200,7 +201,7 @@ func newL34Route(gatewayName, dgName string) *meridio2v1alpha1.L34Route {
 	}
 }
 
-func newPod(name, ip string, ready bool) *corev1.Pod {
+func newPod(name string, ready bool, ips ...string) *corev1.Pod {
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -210,11 +211,13 @@ func newPod(name, ip string, ready bool) *corev1.Pod {
 		},
 		Status: corev1.PodStatus{
 			Phase: corev1.PodRunning,
-			PodIP: ip,
-			PodIPs: []corev1.PodIP{
-				{IP: ip},
-			},
 		},
+	}
+	if len(ips) > 0 {
+		pod.Status.PodIP = ips[0]
+		for _, ip := range ips {
+			pod.Status.PodIPs = append(pod.Status.PodIPs, corev1.PodIP{IP: ip})
+		}
 	}
 	if ready {
 		pod.Status.Conditions = []corev1.PodCondition{
@@ -287,7 +290,7 @@ func TestReconcile_NoAcceptedGateways(t *testing.T) {
 	gw := newGateway(false) // not accepted
 	gwConfig := newGatewayConfig()
 	route := newL34Route(testGatewayName, testDGName)
-	pod := newPod("pod-1", "192.168.100.10", true)
+	pod := newPod("pod-1", true, "192.168.100.10")
 
 	r, c := setupReconciler(dg, gw, gwConfig, route, pod)
 	result, err := r.Reconcile(context.Background(), reconcileRequest())
@@ -307,7 +310,7 @@ func TestReconcile_NoAcceptedGateways(t *testing.T) {
 func TestReconcile_NoReferencedGateways(t *testing.T) {
 	dg := newDG()
 	// No L34Route, no parentRefs → no Gateways
-	pod := newPod("pod-1", "192.168.100.10", true)
+	pod := newPod("pod-1", true, "192.168.100.10")
 
 	r, c := setupReconciler(dg, pod)
 	result, err := r.Reconcile(context.Background(), reconcileRequest())
@@ -330,7 +333,7 @@ func TestReconcile_MultipleGateways_SkipsReconciliation(t *testing.T) {
 	route1 := newL34Route(testGatewayName, testDGName)
 	route2 := newL34Route("second-gateway", testDGName)
 	route2.Name = "route-2"
-	pod := newPod("pod-1", "192.168.100.10", true)
+	pod := newPod("pod-1", true, "192.168.100.10")
 
 	r, c := setupReconciler(dg, gw1, gw2, gwConfig, route1, route2, pod)
 	result, err := r.Reconcile(context.Background(), reconcileRequest())
@@ -349,12 +352,53 @@ func TestReconcile_MultipleGateways_SkipsReconciliation(t *testing.T) {
 	assert.Empty(t, slices)
 }
 
+func TestReconcile_MultipleGateways_RecoveryAfterConflictResolved(t *testing.T) {
+	dg := newDG()
+	gw1 := newGateway(true)
+	gw2 := newGateway(true)
+	gw2.Name = "second-gateway"
+	gwConfig := newGatewayConfig()
+	route1 := newL34Route(testGatewayName, testDGName)
+	route2 := newL34Route("second-gateway", testDGName)
+	route2.Name = "route-2"
+	pod := newPod("pod-1", true, "192.168.100.10")
+
+	r, c := setupReconciler(dg, gw1, gw2, gwConfig, route1, route2, pod)
+
+	// First reconcile: multiple Gateways → Ready=False
+	_, err := r.Reconcile(context.Background(), reconcileRequest())
+	require.NoError(t, err)
+
+	updated := getDGStatus(t, c)
+	cond := findCondition(updated.Status.Conditions, conditionTypeReady)
+	require.NotNil(t, cond)
+	assert.Equal(t, metav1.ConditionFalse, cond.Status)
+	assert.Equal(t, reasonMultipleGateways, cond.Reason)
+
+	// Resolve conflict: delete the second route
+	require.NoError(t, c.Delete(context.Background(), route2))
+
+	// Second reconcile: single Gateway → Ready=True
+	_, err = r.Reconcile(context.Background(), reconcileRequest())
+	require.NoError(t, err)
+
+	updated = getDGStatus(t, c)
+	cond = findCondition(updated.Status.Conditions, conditionTypeReady)
+	require.NotNil(t, cond)
+	assert.Equal(t, metav1.ConditionTrue, cond.Status)
+	assert.Equal(t, reasonEndpointsAvailable, cond.Reason)
+
+	// EndpointSlices created
+	slices := listEndpointSlices(t, c)
+	assert.NotEmpty(t, slices)
+}
+
 func TestReconcile_HappyPath_CreatesEndpointSlice(t *testing.T) {
 	dg := newDG()
 	gw := newGateway(true)
 	gwConfig := newGatewayConfig()
 	route := newL34Route(testGatewayName, testDGName)
-	pod := newPod("pod-1", "192.168.100.10", true)
+	pod := newPod("pod-1", true, "192.168.100.10")
 
 	r, c := setupReconciler(dg, gw, gwConfig, route, pod)
 	result, err := r.Reconcile(context.Background(), reconcileRequest())
@@ -385,8 +429,8 @@ func TestReconcile_HappyPath_MaglevIDsAssigned(t *testing.T) {
 	gw := newGateway(true)
 	gwConfig := newGatewayConfig()
 	route := newL34Route(testGatewayName, testDGName)
-	pod1 := newPod("pod-1", "192.168.100.10", true)
-	pod2 := newPod("pod-2", "192.168.100.11", true)
+	pod1 := newPod("pod-1", true, "192.168.100.10")
+	pod2 := newPod("pod-2", true, "192.168.100.11")
 
 	r, c := setupReconciler(dg, gw, gwConfig, route, pod1, pod2)
 	result, err := r.Reconcile(context.Background(), reconcileRequest())
@@ -404,6 +448,59 @@ func TestReconcile_HappyPath_MaglevIDsAssigned(t *testing.T) {
 	}
 }
 
+func TestReconcile_DualStack_SharedMaglevIDs(t *testing.T) {
+	dg := newDG()
+	gw := newGateway(true)
+	gwConfig := newGatewayConfig()
+	gwConfig.Spec.InternalSubnets = append(gwConfig.Spec.InternalSubnets,
+		meridio2v1alpha1.InternalSubnet{AttachmentType: "NAD", CIDR: testInternalSubnetV6})
+	route := newL34Route(testGatewayName, testDGName)
+
+	pods := make([]client.Object, 16)
+	for i := range 16 {
+		pods[i] = newPod(
+			fmt.Sprintf("pod-%d", i), true,
+			fmt.Sprintf("192.168.100.%d", 10+i),
+			fmt.Sprintf("2001:db8:100::%d", 10+i),
+		)
+	}
+
+	objs := append([]client.Object{dg, gw, gwConfig, route}, pods...)
+	r, c := setupReconciler(objs...)
+	_, err := r.Reconcile(context.Background(), reconcileRequest())
+	require.NoError(t, err)
+
+	slices := listEndpointSlices(t, c)
+	require.Len(t, slices, 2, "Expected 2 EndpointSlices (IPv4 + IPv6)")
+
+	// Collect UID→zone from each slice, keyed by address type
+	zonesByType := make(map[discoveryv1.AddressType]map[string]string)
+	for _, s := range slices {
+		m := make(map[string]string)
+		for _, ep := range s.Endpoints {
+			if ep.TargetRef != nil && ep.Zone != nil {
+				m[string(ep.TargetRef.UID)] = *ep.Zone
+			}
+		}
+		zonesByType[s.AddressType] = m
+	}
+
+	ipv4Zones, ok := zonesByType[discoveryv1.AddressTypeIPv4]
+	require.True(t, ok, "Expected IPv4 EndpointSlice")
+	ipv6Zones, ok := zonesByType[discoveryv1.AddressTypeIPv6]
+	require.True(t, ok, "Expected IPv6 EndpointSlice")
+
+	assert.Len(t, ipv4Zones, 16)
+	assert.Len(t, ipv6Zones, 16)
+
+	// Same Pod must have the same Maglev ID in both slices
+	for uid, v4Zone := range ipv4Zones {
+		v6Zone, exists := ipv6Zones[uid]
+		require.True(t, exists, "Pod %s missing from IPv6 slice", uid)
+		assert.Equal(t, v4Zone, v6Zone, "Pod %s should have same ID across families", uid)
+	}
+}
+
 func TestReconcile_MaglevCapacityExceeded(t *testing.T) {
 	dg := newDG(func(dg *meridio2v1alpha1.DistributionGroup) {
 		dg.Spec.Maglev.MaxEndpoints = 1 // only 1 slot
@@ -411,8 +508,8 @@ func TestReconcile_MaglevCapacityExceeded(t *testing.T) {
 	gw := newGateway(true)
 	gwConfig := newGatewayConfig()
 	route := newL34Route(testGatewayName, testDGName)
-	pod1 := newPod("pod-1", "192.168.100.10", true)
-	pod2 := newPod("pod-2", "192.168.100.11", true)
+	pod1 := newPod("pod-1", true, "192.168.100.10")
+	pod2 := newPod("pod-2", true, "192.168.100.11")
 
 	r, c := setupReconciler(dg, gw, gwConfig, route, pod1, pod2)
 	result, err := r.Reconcile(context.Background(), reconcileRequest())
@@ -434,7 +531,7 @@ func TestReconcile_MaglevCapacityExceeded(t *testing.T) {
 
 func TestReconcile_DGWithDirectParentRef(t *testing.T) {
 	gwGroup := gatewayv1.GroupName
-	gwKind := "Gateway"
+	gwKind := kindGateway
 	dg := newDG(func(dg *meridio2v1alpha1.DistributionGroup) {
 		dg.Spec.ParentRefs = []meridio2v1alpha1.ParentReference{
 			{Name: testGatewayName, Group: &gwGroup, Kind: &gwKind},
@@ -443,7 +540,7 @@ func TestReconcile_DGWithDirectParentRef(t *testing.T) {
 	gw := newGateway(true)
 	gwConfig := newGatewayConfig()
 	// No L34Route — DG references Gateway directly
-	pod := newPod("pod-1", "192.168.100.10", true)
+	pod := newPod("pod-1", true, "192.168.100.10")
 
 	r, c := setupReconciler(dg, gw, gwConfig, pod)
 	result, err := r.Reconcile(context.Background(), reconcileRequest())
@@ -464,7 +561,7 @@ func TestReconcile_DualStack(t *testing.T) {
 		{AttachmentType: "NAD", CIDR: testInternalSubnetV6},
 	}
 	route := newL34Route(testGatewayName, testDGName)
-	pod := newPod("pod-1", "192.168.100.10", true)
+	pod := newPod("pod-1", true, "192.168.100.10")
 	// Add IPv6 address
 	pod.Status.PodIPs = append(pod.Status.PodIPs, corev1.PodIP{IP: "2001:db8:100::10"})
 
@@ -492,7 +589,7 @@ func TestReconcile_PodNotReady_EndpointNotReady(t *testing.T) {
 	gw := newGateway(true)
 	gwConfig := newGatewayConfig()
 	route := newL34Route(testGatewayName, testDGName)
-	pod := newPod("pod-1", "192.168.100.10", false) // not ready
+	pod := newPod("pod-1", false, "192.168.100.10") // not ready
 
 	r, c := setupReconciler(dg, gw, gwConfig, route, pod)
 	result, err := r.Reconcile(context.Background(), reconcileRequest())
@@ -510,7 +607,7 @@ func TestReconcile_RouteReferencesWrongGateway_NoEndpoints(t *testing.T) {
 	gw := newGateway(true)
 	gwConfig := newGatewayConfig()
 	route := newL34Route("other-gateway", testDGName) // wrong gateway
-	pod := newPod("pod-1", "192.168.100.10", true)
+	pod := newPod("pod-1", true, "192.168.100.10")
 
 	r, c := setupReconciler(dg, gw, gwConfig, route, pod)
 	result, err := r.Reconcile(context.Background(), reconcileRequest())
@@ -526,7 +623,7 @@ func TestReconcile_RouteReferencesWrongDG_NoEndpoints(t *testing.T) {
 	gw := newGateway(true)
 	gwConfig := newGatewayConfig()
 	route := newL34Route(testGatewayName, "other-dg") // wrong DG
-	pod := newPod("pod-1", "192.168.100.10", true)
+	pod := newPod("pod-1", true, "192.168.100.10")
 
 	r, c := setupReconciler(dg, gw, gwConfig, route, pod)
 	result, err := r.Reconcile(context.Background(), reconcileRequest())
@@ -543,7 +640,7 @@ func TestReconcile_PodIPOutsideSubnet_Excluded(t *testing.T) {
 	gwConfig := newGatewayConfig()
 	route := newL34Route(testGatewayName, testDGName)
 	// Pod IP not in 192.168.100.0/24
-	pod := newPod("pod-1", "10.0.0.5", true)
+	pod := newPod("pod-1", true, "10.0.0.5")
 
 	r, c := setupReconciler(dg, gw, gwConfig, route, pod)
 	result, err := r.Reconcile(context.Background(), reconcileRequest())
@@ -565,7 +662,7 @@ func TestReconcile_Idempotent(t *testing.T) {
 	gw := newGateway(true)
 	gwConfig := newGatewayConfig()
 	route := newL34Route(testGatewayName, testDGName)
-	pod := newPod("pod-1", "192.168.100.10", true)
+	pod := newPod("pod-1", true, "192.168.100.10")
 
 	r, c := setupReconciler(dg, gw, gwConfig, route, pod)
 
@@ -589,8 +686,8 @@ func TestReconcile_MaglevIDStability(t *testing.T) {
 	gw := newGateway(true)
 	gwConfig := newGatewayConfig()
 	route := newL34Route(testGatewayName, testDGName)
-	pod1 := newPod("pod-1", "192.168.100.10", true)
-	pod2 := newPod("pod-2", "192.168.100.11", true)
+	pod1 := newPod("pod-1", true, "192.168.100.10")
+	pod2 := newPod("pod-2", true, "192.168.100.11")
 
 	r, c := setupReconciler(dg, gw, gwConfig, route, pod1, pod2)
 
@@ -624,7 +721,7 @@ func TestReconcile_CleanupWhenPodsDisappear(t *testing.T) {
 	gw := newGateway(true)
 	gwConfig := newGatewayConfig()
 	route := newL34Route(testGatewayName, testDGName)
-	pod := newPod("pod-1", "192.168.100.10", true)
+	pod := newPod("pod-1", true, "192.168.100.10")
 
 	r, c := setupReconciler(dg, gw, gwConfig, route, pod)
 
@@ -648,6 +745,42 @@ func TestReconcile_CleanupWhenPodsDisappear(t *testing.T) {
 	assert.Equal(t, messageNoMatchingPods, cond.Message)
 }
 
+func TestReconcile_OrphanedSliceDeletedWhenNetworkRemoved(t *testing.T) {
+	dg := newDG()
+	gw := newGateway(true)
+	gwConfig := newGatewayConfig() // has 192.168.100.0/24
+	route := newL34Route(testGatewayName, testDGName)
+	pod := newPod("pod-1", true, "192.168.100.10")
+
+	r, c := setupReconciler(dg, gw, gwConfig, route, pod)
+
+	// First reconcile: creates EndpointSlice for 192.168.100.0/24
+	_, err := r.Reconcile(context.Background(), reconcileRequest())
+	require.NoError(t, err)
+	slices := listEndpointSlices(t, c)
+	require.Len(t, slices, 1)
+
+	// Manually create a second "stale" EndpointSlice (simulates a previously valid network
+	// that no longer exists in GatewayConfiguration — e.g., IPv6 subnet removed)
+	staleSlice := slices[0].DeepCopy()
+	staleSlice.Name = "stale-slice"
+	staleSlice.ResourceVersion = ""
+	staleSlice.Labels[labelNetworkSubnet] = encodeCIDRForLabel("2001:db8:100::/64")
+	require.NoError(t, c.Create(context.Background(), staleSlice))
+
+	// Verify 2 slices exist
+	slices = listEndpointSlices(t, c)
+	require.Len(t, slices, 2)
+
+	// Third reconcile: stale slice should be deleted via reconcileSlices (not step 4)
+	_, err = r.Reconcile(context.Background(), reconcileRequest())
+	require.NoError(t, err)
+
+	slices = listEndpointSlices(t, c)
+	assert.Len(t, slices, 1, "Stale slice should be deleted, valid slice kept")
+	assert.NotEqual(t, "stale-slice", slices[0].Name)
+}
+
 func TestReconcile_CapacityExceededConditionRemovedOnRecovery(t *testing.T) {
 	dg := newDG(func(dg *meridio2v1alpha1.DistributionGroup) {
 		dg.Spec.Maglev.MaxEndpoints = 1
@@ -655,8 +788,8 @@ func TestReconcile_CapacityExceededConditionRemovedOnRecovery(t *testing.T) {
 	gw := newGateway(true)
 	gwConfig := newGatewayConfig()
 	route := newL34Route(testGatewayName, testDGName)
-	pod1 := newPod("pod-1", "192.168.100.10", true)
-	pod2 := newPod("pod-2", "192.168.100.11", true)
+	pod1 := newPod("pod-1", true, "192.168.100.10")
+	pod2 := newPod("pod-2", true, "192.168.100.11")
 
 	r, c := setupReconciler(dg, gw, gwConfig, route, pod1, pod2)
 
@@ -686,7 +819,7 @@ func TestReconcile_NoNetworkContext(t *testing.T) {
 	gwConfig := newGatewayConfig()
 	gwConfig.Spec.InternalSubnets = nil // no internal subnets
 	route := newL34Route(testGatewayName, testDGName)
-	pod := newPod("pod-1", "192.168.100.10", true)
+	pod := newPod("pod-1", true, "192.168.100.10")
 
 	r, c := setupReconciler(dg, gw, gwConfig, route, pod)
 	_, err := r.Reconcile(context.Background(), reconcileRequest())
@@ -717,7 +850,7 @@ func TestReconcile_EndpointSliceModifiedExternally(t *testing.T) {
 	gw := newGateway(true)
 	gwConfig := newGatewayConfig()
 	route := newL34Route(testGatewayName, testDGName)
-	pod := newPod("pod-1", "192.168.100.10", true)
+	pod := newPod("pod-1", true, "192.168.100.10")
 
 	r, c := setupReconciler(dg, gw, gwConfig, route, pod)
 

--- a/internal/controller/distributiongroup/gateways.go
+++ b/internal/controller/distributiongroup/gateways.go
@@ -137,9 +137,9 @@ func (r *DistributionGroupReconciler) isGatewayAccepted(gw *gatewayv1.Gateway) b
 
 // getNetworkContexts extracts network context from GatewayConfigurations
 // Returns map: subnet CIDR → attachment type (NAD/DRA)
-func (r *DistributionGroupReconciler) getNetworkContexts(ctx context.Context, gateways []gatewayv1.Gateway) (map[string]string, error) {
+func (r *DistributionGroupReconciler) getNetworkContexts(ctx context.Context, gateways []gatewayv1.Gateway) ([]gatewayNetworkContext, error) {
 	logger := log.FromContext(ctx)
-	networkContexts := make(map[string]string)
+	result := make([]gatewayNetworkContext, 0, len(gateways))
 
 	for _, gw := range gateways {
 		if gw.Spec.Infrastructure == nil || gw.Spec.Infrastructure.ParametersRef == nil {
@@ -156,16 +156,23 @@ func (r *DistributionGroupReconciler) getNetworkContexts(ctx context.Context, ga
 			return nil, client.IgnoreNotFound(err)
 		}
 
-		// Extract subnet CIDRs with their attachment types
+		networks := make(map[string]string, len(gwConfig.Spec.InternalSubnets))
 		for _, subnet := range gwConfig.Spec.InternalSubnets {
 			normalized, err := normalizeCIDR(subnet.CIDR)
 			if err != nil {
 				logger.Info("Skipping invalid CIDR in GatewayConfiguration", "gateway", gw.Name, "gwconfig", gwConfig.Name, "cidr", subnet.CIDR, "error", err)
 				continue
 			}
-			networkContexts[normalized] = subnet.AttachmentType
+			networks[normalized] = subnet.AttachmentType
+		}
+
+		if len(networks) > 0 {
+			result = append(result, gatewayNetworkContext{
+				gateway:  client.ObjectKeyFromObject(&gw),
+				networks: networks,
+			})
 		}
 	}
 
-	return networkContexts, nil
+	return result, nil
 }

--- a/internal/controller/distributiongroup/helpers.go
+++ b/internal/controller/distributiongroup/helpers.go
@@ -23,17 +23,17 @@ import (
 	"sort"
 	"strings"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
 )
 
 // sortPodsByCreationTime sorts Pods by CreationTimestamp, tiebreak by namespace/name
-func sortPodsByCreationTime(podsWithIP []podWithNetworkIP) {
-	sort.Slice(podsWithIP, func(i, j int) bool {
-		pi, pj := &podsWithIP[i].pod, &podsWithIP[j].pod
-		if pi.CreationTimestamp.Equal(&pj.CreationTimestamp) {
-			return pi.Namespace+"/"+pi.Name < pj.Namespace+"/"+pj.Name
+func sortPodsByCreationTime(pods []corev1.Pod) {
+	sort.Slice(pods, func(i, j int) bool {
+		if pods[i].CreationTimestamp.Equal(&pods[j].CreationTimestamp) {
+			return pods[i].Namespace+"/"+pods[i].Name < pods[j].Namespace+"/"+pods[j].Name
 		}
-		return pi.CreationTimestamp.Before(&pj.CreationTimestamp)
+		return pods[i].CreationTimestamp.Before(&pods[j].CreationTimestamp)
 	})
 }
 

--- a/internal/controller/distributiongroup/helpers_test.go
+++ b/internal/controller/distributiongroup/helpers_test.go
@@ -176,37 +176,37 @@ func TestSortPodsByCreationTime(t *testing.T) {
 	earlier := metav1.NewTime(now.Add(-60000000000))
 	later := metav1.NewTime(now.Add(60000000000))
 
-	pods := []podWithNetworkIP{
-		{pod: corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-c", Namespace: "ns", CreationTimestamp: now}}, ip: "10.0.0.3"},
-		{pod: corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-a", Namespace: "ns", CreationTimestamp: earlier}}, ip: "10.0.0.1"},
-		{pod: corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-b", Namespace: "ns", CreationTimestamp: later}}, ip: "10.0.0.2"},
+	pods := []corev1.Pod{
+		{ObjectMeta: metav1.ObjectMeta{Name: "pod-c", Namespace: "ns", CreationTimestamp: now}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "pod-a", Namespace: "ns", CreationTimestamp: earlier}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "pod-b", Namespace: "ns", CreationTimestamp: later}},
 	}
 
 	sortPodsByCreationTime(pods)
 
-	if pods[0].pod.Name != "pod-a" || pods[1].pod.Name != "pod-c" || pods[2].pod.Name != "pod-b" {
-		t.Errorf("Sort order incorrect: got %v, %v, %v", pods[0].pod.Name, pods[1].pod.Name, pods[2].pod.Name)
+	if pods[0].Name != "pod-a" || pods[1].Name != "pod-c" || pods[2].Name != "pod-b" {
+		t.Errorf("Sort order incorrect: got %v, %v, %v", pods[0].Name, pods[1].Name, pods[2].Name)
 	}
 }
 
 func TestSortPodsByCreationTime_Tiebreak(t *testing.T) {
 	now := metav1.Now()
 
-	pods := []podWithNetworkIP{
-		{pod: corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-z", Namespace: "ns-b", CreationTimestamp: now}}, ip: "10.0.0.3"},
-		{pod: corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-a", Namespace: "ns-a", CreationTimestamp: now}}, ip: "10.0.0.1"},
-		{pod: corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-b", Namespace: "ns-a", CreationTimestamp: now}}, ip: "10.0.0.2"},
+	pods := []corev1.Pod{
+		{ObjectMeta: metav1.ObjectMeta{Name: "pod-z", Namespace: "ns-b", CreationTimestamp: now}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "pod-a", Namespace: "ns-a", CreationTimestamp: now}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "pod-b", Namespace: "ns-a", CreationTimestamp: now}},
 	}
 
 	sortPodsByCreationTime(pods)
 
-	if pods[0].pod.Namespace+"/"+pods[0].pod.Name != "ns-a/pod-a" {
-		t.Errorf("First pod should be ns-a/pod-a, got %s/%s", pods[0].pod.Namespace, pods[0].pod.Name)
+	if pods[0].Namespace+"/"+pods[0].Name != "ns-a/pod-a" {
+		t.Errorf("First pod should be ns-a/pod-a, got %s/%s", pods[0].Namespace, pods[0].Name)
 	}
-	if pods[1].pod.Namespace+"/"+pods[1].pod.Name != "ns-a/pod-b" {
-		t.Errorf("Second pod should be ns-a/pod-b, got %s/%s", pods[1].pod.Namespace, pods[1].pod.Name)
+	if pods[1].Namespace+"/"+pods[1].Name != "ns-a/pod-b" {
+		t.Errorf("Second pod should be ns-a/pod-b, got %s/%s", pods[1].Namespace, pods[1].Name)
 	}
-	if pods[2].pod.Namespace+"/"+pods[2].pod.Name != "ns-b/pod-z" {
-		t.Errorf("Third pod should be ns-b/pod-z, got %s/%s", pods[2].pod.Namespace, pods[2].pod.Name)
+	if pods[2].Namespace+"/"+pods[2].Name != "ns-b/pod-z" {
+		t.Errorf("Third pod should be ns-b/pod-z, got %s/%s", pods[2].Namespace, pods[2].Name)
 	}
 }

--- a/internal/controller/distributiongroup/maglev.go
+++ b/internal/controller/distributiongroup/maglev.go
@@ -20,22 +20,27 @@ import (
 	"strconv"
 	"strings"
 
+	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 )
 
-// assignMaglevIDs assigns stable Maglev IDs to Pods for a specific network
-func assignMaglevIDs(podsWithIP []podWithNetworkIP, existingAssignments map[string]int32, maxEndpoints int32) map[string]int32 {
-	podToID := make(map[string]int32)
-	usedIDs := make(map[int32]bool)
-	var newPods []podWithNetworkIP
+// assignMaglevIDs assigns stable Maglev IDs to Pods.
+// IDs are preserved for Pods with existing assignments; new Pods are sorted
+// by CreationTimestamp and assigned from the available pool.
+func assignMaglevIDs(pods []corev1.Pod, existingAssignments map[string]int32, maxEndpoints int32) map[string]int32 {
+	capacity := min(int32(len(pods)), maxEndpoints)
+	podToID := make(map[string]int32, capacity)
+	usedIDs := make(map[int32]bool, capacity)
+	newPods := make([]corev1.Pod, 0, len(pods))
 
-	// Preserve existing assignments
-	for _, pwip := range podsWithIP {
-		if id, exists := existingAssignments[string(pwip.pod.UID)]; exists {
-			podToID[string(pwip.pod.UID)] = id
+	// Preserve existing assignments (ignore out-of-range IDs)
+	for i := range pods {
+		uid := string(pods[i].UID)
+		if id, exists := existingAssignments[uid]; exists && id >= 0 && id < maxEndpoints {
+			podToID[uid] = id
 			usedIDs[id] = true
 		} else {
-			newPods = append(newPods, pwip)
+			newPods = append(newPods, pods[i])
 		}
 	}
 
@@ -51,11 +56,11 @@ func assignMaglevIDs(podsWithIP []podWithNetworkIP, existingAssignments map[stri
 	}
 
 	// Assign IDs to new Pods from available pool
-	for i, pwip := range newPods {
+	for i := range newPods {
 		if i >= len(availableIDs) {
 			break // Capacity exceeded
 		}
-		podToID[string(pwip.pod.UID)] = availableIDs[i]
+		podToID[string(newPods[i].UID)] = availableIDs[i]
 	}
 
 	return podToID

--- a/internal/controller/distributiongroup/maglev_test.go
+++ b/internal/controller/distributiongroup/maglev_test.go
@@ -84,11 +84,11 @@ func TestExtractMaglevAssignments(t *testing.T) {
 		{
 			Endpoints: []discoveryv1.Endpoint{
 				{
-					TargetRef: &corev1.ObjectReference{Kind: "Pod", UID: types.UID("pod-1")},
+					TargetRef: &corev1.ObjectReference{Kind: kindPod, UID: types.UID("pod-1")},
 					Zone:      ptr(maglevIDPrefix + "5"),
 				},
 				{
-					TargetRef: &corev1.ObjectReference{Kind: "Pod", UID: types.UID("pod-2")},
+					TargetRef: &corev1.ObjectReference{Kind: kindPod, UID: types.UID("pod-2")},
 					Zone:      ptr(maglevIDPrefix + "10"),
 				},
 			},
@@ -111,9 +111,9 @@ func TestExtractMaglevAssignments_SkipInvalid(t *testing.T) {
 			Endpoints: []discoveryv1.Endpoint{
 				{TargetRef: nil, Zone: ptr(maglevIDPrefix + "5")},
 				{TargetRef: &corev1.ObjectReference{Kind: "Service", UID: "svc-1"}, Zone: ptr(maglevIDPrefix + "10")},
-				{TargetRef: &corev1.ObjectReference{Kind: "Pod", UID: "pod-1"}, Zone: ptr("invalid")},
-				{TargetRef: &corev1.ObjectReference{Kind: "Pod", UID: "pod-2"}, Zone: ptr(maglevIDPrefix + "abc")},
-				{TargetRef: &corev1.ObjectReference{Kind: "Pod", UID: "pod-3"}, Zone: ptr(maglevIDPrefix + "15")},
+				{TargetRef: &corev1.ObjectReference{Kind: kindPod, UID: "pod-1"}, Zone: ptr("invalid")},
+				{TargetRef: &corev1.ObjectReference{Kind: kindPod, UID: "pod-2"}, Zone: ptr(maglevIDPrefix + "abc")},
+				{TargetRef: &corev1.ObjectReference{Kind: kindPod, UID: "pod-3"}, Zone: ptr(maglevIDPrefix + "15")},
 			},
 		},
 	}

--- a/internal/controller/distributiongroup/maglev_test.go
+++ b/internal/controller/distributiongroup/maglev_test.go
@@ -27,10 +27,10 @@ import (
 )
 
 func TestAssignMaglevIDs_NewPods(t *testing.T) {
-	pods := []podWithNetworkIP{
-		{pod: corev1.Pod{ObjectMeta: metav1.ObjectMeta{UID: "pod-1"}}, ip: "10.0.0.1"},
-		{pod: corev1.Pod{ObjectMeta: metav1.ObjectMeta{UID: "pod-2"}}, ip: "10.0.0.2"},
-		{pod: corev1.Pod{ObjectMeta: metav1.ObjectMeta{UID: "pod-3"}}, ip: "10.0.0.3"},
+	pods := []corev1.Pod{
+		{ObjectMeta: metav1.ObjectMeta{UID: "pod-1"}},
+		{ObjectMeta: metav1.ObjectMeta{UID: "pod-2"}},
+		{ObjectMeta: metav1.ObjectMeta{UID: "pod-3"}},
 	}
 
 	result := assignMaglevIDs(pods, nil, 32)
@@ -49,10 +49,10 @@ func TestAssignMaglevIDs_PreserveExisting(t *testing.T) {
 		"pod-2": 10,
 	}
 
-	pods := []podWithNetworkIP{
-		{pod: corev1.Pod{ObjectMeta: metav1.ObjectMeta{UID: "pod-1"}}, ip: "10.0.0.1"},
-		{pod: corev1.Pod{ObjectMeta: metav1.ObjectMeta{UID: "pod-2"}}, ip: "10.0.0.2"},
-		{pod: corev1.Pod{ObjectMeta: metav1.ObjectMeta{UID: "pod-3"}}, ip: "10.0.0.3"},
+	pods := []corev1.Pod{
+		{ObjectMeta: metav1.ObjectMeta{UID: "pod-1"}},
+		{ObjectMeta: metav1.ObjectMeta{UID: "pod-2"}},
+		{ObjectMeta: metav1.ObjectMeta{UID: "pod-3"}},
 	}
 
 	result := assignMaglevIDs(pods, existing, 32)
@@ -66,10 +66,10 @@ func TestAssignMaglevIDs_PreserveExisting(t *testing.T) {
 }
 
 func TestAssignMaglevIDs_CapacityLimit(t *testing.T) {
-	pods := []podWithNetworkIP{
-		{pod: corev1.Pod{ObjectMeta: metav1.ObjectMeta{UID: "pod-1"}}, ip: "10.0.0.1"},
-		{pod: corev1.Pod{ObjectMeta: metav1.ObjectMeta{UID: "pod-2"}}, ip: "10.0.0.2"},
-		{pod: corev1.Pod{ObjectMeta: metav1.ObjectMeta{UID: "pod-3"}}, ip: "10.0.0.3"},
+	pods := []corev1.Pod{
+		{ObjectMeta: metav1.ObjectMeta{UID: "pod-1"}},
+		{ObjectMeta: metav1.ObjectMeta{UID: "pod-2"}},
+		{ObjectMeta: metav1.ObjectMeta{UID: "pod-3"}},
 	}
 
 	result := assignMaglevIDs(pods, nil, 2)
@@ -136,16 +136,14 @@ func TestAssignMaglevIDs_CapacityEnforcement(t *testing.T) {
 	}
 
 	// 33 total Pods (32 existing + 1 new)
-	pods := make([]podWithNetworkIP, 33)
+	pods := make([]corev1.Pod, 33)
 	for i := range 32 {
-		pods[i] = podWithNetworkIP{
-			pod: corev1.Pod{ObjectMeta: metav1.ObjectMeta{UID: types.UID("pod-" + strconv.Itoa(i))}},
-			ip:  "10.0.0." + strconv.Itoa(i),
+		pods[i] = corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{UID: types.UID("pod-" + strconv.Itoa(i))},
 		}
 	}
-	pods[32] = podWithNetworkIP{
-		pod: corev1.Pod{ObjectMeta: metav1.ObjectMeta{UID: "pod-new"}},
-		ip:  "10.0.0.33",
+	pods[32] = corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{UID: "pod-new"},
 	}
 
 	result := assignMaglevIDs(pods, existing, 32)

--- a/internal/controller/distributiongroup/routes_test.go
+++ b/internal/controller/distributiongroup/routes_test.go
@@ -17,10 +17,16 @@ limitations under the License.
 package distributiongroup
 
 import (
+	"context"
 	"testing"
 
 	meridio2v1alpha1 "github.com/nordix/meridio-2/api/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
@@ -227,4 +233,90 @@ func TestBackendRefMatchesDG_DefaultGroupKind(t *testing.T) {
 	if backendRefMatchesDG(backendRef, "default", dgKey) {
 		t.Error("Expected no match (defaults to Service, not DistributionGroup)")
 	}
+}
+
+func TestFindDGsReferencingGateways_DirectAndIndirect(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, meridio2v1alpha1.AddToScheme(scheme))
+	require.NoError(t, gatewayv1.Install(scheme))
+
+	gwGroup := gatewayv1.GroupName
+	gwKind := kindGateway
+	dgGroup := meridio2v1alpha1.GroupVersion.Group
+	dgKind := kindDistributionGroup
+
+	// DG with direct parentRef to gw-1
+	dgDirect := &meridio2v1alpha1.DistributionGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "dg-direct", Namespace: "default"},
+		Spec: meridio2v1alpha1.DistributionGroupSpec{
+			ParentRefs: []meridio2v1alpha1.ParentReference{
+				{Group: &gwGroup, Kind: &gwKind, Name: "gw-1"},
+			},
+		},
+	}
+
+	// DG with no parentRef (indirect only via L34Route)
+	dgIndirect := &meridio2v1alpha1.DistributionGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "dg-indirect", Namespace: "default"},
+		Spec:       meridio2v1alpha1.DistributionGroupSpec{},
+	}
+
+	// DG referencing a different Gateway (should NOT be returned)
+	dgOther := &meridio2v1alpha1.DistributionGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "dg-other", Namespace: "default"},
+		Spec: meridio2v1alpha1.DistributionGroupSpec{
+			ParentRefs: []meridio2v1alpha1.ParentReference{
+				{Group: &gwGroup, Kind: &gwKind, Name: "gw-other"},
+			},
+		},
+	}
+
+	// L34Route linking gw-1 → dg-indirect
+	route := &meridio2v1alpha1.L34Route{
+		ObjectMeta: metav1.ObjectMeta{Name: "route-1", Namespace: "default"},
+		Spec: meridio2v1alpha1.L34RouteSpec{
+			ParentRefs: []gatewayv1.ParentReference{
+				{Name: "gw-1"},
+			},
+			BackendRefs: []gatewayv1.BackendRef{
+				{BackendObjectReference: gatewayv1.BackendObjectReference{
+					Group: (*gatewayv1.Group)(&dgGroup),
+					Kind:  (*gatewayv1.Kind)(&dgKind),
+					Name:  "dg-indirect",
+				}},
+			},
+			DestinationCIDRs: []string{"20.0.0.1/32"},
+			Protocols:        []meridio2v1alpha1.TransportProtocol{meridio2v1alpha1.TCP},
+			Priority:         1,
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(dgDirect, dgIndirect, dgOther, route).Build()
+
+	r := &DistributionGroupReconciler{
+		Client:    c,
+		Namespace: "default",
+	}
+
+	requests := r.findDGsReferencingGateways(context.Background(), []client.ObjectKey{
+		{Namespace: "default", Name: "gw-1"},
+	})
+
+	// Should find both dg-direct (parentRef) and dg-indirect (via L34Route)
+	names := make(map[string]bool)
+	for _, req := range requests {
+		names[req.Name] = true
+	}
+
+	assert.True(t, names["dg-direct"], "dg-direct should be found (direct parentRef)")
+	assert.True(t, names["dg-indirect"], "dg-indirect should be found (indirect via L34Route)")
+	assert.False(t, names["dg-other"], "dg-other should NOT be found (references different Gateway)")
+	assert.Len(t, requests, 2)
+}
+
+func TestFindDGsReferencingGateways_EmptyInput(t *testing.T) {
+	r := &DistributionGroupReconciler{}
+	requests := r.findDGsReferencingGateways(context.Background(), nil)
+	assert.Nil(t, requests)
 }

--- a/internal/controller/distributiongroup/slices.go
+++ b/internal/controller/distributiongroup/slices.go
@@ -18,6 +18,7 @@ package distributiongroup
 
 import (
 	"context"
+	"maps"
 	"net"
 	"sort"
 	"strconv"
@@ -46,6 +47,11 @@ func (r *DistributionGroupReconciler) listOwnedSlices(ctx context.Context, dg *m
 		}
 	}
 
+	// Sort by name for deterministic processing order (cache List does not guarantee order)
+	sort.Slice(owned, func(i, j int) bool {
+		return owned[i].Name < owned[j].Name
+	})
+
 	return owned, nil
 }
 
@@ -66,77 +72,108 @@ func (r *DistributionGroupReconciler) deleteAllOwnedSlices(ctx context.Context, 
 }
 
 // calculateDesiredSlices computes the desired EndpointSlices
-func (r *DistributionGroupReconciler) calculateDesiredSlices(ctx context.Context, dg *meridio2v1alpha1.DistributionGroup, pods []corev1.Pod, networkContexts map[string]string, existingSlices []discoveryv1.EndpointSlice) ([]discoveryv1.EndpointSlice, *maglevCapacityInfo) {
-	if len(networkContexts) == 0 {
+func (r *DistributionGroupReconciler) calculateDesiredSlices(ctx context.Context, dg *meridio2v1alpha1.DistributionGroup, pods []corev1.Pod, gwContexts []gatewayNetworkContext, existingSlices []discoveryv1.EndpointSlice) ([]discoveryv1.EndpointSlice, *maglevCapacityInfo) {
+	if len(gwContexts) == 0 {
 		return nil, nil
 	}
 
-	// Group existing slices by network once (O(M) instead of O(N×M))
 	slicesByNetwork := groupSlicesByNetwork(ctx, existingSlices)
 
-	// Filter Pods per network (common for all DG types)
-	podsByNetwork := make(map[string][]podWithNetworkIP)
-	for cidr, attachmentType := range networkContexts {
-		podsWithIP := r.filterPodsWithNetworkContextIP(pods, cidr, attachmentType)
-		if len(podsWithIP) > 0 {
-			podsByNetwork[cidr] = podsWithIP
+	var allDesiredSlices []discoveryv1.EndpointSlice
+	var capacityInfo *maglevCapacityInfo
+
+	// Process each Gateway independently (scopes Maglev allocation per Gateway).
+	// Currently iterates once due to single-Gateway enforcement; the loop structure
+	// is intentional to keep multi-Gateway extensibility open. Supporting multiple
+	// Gateways per DG with the current EndpointSlice model would be problematic:
+	// Gateways sharing the same internal network would reference the same slices,
+	// causing per-Gateway iterations to interfere (conflicting ID assignments and
+	// updates on shared input). Clean endpoint representation separation between
+	// Gateways is required first.
+	for _, gwCtx := range gwContexts {
+		// Filter Pods per network for this Gateway
+		podsByNetwork := make(map[string][]podWithNetworkIP)
+		for cidr, attachmentType := range gwCtx.networks {
+			podsWithIP := r.filterPodsWithNetworkContextIP(pods, cidr, attachmentType)
+			if len(podsWithIP) > 0 {
+				podsByNetwork[cidr] = podsWithIP
+			}
+		}
+		if len(podsByNetwork) == 0 {
+			continue
+		}
+
+		if dg.Spec.Type == meridio2v1alpha1.DistributionGroupTypeMaglev {
+			slices, cap := r.calculateMaglevSlices(dg, podsByNetwork, slicesByNetwork)
+			allDesiredSlices = append(allDesiredSlices, slices...)
+			capacityInfo = cap
+		} else {
+			// Non-Maglev: no capacity restrictions, no stable IDs
+			for cidr, podsWithIP := range podsByNetwork {
+				slices := createSlicesForNetwork(dg, podsWithIP, nil, cidr, slicesByNetwork[cidr])
+				allDesiredSlices = append(allDesiredSlices, slices...)
+			}
 		}
 	}
 
-	// Early exit if no Pods have IPs in any network
-	if len(podsByNetwork) == 0 {
-		return nil, nil
-	}
-
-	// Maglev-specific assignment logic
-	if dg.Spec.Type == meridio2v1alpha1.DistributionGroupTypeMaglev {
-		return r.calculateMaglevSlices(dg, podsByNetwork, slicesByNetwork)
-	}
-
-	// Non-Maglev: no capacity restrictions, no stable IDs
-	var desiredSlices []discoveryv1.EndpointSlice
-	for cidr, podsWithIP := range podsByNetwork {
-		existingForNetwork := slicesByNetwork[cidr]
-		slices := createSlicesForNetwork(dg, podsWithIP, nil, cidr, existingForNetwork)
-		desiredSlices = append(desiredSlices, slices...)
-	}
-	return desiredSlices, nil
+	return allDesiredSlices, capacityInfo
 }
 
-// calculateMaglevSlices handles Maglev-specific endpoint assignment with stable IDs
+// calculateMaglevSlices handles Maglev-specific endpoint assignment with stable IDs.
+// IDs are assigned per Pod UID across all networks within a single Gateway (not per-network).
 func (r *DistributionGroupReconciler) calculateMaglevSlices(dg *meridio2v1alpha1.DistributionGroup, podsByNetwork map[string][]podWithNetworkIP, slicesByNetwork map[string][]discoveryv1.EndpointSlice) ([]discoveryv1.EndpointSlice, *maglevCapacityInfo) {
-	// Determine maxEndpoints (default to 32 if MaglevConfig is nil or MaxEndpoints is 0)
 	maxEndpoints := meridio2v1alpha1.DefaultMaglevMaxEndpoints
 	if dg.Spec.Maglev != nil && dg.Spec.Maglev.MaxEndpoints > 0 {
 		maxEndpoints = dg.Spec.Maglev.MaxEndpoints
 	}
 
-	var desiredSlices []discoveryv1.EndpointSlice
+	// Merge Pods across this Gateway's networks by UID. A Pod appearing in
+	// multiple subnets (dual-stack) is counted once.
+	// Use the largest network's Pod count as capacity hint (in dual-stack,
+	// most Pods appear in all networks so the largest is a good estimate).
+	var estimatedPods int
+	for _, podsWithIP := range podsByNetwork {
+		if len(podsWithIP) > estimatedPods {
+			estimatedPods = len(podsWithIP)
+		}
+	}
+	seen := make(map[string]bool, estimatedPods)
+	allPods := make([]corev1.Pod, 0, estimatedPods)
+	for _, podsWithIP := range podsByNetwork {
+		for _, p := range podsWithIP {
+			if uid := string(p.pod.UID); !seen[uid] {
+				seen[uid] = true
+				allPods = append(allPods, p.pod)
+			}
+		}
+	}
+
+	// Extract existing Pod→ID assignments from all network slices (merged view).
+	// All slices are expected to have consistent IDs for the same Pod UID,
+	// so iteration order over slicesByNetwork does not affect the result.
+	existingAssignments := make(map[string]int32)
+	for _, slices := range slicesByNetwork {
+		maps.Copy(existingAssignments, extractMaglevAssignments(slices))
+	}
+
+	// Assign Maglev IDs once on the merged Pod set
+	podToID := assignMaglevIDs(allPods, existingAssignments, maxEndpoints)
+
+	// Track capacity based on merged set
 	capacityInfo := &maglevCapacityInfo{
 		networkIssues: make(map[string]struct{ excluded, total int32 }),
 	}
-
-	for cidr, podsWithIP := range podsByNetwork {
-		existingForNetwork := slicesByNetwork[cidr]
-
-		// Extract existing Pod→ID assignments for this network
-		existingAssignments := extractMaglevAssignments(existingForNetwork)
-
-		// Assign Maglev IDs for this network context
-		podToID := assignMaglevIDs(podsWithIP, existingAssignments, maxEndpoints)
-
-		// Track capacity issues
-		total := int32(len(podsWithIP))
-		assigned := int32(len(podToID))
-		if assigned < total {
-			capacityInfo.networkIssues[cidr] = struct{ excluded, total int32 }{
-				excluded: total - assigned,
-				total:    total,
-			}
+	if total := int32(len(allPods)); int32(len(podToID)) < total {
+		capacityInfo.networkIssues["all"] = struct{ excluded, total int32 }{
+			excluded: total - int32(len(podToID)),
+			total:    total,
 		}
+	}
 
-		// Create slices for this network
-		slices := createSlicesForNetwork(dg, podsWithIP, podToID, cidr, existingForNetwork)
+	// Distribute shared IDs to per-network slices
+	desiredSlices := make([]discoveryv1.EndpointSlice, 0, len(podsByNetwork))
+	for cidr, podsWithIP := range podsByNetwork {
+		slices := createSlicesForNetwork(dg, podsWithIP, podToID, cidr, slicesByNetwork[cidr])
 		desiredSlices = append(desiredSlices, slices...)
 	}
 
@@ -306,7 +343,7 @@ func createSlicesForNetwork(dg *meridio2v1alpha1.DistributionGroup, podsWithIP [
 		return remainingEndpoints[i].TargetRef.UID < remainingEndpoints[j].TargetRef.UID
 	})
 
-	// Fill remaining capacity in existing slices
+	// Fill remaining capacity in existing slices with new endpoints.
 	for i := range slices {
 		capacity := maxEndpointsPerSlice - len(slices[i].endpoints)
 		if capacity > 0 && len(remainingEndpoints) > 0 {
@@ -315,6 +352,36 @@ func createSlicesForNetwork(dg *meridio2v1alpha1.DistributionGroup, podsWithIP [
 			remainingEndpoints = remainingEndpoints[toAdd:]
 		}
 	}
+
+	// Compact: move endpoints from later slices into earlier slices with free capacity.
+	// This prevents fragmentation after scale-in (mirrors core EndpointSlice controller behavior).
+	for i := 0; i < len(slices)-1; i++ {
+		capacity := maxEndpointsPerSlice - len(slices[i].endpoints)
+		if capacity <= 0 {
+			continue
+		}
+		for j := len(slices) - 1; j > i; j-- {
+			if len(slices[j].endpoints) == 0 {
+				continue
+			}
+			toMove := min(capacity, len(slices[j].endpoints))
+			slices[i].endpoints = append(slices[i].endpoints, slices[j].endpoints[:toMove]...)
+			slices[j].endpoints = slices[j].endpoints[toMove:]
+			capacity -= toMove
+			if capacity <= 0 {
+				break
+			}
+		}
+	}
+
+	// Remove empty slices after compaction
+	compacted := slices[:0]
+	for _, s := range slices {
+		if len(s.endpoints) > 0 {
+			compacted = append(compacted, s)
+		}
+	}
+	slices = compacted
 
 	// Create new slices for remaining endpoints
 	for len(remainingEndpoints) > 0 {

--- a/internal/controller/distributiongroup/slices_test.go
+++ b/internal/controller/distributiongroup/slices_test.go
@@ -182,6 +182,98 @@ func TestCalculateMaglevSlices_StableAcrossReconciles(t *testing.T) {
 	}
 }
 
+func TestCalculateMaglevSlices_AsymmetricNetworkPresence(t *testing.T) {
+	r := &DistributionGroupReconciler{}
+	dg := &meridio2v1alpha1.DistributionGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-dg", Namespace: "default"},
+		Spec: meridio2v1alpha1.DistributionGroupSpec{
+			Type:   meridio2v1alpha1.DistributionGroupTypeMaglev,
+			Maglev: &meridio2v1alpha1.MaglevConfig{MaxEndpoints: 32},
+		},
+	}
+
+	// Pod-1 and Pod-2 are dual-stack, Pod-3 is IPv4 only, Pod-4 is IPv6 only
+	podsByNetwork := map[string][]podWithNetworkIP{
+		"192.168.100.0/24": {
+			{pod: corev1.Pod{ObjectMeta: metav1.ObjectMeta{UID: "uid-1", Name: "pod-1"}}, ip: "192.168.100.10"},
+			{pod: corev1.Pod{ObjectMeta: metav1.ObjectMeta{UID: "uid-2", Name: "pod-2"}}, ip: "192.168.100.11"},
+			{pod: corev1.Pod{ObjectMeta: metav1.ObjectMeta{UID: "uid-3", Name: "pod-3"}}, ip: "192.168.100.12"},
+		},
+		"2001:db8:100::/64": {
+			{pod: corev1.Pod{ObjectMeta: metav1.ObjectMeta{UID: "uid-1", Name: "pod-1"}}, ip: "2001:db8:100::10"},
+			{pod: corev1.Pod{ObjectMeta: metav1.ObjectMeta{UID: "uid-2", Name: "pod-2"}}, ip: "2001:db8:100::11"},
+			{pod: corev1.Pod{ObjectMeta: metav1.ObjectMeta{UID: "uid-4", Name: "pod-4"}}, ip: "2001:db8:100::14"},
+		},
+	}
+
+	slices, _ := r.calculateMaglevSlices(dg, podsByNetwork, nil)
+
+	// Should produce 2 slices (one per network)
+	if len(slices) != 2 {
+		t.Fatalf("Expected 2 slices, got %d", len(slices))
+	}
+
+	// Extract per-network endpoints
+	endpointsByNetwork := make(map[string]map[string]string) // CIDR → uid → zone
+	for _, slice := range slices {
+		network := decodeCIDRFromLabel(slice.Labels[labelNetworkSubnet])
+		if endpointsByNetwork[network] == nil {
+			endpointsByNetwork[network] = make(map[string]string)
+		}
+		for _, ep := range slice.Endpoints {
+			if ep.TargetRef != nil && ep.Zone != nil {
+				endpointsByNetwork[network][string(ep.TargetRef.UID)] = *ep.Zone
+			}
+		}
+	}
+
+	ipv4, ok := endpointsByNetwork["192.168.100.0/24"]
+	if !ok {
+		t.Fatal("Expected IPv4 slice for 192.168.100.0/24")
+	}
+	ipv6, ok := endpointsByNetwork["2001:db8:100::/64"]
+	if !ok {
+		t.Fatal("Expected IPv6 slice for 2001:db8:100::/64")
+	}
+
+	// Pod-3 (IPv4 only): present in IPv4, absent from IPv6
+	if _, exists := ipv4["uid-3"]; !exists {
+		t.Error("Pod-3 should be in IPv4 slice")
+	}
+	if _, exists := ipv6["uid-3"]; exists {
+		t.Error("Pod-3 should NOT be in IPv6 slice")
+	}
+
+	// Pod-4 (IPv6 only): absent from IPv4, present in IPv6
+	if _, exists := ipv4["uid-4"]; exists {
+		t.Error("Pod-4 should NOT be in IPv4 slice")
+	}
+	if _, exists := ipv6["uid-4"]; !exists {
+		t.Error("Pod-4 should be in IPv6 slice")
+	}
+
+	// Dual-stack Pods: same ID across both slices
+	for _, uid := range []string{"uid-1", "uid-2"} {
+		if ipv4[uid] != ipv6[uid] {
+			t.Errorf("Dual-stack pod %s has different IDs: IPv4=%s, IPv6=%s", uid, ipv4[uid], ipv6[uid])
+		}
+	}
+
+	// All 4 Pods get unique IDs (no collision)
+	allIDs := make(map[string]string) // zone → uid (first seen)
+	for _, endpoints := range endpointsByNetwork {
+		for uid, zone := range endpoints {
+			if prev, exists := allIDs[zone]; exists && prev != uid {
+				t.Errorf("ID collision: %s used by both %s and %s", zone, prev, uid)
+			}
+			allIDs[zone] = uid
+		}
+	}
+	if len(allIDs) != 4 {
+		t.Errorf("Expected 4 unique IDs, got %d", len(allIDs))
+	}
+}
+
 func TestCalculateMaglevSlices_PartialPodReplacement(t *testing.T) {
 	r := &DistributionGroupReconciler{}
 	dg := &meridio2v1alpha1.DistributionGroup{
@@ -339,6 +431,93 @@ func TestCreateSlicesForNetwork_MaglevCapacityEnforcement(t *testing.T) {
 				t.Error("pod-3 should be excluded (capacity exceeded)")
 			}
 		}
+	}
+}
+
+func TestCalculateMaglevSlices_CapacityExceededDualStack(t *testing.T) {
+	r := &DistributionGroupReconciler{}
+	dg := &meridio2v1alpha1.DistributionGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-dg", Namespace: "default"},
+		Spec: meridio2v1alpha1.DistributionGroupSpec{
+			Type:   meridio2v1alpha1.DistributionGroupTypeMaglev,
+			Maglev: &meridio2v1alpha1.MaglevConfig{MaxEndpoints: 4},
+		},
+	}
+
+	// 6 dual-stack Pods, capacity 4 — 2 should be excluded from BOTH slices
+	ipv4Pods := make([]podWithNetworkIP, 6)
+	ipv6Pods := make([]podWithNetworkIP, 6)
+	for i := range 6 {
+		uid := types.UID("uid-" + strconv.Itoa(i))
+		name := "pod-" + strconv.Itoa(i)
+		pod := corev1.Pod{ObjectMeta: metav1.ObjectMeta{UID: uid, Name: name, Namespace: "default"}}
+		ipv4Pods[i] = podWithNetworkIP{pod: pod, ip: "192.168.100." + strconv.Itoa(10+i)}
+		ipv6Pods[i] = podWithNetworkIP{pod: pod, ip: "2001:db8:100::" + strconv.Itoa(10+i)}
+	}
+
+	podsByNetwork := map[string][]podWithNetworkIP{
+		"192.168.100.0/24":  ipv4Pods,
+		"2001:db8:100::/64": ipv6Pods,
+	}
+
+	slices, capacityInfo := r.calculateMaglevSlices(dg, podsByNetwork, nil)
+
+	if capacityInfo == nil || len(capacityInfo.networkIssues) == 0 {
+		t.Fatal("Expected capacity exceeded info")
+	}
+
+	// Extract UIDs per network
+	uidsByNetwork := make(map[string]map[string]string)
+	for _, slice := range slices {
+		network := decodeCIDRFromLabel(slice.Labels[labelNetworkSubnet])
+		if uidsByNetwork[network] == nil {
+			uidsByNetwork[network] = make(map[string]string)
+		}
+		for _, ep := range slice.Endpoints {
+			if ep.TargetRef != nil && ep.Zone != nil {
+				uidsByNetwork[network][string(ep.TargetRef.UID)] = *ep.Zone
+			}
+		}
+	}
+
+	ipv4, ok := uidsByNetwork["192.168.100.0/24"]
+	if !ok {
+		t.Fatal("Expected IPv4 slice")
+	}
+	ipv6, ok := uidsByNetwork["2001:db8:100::/64"]
+	if !ok {
+		t.Fatal("Expected IPv6 slice")
+	}
+
+	// Exactly 4 Pods included in each slice
+	if len(ipv4) != 4 {
+		t.Errorf("Expected 4 endpoints in IPv4 slice, got %d", len(ipv4))
+	}
+	if len(ipv6) != 4 {
+		t.Errorf("Expected 4 endpoints in IPv6 slice, got %d", len(ipv6))
+	}
+
+	// Same Pods included in both slices (same set excluded from both)
+	for uid := range ipv4 {
+		if _, exists := ipv6[uid]; !exists {
+			t.Errorf("Pod %s included in IPv4 but excluded from IPv6", uid)
+		}
+	}
+
+	// Included Pods have consistent IDs across slices
+	for uid, v4Zone := range ipv4 {
+		if v6Zone := ipv6[uid]; v4Zone != v6Zone {
+			t.Errorf("Pod %s has different IDs: IPv4=%s, IPv6=%s", uid, v4Zone, v6Zone)
+		}
+	}
+
+	// All assigned IDs are unique
+	usedIDs := make(map[string]bool)
+	for _, zone := range ipv4 {
+		if usedIDs[zone] {
+			t.Errorf("Duplicate ID: %s", zone)
+		}
+		usedIDs[zone] = true
 	}
 }
 
@@ -723,5 +902,80 @@ func TestCreateSlicesForNetwork_CompactionPreservesFullSlices(t *testing.T) {
 	}
 	if len(slices[1].Endpoints) != 2 {
 		t.Errorf("Expected slice-1 to keep 2 endpoints, got %d", len(slices[1].Endpoints))
+	}
+}
+
+func TestCreateSlicesForNetwork_CompactionPreservesMaglevIDs(t *testing.T) {
+	r := &DistributionGroupReconciler{}
+	dg := &meridio2v1alpha1.DistributionGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-dg", Namespace: "default"},
+		Spec: meridio2v1alpha1.DistributionGroupSpec{
+			Type:   meridio2v1alpha1.DistributionGroupTypeMaglev,
+			Maglev: &meridio2v1alpha1.MaglevConfig{MaxEndpoints: 32},
+		},
+	}
+
+	zone0 := maglevIDPrefix + "0"
+	zone1 := maglevIDPrefix + "1"
+	zone2 := maglevIDPrefix + "2"
+	zone3 := maglevIDPrefix + "3"
+
+	// Two existing slices: slice-0 had [pod-0, pod-1, pod-2], slice-1 had [pod-3]
+	// After scale-in: pod-1 and pod-2 removed → slice-1's pod-3 should compact into slice-0
+	existingSlices := []discoveryv1.EndpointSlice{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "slice-0"},
+			Endpoints: []discoveryv1.Endpoint{
+				{TargetRef: &corev1.ObjectReference{Kind: kindPod, UID: "pod-0"}, Zone: &zone0},
+				{TargetRef: &corev1.ObjectReference{Kind: kindPod, UID: "pod-1"}, Zone: &zone1},
+				{TargetRef: &corev1.ObjectReference{Kind: kindPod, UID: "pod-2"}, Zone: &zone2},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "slice-1"},
+			Endpoints: []discoveryv1.Endpoint{
+				{TargetRef: &corev1.ObjectReference{Kind: kindPod, UID: "pod-3"}, Zone: &zone3},
+			},
+		},
+	}
+
+	// Only pod-0 and pod-3 remain
+	remainingPods := []podWithNetworkIP{
+		{pod: corev1.Pod{ObjectMeta: metav1.ObjectMeta{UID: "pod-0", Name: "pod-0"}}, ip: "10.0.0.1"},
+		{pod: corev1.Pod{ObjectMeta: metav1.ObjectMeta{UID: "pod-3", Name: "pod-3"}}, ip: "10.0.0.4"},
+	}
+
+	podsByNetwork := map[string][]podWithNetworkIP{"192.168.1.0/24": remainingPods}
+	slicesByNetwork := map[string][]discoveryv1.EndpointSlice{"192.168.1.0/24": existingSlices}
+
+	// Reconcile: compaction should merge into 1 slice
+	slices, _ := r.calculateMaglevSlices(dg, podsByNetwork, slicesByNetwork)
+
+	// Verify compaction occurred: 2 slices → 1 slice
+	if len(slices) != 1 {
+		t.Fatalf("Expected compaction to 1 slice, got %d", len(slices))
+	}
+	if len(slices[0].Endpoints) != 2 {
+		t.Fatalf("Expected 2 endpoints after compaction, got %d", len(slices[0].Endpoints))
+	}
+
+	// Verify IDs are preserved for surviving Pods
+	for _, ep := range slices[0].Endpoints {
+		if ep.TargetRef == nil || ep.Zone == nil {
+			t.Error("Endpoint missing targetRef or zone after compaction")
+			continue
+		}
+		switch string(ep.TargetRef.UID) {
+		case "pod-0":
+			if *ep.Zone != zone0 {
+				t.Errorf("pod-0 ID changed after compaction: expected %s, got %s", zone0, *ep.Zone)
+			}
+		case "pod-3":
+			if *ep.Zone != zone3 {
+				t.Errorf("pod-3 ID changed after compaction: expected %s, got %s", zone3, *ep.Zone)
+			}
+		default:
+			t.Errorf("Unexpected pod in compacted slice: %s", ep.TargetRef.UID)
+		}
 	}
 }

--- a/internal/controller/distributiongroup/slices_test.go
+++ b/internal/controller/distributiongroup/slices_test.go
@@ -18,6 +18,7 @@ package distributiongroup
 
 import (
 	"context"
+	"strconv"
 	"testing"
 
 	meridio2v1alpha1 "github.com/nordix/meridio-2/api/v1alpha1"
@@ -26,6 +27,260 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
+
+func TestCalculateMaglevSlices_SharedIDsAcrossNetworks(t *testing.T) {
+	r := &DistributionGroupReconciler{}
+	dg := &meridio2v1alpha1.DistributionGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-dg", Namespace: "default"},
+		Spec: meridio2v1alpha1.DistributionGroupSpec{
+			Type:   meridio2v1alpha1.DistributionGroupTypeMaglev,
+			Maglev: &meridio2v1alpha1.MaglevConfig{MaxEndpoints: 32},
+		},
+	}
+
+	// 32 Pods appear in both IPv4 and IPv6 networks (dual-stack)
+	ipv4Pods := make([]podWithNetworkIP, 32)
+	ipv6Pods := make([]podWithNetworkIP, 32)
+	for i := range 32 {
+		uid := types.UID("uid-" + strconv.Itoa(i))
+		name := "pod-" + strconv.Itoa(i)
+		pod := corev1.Pod{ObjectMeta: metav1.ObjectMeta{UID: uid, Name: name, Namespace: "default"}}
+		ipv4Pods[i] = podWithNetworkIP{pod: pod, ip: "192.168.100." + strconv.Itoa(10+i)}
+		ipv6Pods[i] = podWithNetworkIP{pod: pod, ip: "2001:db8:100::" + strconv.Itoa(10+i)}
+	}
+
+	podsByNetwork := map[string][]podWithNetworkIP{
+		"192.168.100.0/24":  ipv4Pods,
+		"2001:db8:100::/64": ipv6Pods,
+	}
+
+	slices, capacityInfo := r.calculateMaglevSlices(dg, podsByNetwork, nil)
+
+	// Should produce 2 slices (one per network)
+	if len(slices) != 2 {
+		t.Fatalf("Expected 2 slices (one per network), got %d", len(slices))
+	}
+
+	// Extract Pod UID → Maglev zone from each network's slice
+	idsByNetwork := make(map[string]map[string]string) // decoded CIDR → uid → zone
+	for _, slice := range slices {
+		network := decodeCIDRFromLabel(slice.Labels[labelNetworkSubnet])
+		if idsByNetwork[network] == nil {
+			idsByNetwork[network] = make(map[string]string)
+		}
+		for _, ep := range slice.Endpoints {
+			if ep.TargetRef != nil && ep.Zone != nil {
+				idsByNetwork[network][string(ep.TargetRef.UID)] = *ep.Zone
+			}
+		}
+	}
+
+	ipv4IDs := idsByNetwork["192.168.100.0/24"]
+	ipv6IDs := idsByNetwork["2001:db8:100::/64"]
+
+	if len(ipv4IDs) != 32 {
+		t.Fatalf("Expected 32 endpoints in IPv4 slice, got %d", len(ipv4IDs))
+	}
+	if len(ipv6IDs) != 32 {
+		t.Fatalf("Expected 32 endpoints in IPv6 slice, got %d", len(ipv6IDs))
+	}
+
+	// Core assertion: every Pod must have the same Maglev ID in both networks
+	for uid, v4Zone := range ipv4IDs {
+		v6Zone, exists := ipv6IDs[uid]
+		if !exists {
+			t.Errorf("Pod %s exists in IPv4 slice but not IPv6", uid)
+			continue
+		}
+		if v4Zone != v6Zone {
+			t.Errorf("Pod %s has different Maglev IDs across networks: IPv4=%s, IPv6=%s", uid, v4Zone, v6Zone)
+		}
+	}
+
+	// No capacity issues expected (32 pods, 32 max)
+	if capacityInfo != nil && len(capacityInfo.networkIssues) > 0 {
+		t.Errorf("Unexpected capacity issues: %v", capacityInfo.networkIssues)
+	}
+}
+
+func TestCalculateMaglevSlices_StableAcrossReconciles(t *testing.T) {
+	r := &DistributionGroupReconciler{}
+	dg := &meridio2v1alpha1.DistributionGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-dg", Namespace: "default"},
+		Spec: meridio2v1alpha1.DistributionGroupSpec{
+			Type:   meridio2v1alpha1.DistributionGroupTypeMaglev,
+			Maglev: &meridio2v1alpha1.MaglevConfig{MaxEndpoints: 32},
+		},
+	}
+
+	// 32 dual-stack Pods
+	ipv4Pods := make([]podWithNetworkIP, 32)
+	ipv6Pods := make([]podWithNetworkIP, 32)
+	for i := range 32 {
+		uid := types.UID("uid-" + strconv.Itoa(i))
+		name := "pod-" + strconv.Itoa(i)
+		pod := corev1.Pod{ObjectMeta: metav1.ObjectMeta{UID: uid, Name: name, Namespace: "default"}}
+		ipv4Pods[i] = podWithNetworkIP{pod: pod, ip: "192.168.100." + strconv.Itoa(10+i)}
+		ipv6Pods[i] = podWithNetworkIP{pod: pod, ip: "2001:db8:100::" + strconv.Itoa(10+i)}
+	}
+
+	podsByNetwork := map[string][]podWithNetworkIP{
+		"192.168.100.0/24":  ipv4Pods,
+		"2001:db8:100::/64": ipv6Pods,
+	}
+
+	// First reconcile: no existing slices
+	slices1, _ := r.calculateMaglevSlices(dg, podsByNetwork, nil)
+
+	// Build slicesByNetwork from first reconcile output (simulates what listOwnedSlices returns)
+	slicesByNetwork := make(map[string][]discoveryv1.EndpointSlice)
+	for _, s := range slices1 {
+		network := decodeCIDRFromLabel(s.Labels[labelNetworkSubnet])
+		slicesByNetwork[network] = append(slicesByNetwork[network], s)
+	}
+
+	// Second reconcile: pass first reconcile's output as existing slices
+	slices2, _ := r.calculateMaglevSlices(dg, podsByNetwork, slicesByNetwork)
+
+	// Extract all UID→zone mappings from each reconcile, detecting cross-network inconsistencies
+	getIDs := func(slices []discoveryv1.EndpointSlice) map[string]string {
+		ids := make(map[string]string)
+		for _, s := range slices {
+			for _, ep := range s.Endpoints {
+				if ep.TargetRef != nil && ep.Zone != nil {
+					uid := string(ep.TargetRef.UID)
+					if existing, seen := ids[uid]; seen && existing != *ep.Zone {
+						t.Errorf("Pod %s has inconsistent IDs across network slices: %s vs %s", uid, existing, *ep.Zone)
+					}
+					ids[uid] = *ep.Zone
+				}
+			}
+		}
+		return ids
+	}
+
+	ids1 := getIDs(slices1)
+	ids2 := getIDs(slices2)
+
+	if len(ids1) != 32 { // 32 unique pods (each appears in 2 slices with same ID)
+		t.Fatalf("First reconcile: expected 32 unique pod entries, got %d", len(ids1))
+	}
+	if len(ids2) != 32 {
+		t.Fatalf("Second reconcile: expected 32 unique pod entries, got %d", len(ids2))
+	}
+
+	// Every Pod must have the same ID in both reconciles
+	for uid, zone1 := range ids1 {
+		zone2, exists := ids2[uid]
+		if !exists {
+			t.Errorf("Pod %s missing in second reconcile", uid)
+			continue
+		}
+		if zone1 != zone2 {
+			t.Errorf("Pod %s ID changed between reconciles: %s → %s", uid, zone1, zone2)
+		}
+	}
+}
+
+func TestCalculateMaglevSlices_PartialPodReplacement(t *testing.T) {
+	r := &DistributionGroupReconciler{}
+	dg := &meridio2v1alpha1.DistributionGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-dg", Namespace: "default"},
+		Spec: meridio2v1alpha1.DistributionGroupSpec{
+			Type:   meridio2v1alpha1.DistributionGroupTypeMaglev,
+			Maglev: &meridio2v1alpha1.MaglevConfig{MaxEndpoints: 32},
+		},
+	}
+
+	makePods := func(prefix string, count, ipOffset int) ([]podWithNetworkIP, []podWithNetworkIP) {
+		v4 := make([]podWithNetworkIP, count)
+		v6 := make([]podWithNetworkIP, count)
+		for i := range count {
+			uid := types.UID(prefix + "-" + strconv.Itoa(i))
+			name := prefix + "-" + strconv.Itoa(i)
+			pod := corev1.Pod{ObjectMeta: metav1.ObjectMeta{UID: uid, Name: name, Namespace: "default"}}
+			v4[i] = podWithNetworkIP{pod: pod, ip: "192.168.100." + strconv.Itoa(ipOffset+i)}
+			v6[i] = podWithNetworkIP{pod: pod, ip: "2001:db8:100::" + strconv.Itoa(ipOffset+i)}
+		}
+		return v4, v6
+	}
+
+	// Initial: 32 dual-stack Pods
+	origV4, origV6 := makePods("orig", 32, 10)
+	podsByNetwork := map[string][]podWithNetworkIP{
+		"192.168.100.0/24":  origV4,
+		"2001:db8:100::/64": origV6,
+	}
+
+	// First reconcile
+	slices1, _ := r.calculateMaglevSlices(dg, podsByNetwork, nil)
+
+	// Build existing slices for second reconcile
+	slicesByNetwork := make(map[string][]discoveryv1.EndpointSlice)
+	for _, s := range slices1 {
+		network := decodeCIDRFromLabel(s.Labels[labelNetworkSubnet])
+		slicesByNetwork[network] = append(slicesByNetwork[network], s)
+	}
+
+	// Replace half the Pods (indices 16-31) with new ones
+	newV4, newV6 := makePods("new", 16, 50)
+	podsByNetwork2 := map[string][]podWithNetworkIP{
+		"192.168.100.0/24":  append(origV4[:16], newV4...),
+		"2001:db8:100::/64": append(origV6[:16], newV6...),
+	}
+
+	// Second reconcile with replaced Pods
+	slices2, _ := r.calculateMaglevSlices(dg, podsByNetwork2, slicesByNetwork)
+
+	// Extract IDs, detecting cross-network inconsistencies
+	getIDs := func(slices []discoveryv1.EndpointSlice) map[string]string {
+		ids := make(map[string]string)
+		for _, s := range slices {
+			for _, ep := range s.Endpoints {
+				if ep.TargetRef != nil && ep.Zone != nil {
+					uid := string(ep.TargetRef.UID)
+					if existing, seen := ids[uid]; seen && existing != *ep.Zone {
+						t.Errorf("Pod %s has inconsistent IDs across networks: %s vs %s", uid, existing, *ep.Zone)
+					}
+					ids[uid] = *ep.Zone
+				}
+			}
+		}
+		return ids
+	}
+
+	ids1 := getIDs(slices1)
+	ids2 := getIDs(slices2)
+
+	if len(ids1) != 32 {
+		t.Fatalf("First reconcile: expected 32 unique pod entries, got %d", len(ids1))
+	}
+	if len(ids2) != 32 {
+		t.Fatalf("Second reconcile: expected 32 unique pod entries, got %d", len(ids2))
+	}
+
+	// Surviving Pods (orig-0 through orig-15) must keep their original IDs
+	for i := range 16 {
+		uid := "orig-" + strconv.Itoa(i)
+		zone1, ok1 := ids1[uid]
+		zone2, ok2 := ids2[uid]
+		if !ok1 || !ok2 {
+			t.Errorf("Surviving pod %s missing from reconcile results", uid)
+			continue
+		}
+		if zone1 != zone2 {
+			t.Errorf("Surviving pod %s ID changed: %s → %s", uid, zone1, zone2)
+		}
+	}
+
+	// New Pods (new-0 through new-15) must be present in the allocation
+	for i := range 16 {
+		uid := "new-" + strconv.Itoa(i)
+		if _, exists := ids2[uid]; !exists {
+			t.Errorf("New pod %s should have an ID assigned", uid)
+		}
+	}
+}
 
 func TestCreateSlicesForNetwork_MaglevCapacityEnforcement(t *testing.T) {
 	dg := &meridio2v1alpha1.DistributionGroup{
@@ -368,5 +623,105 @@ func TestCreateSlicesForNetwork_StructurePreservation(t *testing.T) {
 	}
 	if len(slices[0].Endpoints) != 3 {
 		t.Errorf("Expected 3 endpoints in reused slice, got %d", len(slices[0].Endpoints))
+	}
+}
+
+func TestCreateSlicesForNetwork_Compaction(t *testing.T) {
+	dg := &meridio2v1alpha1.DistributionGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-dg", Namespace: "default"},
+	}
+
+	// Two existing slices: slice-0 had [pod-1, pod-2, pod-3], slice-1 had [pod-4, pod-5]
+	existingSlices := []discoveryv1.EndpointSlice{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "slice-0"},
+			Endpoints: []discoveryv1.Endpoint{
+				{TargetRef: &corev1.ObjectReference{UID: "pod-1"}},
+				{TargetRef: &corev1.ObjectReference{UID: "pod-2"}},
+				{TargetRef: &corev1.ObjectReference{UID: "pod-3"}},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "slice-1"},
+			Endpoints: []discoveryv1.Endpoint{
+				{TargetRef: &corev1.ObjectReference{UID: "pod-4"}},
+				{TargetRef: &corev1.ObjectReference{UID: "pod-5"}},
+			},
+		},
+	}
+
+	// After scale-in: only pod-1 and pod-4 remain
+	podsWithIP := []podWithNetworkIP{
+		{pod: corev1.Pod{ObjectMeta: metav1.ObjectMeta{UID: "pod-1", Name: "pod-1"}}, ip: "10.0.0.1"},
+		{pod: corev1.Pod{ObjectMeta: metav1.ObjectMeta{UID: "pod-4", Name: "pod-4"}}, ip: "10.0.0.4"},
+	}
+
+	slices := createSlicesForNetwork(dg, podsWithIP, nil, "192.168.1.0/24", existingSlices)
+
+	// Compaction should move pod-4 from slice-1 into slice-0 (which has capacity)
+	// and eliminate slice-1
+	if len(slices) != 1 {
+		t.Errorf("Expected 1 slice after compaction, got %d", len(slices))
+	}
+	if slices[0].Name != "slice-0" {
+		t.Errorf("Expected surviving slice to be 'slice-0', got %q", slices[0].Name)
+	}
+	if len(slices[0].Endpoints) != 2 {
+		t.Errorf("Expected 2 endpoints in compacted slice, got %d", len(slices[0].Endpoints))
+	}
+}
+
+func TestCreateSlicesForNetwork_CompactionPreservesFullSlices(t *testing.T) {
+	dg := &meridio2v1alpha1.DistributionGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-dg", Namespace: "default"},
+	}
+
+	// slice-0 is full (maxEndpointsPerSlice=100), slice-1 has 2 endpoints
+	existingSlice0Endpoints := make([]discoveryv1.Endpoint, maxEndpointsPerSlice)
+	podsWithIP := make([]podWithNetworkIP, maxEndpointsPerSlice+2)
+	for i := range maxEndpointsPerSlice {
+		uid := types.UID("pod-" + strconv.Itoa(i))
+		existingSlice0Endpoints[i] = discoveryv1.Endpoint{
+			TargetRef: &corev1.ObjectReference{UID: uid},
+		}
+		podsWithIP[i] = podWithNetworkIP{
+			pod: corev1.Pod{ObjectMeta: metav1.ObjectMeta{UID: uid, Name: "pod-" + strconv.Itoa(i)}},
+			ip:  "10.0.0." + strconv.Itoa(i),
+		}
+	}
+	// 2 extra pods in slice-1
+	for i := range 2 {
+		uid := types.UID("extra-" + strconv.Itoa(i))
+		podsWithIP[maxEndpointsPerSlice+i] = podWithNetworkIP{
+			pod: corev1.Pod{ObjectMeta: metav1.ObjectMeta{UID: uid, Name: "extra-" + strconv.Itoa(i)}},
+			ip:  "10.0.1." + strconv.Itoa(i),
+		}
+	}
+
+	existingSlices := []discoveryv1.EndpointSlice{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "slice-0"},
+			Endpoints:  existingSlice0Endpoints,
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "slice-1"},
+			Endpoints: []discoveryv1.Endpoint{
+				{TargetRef: &corev1.ObjectReference{UID: "extra-0"}},
+				{TargetRef: &corev1.ObjectReference{UID: "extra-1"}},
+			},
+		},
+	}
+
+	slices := createSlicesForNetwork(dg, podsWithIP, nil, "192.168.1.0/24", existingSlices)
+
+	// slice-0 is full, slice-1 cannot be compacted into it — both should remain
+	if len(slices) != 2 {
+		t.Errorf("Expected 2 slices (no compaction possible), got %d", len(slices))
+	}
+	if len(slices[0].Endpoints) != maxEndpointsPerSlice {
+		t.Errorf("Expected slice-0 to remain full (%d), got %d", maxEndpointsPerSlice, len(slices[0].Endpoints))
+	}
+	if len(slices[1].Endpoints) != 2 {
+		t.Errorf("Expected slice-1 to keep 2 endpoints, got %d", len(slices[1].Endpoints))
 	}
 }

--- a/internal/controller/distributiongroup/status.go
+++ b/internal/controller/distributiongroup/status.go
@@ -61,7 +61,11 @@ func buildReadyCondition(hasEndpoints bool, generation int64, message string) me
 		condition.Message = messageEndpointsAvailable
 	} else {
 		condition.Status = metav1.ConditionFalse
-		condition.Reason = reasonNoEndpoints
+		if message == messageMultipleGateways {
+			condition.Reason = reasonMultipleGateways
+		} else {
+			condition.Reason = reasonNoEndpoints
+		}
 		if message != "" {
 			condition.Message = message
 		} else {

--- a/internal/controller/distributiongroup/status_test.go
+++ b/internal/controller/distributiongroup/status_test.go
@@ -69,6 +69,23 @@ func TestBuildReadyCondition_NoEndpointsWithCustomMessage(t *testing.T) {
 	}
 }
 
+func TestBuildReadyCondition_MultipleGateways(t *testing.T) {
+	cond := buildReadyCondition(false, 3, messageMultipleGateways)
+
+	if cond.Type != conditionTypeReady {
+		t.Errorf("Expected type %q, got %q", conditionTypeReady, cond.Type)
+	}
+	if cond.Status != metav1.ConditionFalse {
+		t.Errorf("Expected status False, got %v", cond.Status)
+	}
+	if cond.Reason != reasonMultipleGateways {
+		t.Errorf("Expected reason %q, got %q", reasonMultipleGateways, cond.Reason)
+	}
+	if cond.Message != messageMultipleGateways {
+		t.Errorf("Expected message %q, got %q", messageMultipleGateways, cond.Message)
+	}
+}
+
 func TestBuildCapacityCondition(t *testing.T) {
 	issues := map[string]struct{ excluded, total int32 }{
 		"192.168.1.0/24": {excluded: 5, total: 37},

--- a/internal/controller/distributiongroup/types.go
+++ b/internal/controller/distributiongroup/types.go
@@ -16,12 +16,24 @@ limitations under the License.
 
 package distributiongroup
 
-import corev1 "k8s.io/api/core/v1"
+import (
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
 
 // podWithNetworkIP pairs a Pod with its scraped secondary IP for a specific network context
 type podWithNetworkIP struct {
 	pod corev1.Pod
 	ip  string
+}
+
+// gatewayNetworkContext groups network contexts for a single Gateway.
+// Used to scope Maglev ID allocation per Gateway.
+type gatewayNetworkContext struct {
+	// gateway is the namespaced name of the Gateway object.
+	gateway client.ObjectKey
+	// networks maps normalized CIDR → attachment type for this Gateway.
+	networks map[string]string
 }
 
 // maglevCapacityInfo tracks Maglev capacity issues per network


### PR DESCRIPTION
## Fix Maglev ID allocation: shared per-DG per-Gateway

Fixes #70

### Summary

The DG controller previously assigned Maglev IDs independently per network/CIDR, causing the same Pod to receive different IDs in IPv4 and IPv6 EndpointSlices. This broke the LB controller which uses a single NFQLB hash table per DG.

This PR fixes the allocation side: IDs are now assigned once per Pod UID across all networks within a Gateway, ensuring consistent IDs in both IPv4 and IPv6 EndpointSlices.

Note: The LB controller does not yet fully support dual-stack routing. That work is tracked separately and depends on the ongoing LB refactor.

### Changes

DG controller:
- Introduce gatewayNetworkContext to group networks per Gateway (future multi-Gateway ready)
- Merge Pods by UID across a Gateway's CIDRs before Maglev ID assignment
- Simplify assignMaglevIDs and sortPodsByCreationTime to accept []corev1.Pod (IP not relevant for allocation)
- Add multi-Gateway enforcement: Ready=False with reason MultipleGateways if >1 accepted Gateway references the DG
- Add EndpointSlice compaction (fill earlier slices after scale-in, remove empty ones)
- Sort owned slices by name for deterministic processing (cache List order is not guaranteed)
- Use maps.Copy for existing assignment extraction
- Pre-allocate map/slice capacities

Documentation:
- Update docs/controllers/distributiongroup.md — reconciliation flow, Maglev scoping rationale, compaction, multi-GW step
- Update docs/operations/constraints-and-limitations.md — dual-stack constraint status
- Update docs/operations/troubleshooting.md — internalSubnets references, MultipleGateways reason
- Add docs/design/maglev-id-shared-allocation.md — design study covering problem space, alternatives, and explored directions

Tests:
- Shared IDs across networks (32 dual-stack Pods)
- Stability across reconciles
- Partial Pod replacement (16 of 32 replaced, surviving Pods keep IDs)
- EndpointSlice compaction and full-slice preservation
- Multi-Gateway reconciliation skip
- buildReadyCondition with MultipleGateways reason

### What's NOT in this PR
- LB dual-stack route handling (separate PR, pending LB refactor)
- DG gatekeeper (require all IPs before adding new Pods)
- IP family mode management (#128)
