### PR TITLE
Add --cert-wait-timeout flag to poll for certificates before starting

### DIFF
--- a/cmd/controller-manager/cmd/run.go
+++ b/cmd/controller-manager/cmd/run.go
@@ -21,7 +21,6 @@ import (
 	"crypto/tls"
 	goflag "flag"
 	"fmt"
-	"path/filepath"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -112,19 +111,17 @@ func runManager(cfg *config.ManagerConfig) error {
 
 	// Wait for certificate files if configured
 	if cfg.CertWaitTimeout > 0 {
-		var certFiles []string
-		if cfg.EnableWebhooks && cfg.WebhookCertPath != "" {
-			certFiles = append(certFiles,
-				filepath.Join(cfg.WebhookCertPath, cfg.WebhookCertName),
-				filepath.Join(cfg.WebhookCertPath, cfg.WebhookCertKey),
-			)
-		}
-		if cfg.MetricsAddr != "0" && cfg.SecureMetrics && cfg.MetricsCertPath != "" {
-			certFiles = append(certFiles,
-				filepath.Join(cfg.MetricsCertPath, cfg.MetricsCertName),
-				filepath.Join(cfg.MetricsCertPath, cfg.MetricsCertKey),
-			)
-		}
+		certFiles := (&prerequisites.CertWaitConfig{
+			EnableWebhooks:  cfg.EnableWebhooks,
+			WebhookCertPath: cfg.WebhookCertPath,
+			WebhookCertName: cfg.WebhookCertName,
+			WebhookCertKey:  cfg.WebhookCertKey,
+			MetricsAddr:     cfg.MetricsAddr,
+			SecureMetrics:   cfg.SecureMetrics,
+			MetricsCertPath: cfg.MetricsCertPath,
+			MetricsCertName: cfg.MetricsCertName,
+			MetricsCertKey:  cfg.MetricsCertKey,
+		}).CertFiles()
 		if len(certFiles) > 0 {
 			timeout := cfg.CertWaitTimeout
 			ctx, cancel := context.WithTimeout(context.Background(), timeout)

--- a/cmd/controller-manager/cmd/run.go
+++ b/cmd/controller-manager/cmd/run.go
@@ -86,6 +86,10 @@ func NewRunCmd() *cobra.Command {
 				return fmt.Errorf("LB deployment template not found: %w", err)
 			}
 
+			if cfg.CertWaitTimeout > time.Minute {
+				return fmt.Errorf("--cert-wait-timeout cannot exceed 1 minute (got %s)", cfg.CertWaitTimeout)
+			}
+
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -122,11 +126,12 @@ func runManager(cfg *config.ManagerConfig) error {
 			)
 		}
 		if len(certFiles) > 0 {
-			timeout := min(cfg.CertWaitTimeout, time.Minute)
+			timeout := cfg.CertWaitTimeout
 			ctx, cancel := context.WithTimeout(context.Background(), timeout)
-			defer cancel()
 			setupLog.Info("waiting for certificate files", "files", certFiles, "timeout", timeout)
-			if err := prerequisites.WaitForCerts(ctx, certFiles); err != nil {
+			err := prerequisites.WaitForCerts(ctx, certFiles)
+			cancel()
+			if err != nil {
 				return fmt.Errorf("certificate wait failed: %w", err)
 			}
 			setupLog.Info("all certificate files are available")

--- a/cmd/controller-manager/cmd/run.go
+++ b/cmd/controller-manager/cmd/run.go
@@ -17,9 +17,12 @@ limitations under the License.
 package cmd
 
 import (
+	"context"
 	"crypto/tls"
 	goflag "flag"
 	"fmt"
+	"path/filepath"
+	"time"
 
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
@@ -102,6 +105,34 @@ func NewRunCmd() *cobra.Command {
 
 func runManager(cfg *config.ManagerConfig) error {
 	setupLog.Info("starting controller-manager", "config", cfg)
+
+	// Wait for certificate files if configured
+	if cfg.CertWaitTimeout > 0 {
+		var certFiles []string
+		if cfg.EnableWebhooks && cfg.WebhookCertPath != "" {
+			certFiles = append(certFiles,
+				filepath.Join(cfg.WebhookCertPath, cfg.WebhookCertName),
+				filepath.Join(cfg.WebhookCertPath, cfg.WebhookCertKey),
+			)
+		}
+		if cfg.MetricsAddr != "0" && cfg.SecureMetrics && cfg.MetricsCertPath != "" {
+			certFiles = append(certFiles,
+				filepath.Join(cfg.MetricsCertPath, cfg.MetricsCertName),
+				filepath.Join(cfg.MetricsCertPath, cfg.MetricsCertKey),
+			)
+		}
+		if len(certFiles) > 0 {
+			timeout := min(cfg.CertWaitTimeout, time.Minute)
+			ctx, cancel := context.WithTimeout(context.Background(), timeout)
+			defer cancel()
+			setupLog.Info("waiting for certificate files", "files", certFiles, "timeout", timeout)
+			if err := prerequisites.WaitForCerts(ctx, certFiles); err != nil {
+				return fmt.Errorf("certificate wait failed: %w", err)
+			}
+			setupLog.Info("all certificate files are available")
+		}
+	}
+
 	var tlsOpts []func(*tls.Config)
 	if !cfg.EnableHTTP2 {
 		disableHTTP2 := func(c *tls.Config) {

--- a/docs/controllers/gateway.md
+++ b/docs/controllers/gateway.md
@@ -541,6 +541,13 @@ spec:
 - Default: `stateless-load-balancer`
 - Injected by Kustomize replacement (handles namePrefix)
 
+**`--cert-wait-timeout`**:
+- Duration to wait for certificate files before starting
+- Default: `10s`
+- Set to `0` to disable waiting (fail immediately if certs are missing)
+- Maximum: `1m` (values above are rejected at startup)
+- Only waits for certs that are actually needed based on other flags
+
 ### Environment Variables
 All flags can be set via `MERIDIO_*` environment variables (e.g., `MERIDIO_NAMESPACE`).
 

--- a/docs/operations/constraints-and-limitations.md
+++ b/docs/operations/constraints-and-limitations.md
@@ -112,9 +112,9 @@ When a Node becomes NotReady, the controller does not immediately reconcile affe
 
 Log level is set at startup via `--log-level` / `MERIDIO_LOG_LEVEL` and cannot be changed without restarting the process. All four controllers (controller-manager, router, loadbalancer, sidecar) share this limitation.
 
-**24. No cert-wait-timeout**
+**24. ~~No cert-wait-timeout~~** *(resolved)*
 
-The controller-manager crashes immediately if TLS certificates are not yet provisioned. When deployed simultaneously with cert-manager (e.g., via a single Helm chart), this causes several restart cycles before certs are ready.
+The controller-manager now waits for TLS certificates before starting (default: 10s, maximum: 1m, configurable via `--cert-wait-timeout`). This avoids unnecessary restart cycles when deployed simultaneously with cert-manager.
 
 **25. Minimum Kubernetes version 1.31** *(architectural constraint)*
 

--- a/internal/common/config/manager.go
+++ b/internal/common/config/manager.go
@@ -52,6 +52,7 @@ type ManagerConfig struct {
 	LBServiceAccount string
 
 	// Certificates
+	CertWaitTimeout time.Duration
 	WebhookPort     int
 	WebhookCertPath string
 	WebhookCertName string
@@ -95,6 +96,8 @@ func (c *ManagerConfig) AddFlags(fs *pflag.FlagSet) {
 		"ServiceAccount name for LB Deployment pods.")
 	fs.IntVar(&c.WebhookPort, "webhook-port", 9443,
 		"The port the webhook server binds to.")
+	fs.DurationVar(&c.CertWaitTimeout, "cert-wait-timeout", 10*time.Second,
+		"Duration to wait for certificate files before starting. 0 means no wait. Maximum 1 minute.")
 	fs.StringVar(&c.WebhookCertPath, "webhook-cert-path", "",
 		"The directory that contains the webhook certificate.")
 	fs.StringVar(&c.WebhookCertName, "webhook-cert-name", "tls.crt",
@@ -129,6 +132,7 @@ func (c *ManagerConfig) BindEnv(fs *pflag.FlagSet) {
 	bindString(fs, "template-path", "MERIDIO_TEMPLATE_PATH", &c.TemplatePath)
 	bindString(fs, "lb-service-account", "MERIDIO_LB_SERVICE_ACCOUNT", &c.LBServiceAccount)
 	bindInt(fs, "webhook-port", "MERIDIO_WEBHOOK_PORT", &c.WebhookPort)
+	bindDuration(fs, "cert-wait-timeout", "MERIDIO_CERT_WAIT_TIMEOUT", &c.CertWaitTimeout)
 	bindString(fs, "webhook-cert-path", "MERIDIO_WEBHOOK_CERT_PATH", &c.WebhookCertPath)
 	bindString(fs, "webhook-cert-name", "MERIDIO_WEBHOOK_CERT_NAME", &c.WebhookCertName)
 	bindString(fs, "webhook-cert-key", "MERIDIO_WEBHOOK_CERT_KEY", &c.WebhookCertKey)

--- a/internal/common/prerequisites/cert_wait.go
+++ b/internal/common/prerequisites/cert_wait.go
@@ -20,12 +20,44 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"time"
 
 	"golang.org/x/sync/errgroup"
 )
 
 const certPollInterval = 1 * time.Second
+
+// CertWaitConfig holds the configuration parameters needed to determine which certificate files to wait for.
+type CertWaitConfig struct {
+	EnableWebhooks  bool
+	WebhookCertPath string
+	WebhookCertName string
+	WebhookCertKey  string
+	MetricsAddr     string
+	SecureMetrics   bool
+	MetricsCertPath string
+	MetricsCertName string
+	MetricsCertKey  string
+}
+
+// CertFiles returns the list of certificate files that need to exist based on the configuration.
+func (c *CertWaitConfig) CertFiles() []string {
+	var certFiles []string
+	if c.EnableWebhooks && c.WebhookCertPath != "" {
+		certFiles = append(certFiles,
+			filepath.Join(c.WebhookCertPath, c.WebhookCertName),
+			filepath.Join(c.WebhookCertPath, c.WebhookCertKey),
+		)
+	}
+	if c.MetricsAddr != "0" && c.SecureMetrics && c.MetricsCertPath != "" {
+		certFiles = append(certFiles,
+			filepath.Join(c.MetricsCertPath, c.MetricsCertName),
+			filepath.Join(c.MetricsCertPath, c.MetricsCertKey),
+		)
+	}
+	return certFiles
+}
 
 // WaitForCerts polls for all specified files concurrently until they exist
 // or the context is cancelled. Returns nil if all files are found.

--- a/internal/common/prerequisites/cert_wait.go
+++ b/internal/common/prerequisites/cert_wait.go
@@ -1,0 +1,66 @@
+/*
+Copyright (c) 2026 OpenInfra Foundation Europe. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prerequisites
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+)
+
+const certPollInterval = 1 * time.Second
+
+// WaitForCerts polls for all specified files concurrently until they exist
+// or the context is cancelled. Returns nil if all files are found.
+func WaitForCerts(ctx context.Context, files []string) error {
+	if len(files) == 0 {
+		return nil
+	}
+
+	g, ctx := errgroup.WithContext(ctx)
+	for _, f := range files {
+		g.Go(func() error {
+			return waitForFile(ctx, f)
+		})
+	}
+
+	return g.Wait()
+}
+
+func waitForFile(ctx context.Context, path string) error {
+	// Check immediately before entering the poll loop
+	if _, err := os.Stat(path); err == nil {
+		return nil
+	}
+
+	ticker := time.NewTicker(certPollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("timed out waiting for certificate file %q: %w", path, ctx.Err())
+		case <-ticker.C:
+			if _, err := os.Stat(path); err == nil {
+				return nil
+			}
+		}
+	}
+}

--- a/internal/common/prerequisites/cert_wait_test.go
+++ b/internal/common/prerequisites/cert_wait_test.go
@@ -57,7 +57,7 @@ func TestWaitForCerts_FilesAppearLater(t *testing.T) {
 	f1 := filepath.Join(dir, "tls.crt")
 	f2 := filepath.Join(dir, "tls.key")
 
-	// Create files after a short delay
+	// Create certs after a short delay
 	go func() {
 		time.Sleep(500 * time.Millisecond)
 		_ = os.WriteFile(f1, []byte("cert"), 0o600)
@@ -117,6 +117,124 @@ func TestWaitForCerts_PartialFiles(t *testing.T) {
 
 	err := WaitForCerts(ctx, []string{f1, f2})
 	if err == nil {
-		t.Fatal("expected error when one file is missing, got nil")
+		t.Fatal("expected error when one cert is missing, got nil")
+	}
+}
+
+func TestCertFiles_WebhookOnly(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &CertWaitConfig{
+		EnableWebhooks:  true,
+		WebhookCertPath: dir,
+		WebhookCertName: "tls.crt",
+		WebhookCertKey:  "tls.key",
+		MetricsAddr:     "0",
+	}
+	certFiles := cfg.CertFiles()
+	if len(certFiles) != 2 {
+		t.Fatalf("expected 2 certs, got %d", len(certFiles))
+	}
+}
+
+func TestCertFiles_MetricsOnly(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &CertWaitConfig{
+		EnableWebhooks:  false,
+		MetricsAddr:     ":8443",
+		SecureMetrics:   true,
+		MetricsCertPath: dir,
+		MetricsCertName: "tls.crt",
+		MetricsCertKey:  "tls.key",
+	}
+	certFiles := cfg.CertFiles()
+	if len(certFiles) != 2 {
+		t.Fatalf("expected 2 certs, got %d", len(certFiles))
+	}
+}
+
+func TestCertFiles_NoneNeeded(t *testing.T) {
+	cfg := &CertWaitConfig{
+		EnableWebhooks: false,
+		MetricsAddr:    "0",
+	}
+	certFiles := cfg.CertFiles()
+	if len(certFiles) != 0 {
+		t.Fatalf("expected 0 certs, got %d", len(certFiles))
+	}
+}
+
+func TestCertFiles_WebhooksDisabledIgnoresCertPath(t *testing.T) {
+	cfg := &CertWaitConfig{
+		EnableWebhooks:  false,
+		WebhookCertPath: "/some/path",
+		WebhookCertName: "tls.crt",
+		WebhookCertKey:  "tls.key",
+	}
+	certFiles := cfg.CertFiles()
+	if len(certFiles) != 0 {
+		t.Fatalf("expected 0 certs when webhooks disabled, got %d", len(certFiles))
+	}
+}
+
+func TestCertFiles_MetricsInsecureIgnoresCertPath(t *testing.T) {
+	cfg := &CertWaitConfig{
+		MetricsAddr:     ":8443",
+		SecureMetrics:   false,
+		MetricsCertPath: "/some/path",
+		MetricsCertName: "tls.crt",
+		MetricsCertKey:  "tls.key",
+	}
+	certFiles := cfg.CertFiles()
+	if len(certFiles) != 0 {
+		t.Fatalf("expected 0 certs when metrics insecure, got %d", len(certFiles))
+	}
+}
+
+func TestCertWaitIntegration_TimeoutWhenCertsMissing(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &CertWaitConfig{
+		EnableWebhooks:  true,
+		WebhookCertPath: dir,
+		WebhookCertName: "tls.crt",
+		WebhookCertKey:  "tls.key",
+	}
+	certFiles := cfg.CertFiles()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	err := WaitForCerts(ctx, certFiles)
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+}
+
+func TestCertWaitIntegration_SucceedsWhenCertsExist(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &CertWaitConfig{
+		EnableWebhooks:  true,
+		WebhookCertPath: dir,
+		WebhookCertName: "tls.crt",
+		WebhookCertKey:  "tls.key",
+		MetricsAddr:     ":8443",
+		SecureMetrics:   true,
+		MetricsCertPath: dir,
+		MetricsCertName: "metrics.crt",
+		MetricsCertKey:  "metrics.key",
+	}
+
+	// Create all cert files
+	for _, f := range cfg.CertFiles() {
+		if err := os.WriteFile(f, []byte("data"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	err := WaitForCerts(ctx, cfg.CertFiles())
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
 	}
 }

--- a/internal/common/prerequisites/cert_wait_test.go
+++ b/internal/common/prerequisites/cert_wait_test.go
@@ -1,0 +1,122 @@
+/*
+Copyright (c) 2026 OpenInfra Foundation Europe. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prerequisites
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestWaitForCerts_EmptyList(t *testing.T) {
+	err := WaitForCerts(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+}
+
+func TestWaitForCerts_FilesAlreadyExist(t *testing.T) {
+	dir := t.TempDir()
+	f1 := filepath.Join(dir, "tls.crt")
+	f2 := filepath.Join(dir, "tls.key")
+
+	if err := os.WriteFile(f1, []byte("cert"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(f2, []byte("key"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	err := WaitForCerts(ctx, []string{f1, f2})
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+}
+
+func TestWaitForCerts_FilesAppearLater(t *testing.T) {
+	dir := t.TempDir()
+	f1 := filepath.Join(dir, "tls.crt")
+	f2 := filepath.Join(dir, "tls.key")
+
+	// Create files after a short delay
+	go func() {
+		time.Sleep(500 * time.Millisecond)
+		_ = os.WriteFile(f1, []byte("cert"), 0o600)
+		_ = os.WriteFile(f2, []byte("key"), 0o600)
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := WaitForCerts(ctx, []string{f1, f2})
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+}
+
+func TestWaitForCerts_Timeout(t *testing.T) {
+	dir := t.TempDir()
+	f1 := filepath.Join(dir, "tls.crt")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	err := WaitForCerts(ctx, []string{f1})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestWaitForCerts_ContextCancelled(t *testing.T) {
+	dir := t.TempDir()
+	f1 := filepath.Join(dir, "tls.crt")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		cancel()
+	}()
+
+	err := WaitForCerts(ctx, []string{f1})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestWaitForCerts_PartialFiles(t *testing.T) {
+	dir := t.TempDir()
+	f1 := filepath.Join(dir, "tls.crt")
+	f2 := filepath.Join(dir, "tls.key")
+
+	// Only create one file
+	if err := os.WriteFile(f1, []byte("cert"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	err := WaitForCerts(ctx, []string{f1, f2})
+	if err == nil {
+		t.Fatal("expected error when one file is missing, got nil")
+	}
+}


### PR DESCRIPTION
This is a solution for #78.

When the controller-manager and cert-manager are deployed simultaneously, TLS certificates may not be provisioned yet at startup. This flag allows the controller-manager to poll for required certificate files before starting the manager.

Behavior:
- 0: no wait, fail immediately if certs are missing
- \>0: wait up to the specified duration
- Max: 1, values above are rejected at startup
- Default: 10s

Only waits for certs that are actually needed:
- Webhook cert: when `--enable-webhooks=true` and `--webhook-cert-path` is set
- Metrics cert: when `--metrics-bind-address` is not 0, `--metrics-secure=true`, and `--metrics-cert-path` is set

All files are checked concurrently so total wait is bounded by the timeout.