### PR TITLE
Increase e2e deployment timeout and add failure diagnostics

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -110,6 +110,14 @@ jobs:
         run: |
           make -C test/e2e deploy-${{ matrix.suite }} REGISTRY=${{ secrets.HARBOR_REGISTRY }}/cloud-native/meridio-2 VERSION=${{ needs.get-tag.outputs.tag }}
           kubectl get all -A -o wide
+      - name: Diagnose deployment issues
+        if: failure()
+        run: |
+          NS="e2e-${{ matrix.suite }}"
+          kubectl get pods -n $NS -o wide
+          kubectl describe pods -n $NS
+          kubectl get events -n $NS --sort-by='.lastTimestamp'
+          kubectl logs -n $NS --all-containers --prefix --tail=200 -l app || true
       - name: Run ${{ matrix.suite }} tests
         run: make -C test/e2e test-${{ matrix.suite }} REGISTRY=${{ secrets.HARBOR_REGISTRY }}/cloud-native/meridio-2 VERSION=${{ needs.get-tag.outputs.tag }} GINKGO_FLAGS="--junit-report=junit-${{ matrix.suite }}-${{ matrix.k8s_version }}.xml"
       - name: Upload test results

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -151,7 +151,7 @@ define deploy-suite
 	if ! $(KUBECTL) get deployment meridio-2-controller-manager-$$SUITE_LABEL -n $$NS -o jsonpath='{.spec.template.spec.volumes[*].name}' | grep -q templates-override; then \
 		$(KUBECTL) patch deployment meridio-2-controller-manager-$$SUITE_LABEL -n $$NS --type=json -p='[{"op":"add","path":"/spec/template/spec/containers/0/volumeMounts/-","value":{"name":"templates-override","mountPath":"/templates-override"}},{"op":"add","path":"/spec/template/spec/volumes/-","value":{"name":"templates-override","configMap":{"name":"lb-template-override-'$$SUITE_LABEL'"}}}]'; \
 	fi; \
-	$(KUBECTL) wait --for=condition=Available --timeout=180s -n $$NS deployment/meridio-2-controller-manager-$$SUITE_LABEL; \
+	$(KUBECTL) wait --for=condition=Available --timeout=600s -n $$NS deployment/meridio-2-controller-manager-$$SUITE_LABEL; \
 	$(KUBECTL) wait --for=condition=Ready --timeout=60s -n $$NS certificate/meridio-2-serving-cert-$$SUITE_LABEL; \
 	timeout=60; elapsed=0; \
 	until $(KUBECTL) get endpoints -n $$NS meridio-2-webhook-service-$$SUITE_LABEL -o jsonpath='{.subsets[*].addresses[*].ip}' | grep -q .; do \
@@ -168,9 +168,9 @@ define deploy-suite
 		sleep 1; elapsed=$$((elapsed + 1)); \
 		if [ $$elapsed -ge $$timeout ]; then echo "Timeout waiting for deployments: $(4)"; exit 1; fi; \
 	done; \
-	$(KUBECTL) wait --for=condition=Available --timeout=300s -n $$NS $(foreach dep,$(4),deployment/$(dep)); \
+	$(KUBECTL) wait --for=condition=Available --timeout=600s -n $$NS $(foreach dep,$(4),deployment/$(dep)); \
 	sed 's|registry.nordix.org/cloud-native/meridio-2/network-sidecar:latest|$(REGISTRY)/network-sidecar:$(VERSION)|g; s|registry.nordix.org/cloud-native/meridio-2/example-target:latest|$(REGISTRY)/example-target:$(VERSION)|g' $$SUITE_DIR/targets.yaml | $(KUBECTL) apply -n $$NS -f -; \
-	$(KUBECTL) wait --for=condition=Available --timeout=480s -n $$NS $$($(KUBECTL) get deployment -n $$NS -l app -o name | grep target); \
+	$(KUBECTL) wait --for=condition=Available --timeout=600s -n $$NS $$($(KUBECTL) get deployment -n $$NS -l app -o name | grep target); \
 	echo "Waiting for all pods to be ready in namespace $$NS..."; \
 	timeout=300; elapsed=0; \
 	until [ $$($(KUBECTL) get pods -n $$NS --field-selector=status.phase!=Succeeded,status.phase!=Failed -o json | jq -r '.items[] | select(.status.phase=="Running" and ([.status.conditions[] | select(.type=="Ready" and .status=="True")] | length) > 0) | .metadata.name' | wc -l) -eq $$($(KUBECTL) get pods -n $$NS --field-selector=status.phase!=Succeeded,status.phase!=Failed --no-headers | wc -l) ]; do \


### PR DESCRIPTION
## Problem

E2E tests occasionally fail during deployment due to timeouts waiting for `target` or `sllb-gw` deployments to become available. These sporadic failures make it difficult to diagnose the root cause.

## Changes

- **Increased deployment timeouts** from 300s/480s to 600s in `test/e2e/Makefile` to accommodate slower CI environments
- **Added failure diagnostics** in `.github/workflows/e2e.yaml` that automatically captures:
  - Pod status and descriptions
  - Recent events in the test namespace
  - Container logs from failed deployments