### PR TITLE
RFC 5881 compliant BFD port range

### DIFF
--- a/cmd/router/cmd/run.go
+++ b/cmd/router/cmd/run.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -151,12 +150,6 @@ func runRouter(ctx context.Context, cfg *config.RouterConfig) error {
 	}
 
 	setupLog.Info("starting router", "gateway", cfg.GatewayName, "namespace", cfg.GatewayNamespace)
-
-	// Set ephemeral port range to comply with RFC 5881 Section 4 (BFD source ports: 49152-65535).
-	if err := os.WriteFile("/proc/sys/net/ipv4/ip_local_port_range", []byte("49152 65535"), 0o644); err != nil {
-		setupLog.Error(err, "failed to set ip_local_port_range (requires NET_ADMIN)")
-		return err
-	}
 
 	ctx = ctrl.SetupSignalHandler()
 	g, ctx := errgroup.WithContext(ctx)

--- a/cmd/router/cmd/run.go
+++ b/cmd/router/cmd/run.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -150,6 +151,12 @@ func runRouter(ctx context.Context, cfg *config.RouterConfig) error {
 	}
 
 	setupLog.Info("starting router", "gateway", cfg.GatewayName, "namespace", cfg.GatewayNamespace)
+
+	// Set ephemeral port range to comply with RFC 5881 Section 4 (BFD source ports: 49152-65535).
+	if err := os.WriteFile("/proc/sys/net/ipv4/ip_local_port_range", []byte("49152 65535"), 0o644); err != nil {
+		setupLog.Error(err, "failed to set ip_local_port_range (requires NET_ADMIN)")
+		return err
+	}
 
 	ctx = ctrl.SetupSignalHandler()
 	g, ctx := errgroup.WithContext(ctx)

--- a/docs/controllers/gateway.md
+++ b/docs/controllers/gateway.md
@@ -482,6 +482,7 @@ The LB Pod's network namespace requires specific sysctls for correct operation. 
 | `net.ipv4.conf.default.rp_filter` | `2` | Loose RPF for new interfaces |
 | `net.ipv4.fwmark_reflect` | `1` | Copy fwmark to locally generated ICMP replies (required for PMTU SNAT) |
 | `net.ipv6.fwmark_reflect` | `1` | Same for IPv6 |
+| `net.ipv4.ip_local_port_range` | `49152 65535` | RFC 5881 BFD source port compliance |
 
 **Example using Multus tuning plugin:**
 
@@ -504,7 +505,8 @@ spec:
           "net.ipv4.conf.all.rp_filter": "2",
           "net.ipv4.conf.default.rp_filter": "2",
           "net.ipv4.fwmark_reflect": "1",
-          "net.ipv6.fwmark_reflect": "1"
+          "net.ipv6.fwmark_reflect": "1",
+          "net.ipv4.ip_local_port_range": "49152 65535"
         }
       }]
   }'

--- a/docs/operations/constraints-and-limitations.md
+++ b/docs/operations/constraints-and-limitations.md
@@ -80,7 +80,7 @@ Only BGP-based GatewayRouter configuration is implemented. Static routing with B
 
 **17. BFD not fully restricted**
 
-BFD source ports are not restricted to the IANA-approved range (49152–65535) per RFC 5881 — BIRD on Linux does not support `IP_PORTRANGE`, requiring a `ip_local_port_range` sysctl workaround that is not yet configured. BFD is not restricted to single-hop mode port (3784), and BFD sessions are not restricted by configuration to the external interface(s) only.
+BFD source ports comply with the IANA-approved range (49152–65535) per RFC 5881 only when `net.ipv4.ip_local_port_range` is set to `49152 65535` in the LB Pod's network namespace. This can be achieved via a tuning NAD (e.g., the `sysctl-tuning` NAD example in [Gateway controller docs](../controllers/gateway.md#sysctl-prerequisites-for-lb-pods)) attached to the LB Pods through GatewayConfiguration. Without it, BIRD uses the kernel default range which violates the RFC. BFD is not restricted to single-hop mode port (3784), and BFD sessions are not restricted by configuration to the external interface(s) only.
 
 ## Sidecar Controller
 

--- a/test/e2e/suites/common-appnetwork/nad.yaml
+++ b/test/e2e/suites/common-appnetwork/nad.yaml
@@ -20,7 +20,8 @@ spec:
             "net.ipv4.conf.all.rp_filter": "2",
             "net.ipv4.conf.default.rp_filter": "2",
             "net.ipv4.fwmark_reflect": "1",
-            "net.ipv6.fwmark_reflect": "1"
+            "net.ipv6.fwmark_reflect": "1",
+            "net.ipv4.ip_local_port_range": "49152 65535"
           }
         }
       ]

--- a/test/e2e/suites/low-mtu/nad.yaml
+++ b/test/e2e/suites/low-mtu/nad.yaml
@@ -20,7 +20,8 @@ spec:
             "net.ipv4.conf.all.rp_filter": "2",
             "net.ipv4.conf.default.rp_filter": "2",
             "net.ipv4.fwmark_reflect": "1",
-            "net.ipv6.fwmark_reflect": "1"
+            "net.ipv6.fwmark_reflect": "1",
+            "net.ipv4.ip_local_port_range": "49152 65535"
           }
         }
       ]

--- a/test/e2e/suites/sctp-multihoming/nad.yaml
+++ b/test/e2e/suites/sctp-multihoming/nad.yaml
@@ -21,7 +21,8 @@ spec:
             "net.ipv4.conf.default.rp_filter": "2",
             "net.ipv4.fwmark_reflect": "1",
             "net.ipv6.fwmark_reflect": "1",
-            "net.ipv6.conf.all.accept_dad": "0"
+            "net.ipv6.conf.all.accept_dad": "0",
+            "net.ipv4.ip_local_port_range": "49152 65535"
           }
         }
       ]

--- a/test/e2e/suites/separate-appnetwork/nad.yaml
+++ b/test/e2e/suites/separate-appnetwork/nad.yaml
@@ -20,7 +20,8 @@ spec:
             "net.ipv4.conf.all.rp_filter": "2",
             "net.ipv4.conf.default.rp_filter": "2",
             "net.ipv4.fwmark_reflect": "1",
-            "net.ipv6.fwmark_reflect": "1"
+            "net.ipv6.fwmark_reflect": "1",
+            "net.ipv4.ip_local_port_range": "49152 65535"
           }
         }
       ]


### PR DESCRIPTION
### Problem

BIRD uses the kernel's ephemeral port allocation for BFD UDP sockets. The Linux default range (32768 60999) violates RFC 5881, and strict BFD peers may reject packets with source ports below 49152.

### Alternatives considered

1. Init container in the LB Deployment template
It requires `privileged: true` for the init container, which conflicts with the restricted Pod Security Standard currently in use.

2. Pod-level securityContext.sysctls
It would require the sysctl to be listed as "safe" in the kubelet config, or the Pod Security Admission to allow "unsafe" `sysctls. ip_local_port_range` is namespaced (per-netns) so it's safe in practice, but K8s classifies it as unsafe by default.

3. Set it inside the router process at startup
`/proc/sys` is mounted read-only in containers; `NET_ADMIN` capability is not enough, it would require `SYS_ADMIN` too.

### Solution
#### `sysctl` tuning via Multus NAD
Add `"net.ipv4.ip_local_port_range": "49152 65535"` to the existing `sysctl-tuning` NAD that is already attached to LB Pods via GatewayConfiguration. This applies the correct range in the Pod's network namespace without requiring code changes or additional capabilities.

It fixes #77.