### PR TITLE
Sidecar restart recovery: emptyDir persistence + kernel VIP scanning

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -114,7 +114,7 @@ jobs:
         if: failure()
         run: |
           NS="e2e-${{ matrix.suite }}"
-          kubectl get pods -n $NS -o wide
+          kubectl get pods -A -o wide
           kubectl describe pods -n $NS
           kubectl get events -n $NS --sort-by='.lastTimestamp'
           kubectl logs -n $NS --all-containers --prefix --tail=200 -l app || true

--- a/cmd/network-sidecar/cmd/run.go
+++ b/cmd/network-sidecar/cmd/run.go
@@ -126,7 +126,7 @@ func runSidecar(cfg *config.SidecarConfig) error {
 		PodUID:     cfg.PodUID,
 		MinTableID: cfg.MinTableID,
 		MaxTableID: cfg.MaxTableID,
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(mgr, cfg); err != nil {
 		return fmt.Errorf("failed to setup controller: %w", err)
 	}
 

--- a/docs/controllers/sidecar.md
+++ b/docs/controllers/sidecar.md
@@ -176,9 +176,13 @@ Write a mapping file to an `emptyDir` mount on each reconcile. `emptyDir` surviv
 **4. nftables maps with gateway name hashing:**
 Store `hash(gatewayName) → tableID` in a `mark : mark` nftables map. Avoids the VIP instability problem, but adds hash collision risk and complexity.
 
-No approach has been selected yet. The kernel scan approach (1) is simplest but causes brief disruption. The `emptyDir` approach (3) preserves traffic but relies on filesystem state. A hybrid (persist mapping + surgical diff) would be ideal but adds complexity.
+**Current implementation:** Hybrid approach combining 1 and 3:
+- **Kernel VIP scan** (`scanManagedVIPs`) runs at startup to seed `managedVIPs` from existing /32 and /128 addresses on secondary interfaces. This prevents VIP leaks (Issue 1) by enabling cleanup of stale VIPs even after restart.
+- **emptyDir persistence** (`loadMapping`/`saveMapping`) preserves the `gatewayName → tableID` mapping via `--table-id-mapping-file` (default: `/var/run/meridio/table-id-mapping.json`). This prevents table ID shifts (Issues 2 & 3) by restoring stable mappings across container restarts.
 
-**Status: Not yet implemented.** Required before production use.
+The mapping file is saved after each successful reconcile and loaded at startup. Persistence can be disabled by setting `--table-id-mapping-file=""` (useful for testing or when table ID stability is not required).
+
+**Why hybrid:** Neither approach alone solves all issues. Kernel scan addresses VIP leaks but cannot recover table IDs (no `gatewayName` in kernel state). emptyDir preserves table IDs but cannot discover stale VIPs (file only contains current gateways). Together they provide complete restart recovery without traffic disruption.
 
 ## Error Handling
 
@@ -215,6 +219,7 @@ This tolerance is essential for idempotent reconciliation and makes the controll
 | `--pod-uid` | `POD_UID` | (required) | Pod UID (Downward API) |
 | `--min-table-id` | `MERIDIO_MIN_TABLE_ID` | `50000` | Minimum routing table ID |
 | `--max-table-id` | `MERIDIO_MAX_TABLE_ID` | `55000` | Maximum routing table ID |
+| `--table-id-mapping-file` | `MERIDIO_TABLE_ID_MAPPING_FILE` | `/var/run/meridio/table-id-mapping.json` | Path to persist table ID allocations (empty to disable) |
 | `--health-probe-bind-address` | `MERIDIO_PROBE_ADDR` | `:8082` | Health probe address |
 | `--log-level` | `MERIDIO_LOG_LEVEL` | `info` | Log level |
 | `--metrics-bind-address` | `MERIDIO_METRICS_ADDR` | `0` | Metrics endpoint (0 = disabled) |
@@ -813,7 +818,9 @@ internal/controller/sidecar/
 ├── network.go             # findInterfaceBySubnet, syncVIPs, syncRules, syncRoutes, flushTable
 ├── netlink.go             # netlinkOps interface + defaultNetlinkOps (real netlink delegation)
 ├── tableid.go             # tableIDAllocator (gateway name → table ID mapping)
+├── persistence.go         # loadMapping/saveMapping (emptyDir persistence)
 ├── controller_test.go     # Unit tests (Reconcile, status, network functions)
+├── persistence_test.go    # Persistence tests (load/save, round-trip, empty path)
 ├── mock_netlink_test.go   # mockNetlink implementation for testing
 └── tableid_test.go        # Table ID allocator tests
 

--- a/docs/controllers/sidecar.md
+++ b/docs/controllers/sidecar.md
@@ -115,9 +115,9 @@ The manager's cache is configured to watch only the single ENC matching the Pod 
 
 **ObservedGeneration:** Tracks which ENC generation was processed
 
-## Known Limitations: Restart Recovery
+## Restart Recovery
 
-The controller keeps `tableIDs`, `managedVIPs`, and `nl` in memory. On restart (Pod restart, OOM kill, node reboot), all in-memory state is lost. The first reconcile after restart re-initializes these as empty, which causes several issues:
+The controller keeps `tableIDs`, `managedVIPs`, and `nl` in memory. On restart (Pod restart, OOM kill, node reboot), this in-memory state is lost. If the first reconcile after restart re-initializes these as empty (no recovery mechanism), several issues can occur:
 
 ### Issues
 
@@ -131,11 +131,11 @@ Note: VIP re-add after restart is not an issue — `syncVIPs` tolerates `EEXIST`
 
 #### Issue 1: VIP leak
 
-`managedVIPs` is empty after restart, so VIPs from a previous run that are no longer desired are never removed — `syncVIPs` only removes VIPs within its managed set.
+Without recovery, `managedVIPs` would be empty after restart, so VIPs from a previous run that are no longer desired would never be removed — `syncVIPs` only removes VIPs within its managed set.
 
 #### Issues 2 & 3: Orphaned routes and rules on table ID shift
 
-Both share the same root cause: after restart the `tableIDAllocator` has no memory of previously-used table IDs, so tables from a previous run that aren't re-allocated become invisible orphans.
+Both share the same root cause: without recovery, the `tableIDAllocator` after restart has no memory of previously-used table IDs, so tables from a previous run that aren't re-allocated become invisible orphans.
 
 **Concrete scenario:**
 
@@ -145,16 +145,16 @@ Before restart:
 - Kernel: table 50000 has gw-a routes/rules, table 50001 has gw-b routes/rules
 
 After restart, `gw-a` is removed from the ENC:
-- Allocator starts fresh: `gw-b → 50000` (first and only allocation)
+- Without recovery, allocator starts fresh: `gw-b → 50000` (first and only allocation)
 - Controller writes gw-b's routes into table 50000 via `RouteReplace`, overwriting gw-a's old routes — this is fine
 - But table 50001 (gw-b's old table) is never allocated to any gateway
 - `flushTable` only runs for gateways removed from the *current* ENC spec, and the allocator doesn't know 50001 was ever used
 - `syncRules` only scans rules matching its own `tableID`, so rules pointing to 50001 are never cleaned
 - Result: table 50001 retains stale routes and rules indefinitely
 
-Table ID shift is a latent condition that builds up during normal operation through gateway add/remove cycles, but only manifests after a restart. For example: `gw-c → 50000`, `gw-d → 50001` are added first, then `gw-a → 50002`, `gw-b → 50003`. Later `gw-c` and `gw-d` are removed (properly cleaned, IDs 50000-50001 freed). Running state is now `gw-a → 50002`, `gw-b → 50003` — correct while the process is alive. After restart, the fresh allocator assigns `gw-a → 50000`, `gw-b → 50001`. Tables 50002 and 50003 are now orphaned with stale routes and rules.
+Table ID shift is a latent condition that builds up during normal operation through gateway add/remove cycles, but only manifests after a restart. For example: `gw-c → 50000`, `gw-d → 50001` are added first, then `gw-a → 50002`, `gw-b → 50003`. Later `gw-c` and `gw-d` are removed (properly cleaned, IDs 50000-50001 freed). Running state is now `gw-a → 50002`, `gw-b → 50003` — correct while the process is alive. After restart without recovery, the fresh allocator assigns `gw-a → 50000`, `gw-b → 50001`. Tables 50002 and 50003 are now orphaned with stale routes and rules.
 
-A simpler variant: the gateway set shrinks while the sidecar is down (e.g. `gw-b` removed from the ENC during a restart). The running sidecar would have cleaned table 50001 via the stale gateway path, but since it wasn't running, the cleanup never happened. After restart, only `gw-a → 50000` is allocated — table 50001 retains gw-b's old routes and rules with no code path to reach it.
+A simpler variant: the gateway set shrinks while the sidecar is down (e.g. `gw-b` removed from the ENC during a restart). The running sidecar would have cleaned table 50001 via the stale gateway path, but since it wasn't running, the cleanup never happened. After restart without recovery, only `gw-a → 50000` is allocated — table 50001 retains gw-b's old routes and rules with no code path to reach it.
 
 Note: a pure ID swap (same gateways, different assignment) is self-healing — `RouteReplace` overwrites old routes and `syncRules` cleans stale rules in all actively-allocated tables. The problem is only with *unallocated* tables that no gateway claims.
 
@@ -182,7 +182,7 @@ Store `hash(gatewayName) → tableID` in a `mark : mark` nftables map. Avoids th
 
 The mapping file is saved after each successful reconcile and loaded at startup. Persistence can be disabled by setting `--table-id-mapping-file=""` (useful for testing or when table ID stability is not required).
 
-**Why hybrid:** Neither approach alone solves all issues. Kernel scan addresses VIP leaks but cannot recover table IDs (no `gatewayName` in kernel state). emptyDir preserves table IDs but cannot discover stale VIPs (file only contains current gateways). Together they provide complete restart recovery without traffic disruption.
+**Why hybrid:** Neither approach alone solves all issues. Kernel scan addresses VIP leaks but cannot recover table IDs (no `gatewayName` in kernel state). emptyDir preserves table IDs but cannot discover stale VIPs (file only contains current gateways). Together they can provide restart recovery without traffic disruption.
 
 ## Error Handling
 

--- a/docs/operations/constraints-and-limitations.md
+++ b/docs/operations/constraints-and-limitations.md
@@ -84,9 +84,9 @@ BFD source ports comply with the IANA-approved range (49152–65535) per RFC 588
 
 ## Sidecar Controller
 
-**18. No sidecar restart recovery**
+**18. ~~No sidecar restart recovery~~ (Resolved)**
 
-All in-memory state (`tableIDs`, `managedVIPs`) is lost on sidecar container restart. This causes VIP leaks (old VIPs not removed from the interface) and orphaned routing rules/tables when table IDs are reallocated differently after restart. Restarting the sidecar container/process is not recommended.
+The sidecar implements restart recovery via hybrid approach: emptyDir persistence for table ID mappings and kernel VIP scanning. Primary issues (table ID shifts, VIP leaks on in-scope interfaces, orphaned routes/rules) are resolved. Some edge cases remain (VIP cleanup for removed-gateway exclusive interfaces). See [Sidecar Controller docs](../controllers/sidecar.md#restart-recovery) for details.
 
 **19. Sidecar policy routing rule priority not configurable** *(architectural constraint)*
 

--- a/internal/common/config/sidecar.go
+++ b/internal/common/config/sidecar.go
@@ -22,19 +22,20 @@ import (
 
 // SidecarConfig holds configuration for the network sidecar
 type SidecarConfig struct {
-	PodName         string
-	PodNamespace    string
-	PodUID          string
-	ProbeAddr       string
-	LogLevel        string
-	MinTableID      int
-	MaxTableID      int
-	MetricsAddr     string
-	SecureMetrics   bool
-	MetricsCertPath string
-	MetricsCertName string
-	MetricsCertKey  string
-	EnableHTTP2     bool
+	PodName            string
+	PodNamespace       string
+	PodUID             string
+	ProbeAddr          string
+	LogLevel           string
+	MinTableID         int
+	MaxTableID         int
+	TableIDMappingFile string
+	MetricsAddr        string
+	SecureMetrics      bool
+	MetricsCertPath    string
+	MetricsCertName    string
+	MetricsCertKey     string
+	EnableHTTP2        bool
 }
 
 // AddFlags adds configuration flags to the provided FlagSet
@@ -53,6 +54,8 @@ func (c *SidecarConfig) AddFlags(fs *pflag.FlagSet) {
 		"Minimum routing table ID for source-based routing")
 	fs.IntVar(&c.MaxTableID, "max-table-id", 55000,
 		"Maximum routing table ID for source-based routing")
+	fs.StringVar(&c.TableIDMappingFile, "table-id-mapping-file", "/var/run/meridio/table-id-mapping.json",
+		"Path to persist table ID allocations (empty to disable)")
 	fs.StringVar(&c.MetricsAddr, "metrics-bind-address", "0",
 		"The address the metrics endpoint binds to. "+
 			"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
@@ -78,10 +81,16 @@ func (c *SidecarConfig) BindEnv(fs *pflag.FlagSet) {
 	bindString(fs, "log-level", "MERIDIO_LOG_LEVEL", &c.LogLevel)
 	bindInt(fs, "min-table-id", "MERIDIO_MIN_TABLE_ID", &c.MinTableID)
 	bindInt(fs, "max-table-id", "MERIDIO_MAX_TABLE_ID", &c.MaxTableID)
+	bindString(fs, "table-id-mapping-file", "MERIDIO_TABLE_ID_MAPPING_FILE", &c.TableIDMappingFile)
 	bindString(fs, "metrics-bind-address", "MERIDIO_METRICS_ADDR", &c.MetricsAddr)
 	bindBool(fs, "metrics-secure", "MERIDIO_METRICS_SECURE", &c.SecureMetrics)
 	bindString(fs, "metrics-cert-path", "MERIDIO_METRICS_CERT_PATH", &c.MetricsCertPath)
 	bindString(fs, "metrics-cert-name", "MERIDIO_METRICS_CERT_NAME", &c.MetricsCertName)
 	bindString(fs, "metrics-cert-key", "MERIDIO_METRICS_CERT_KEY", &c.MetricsCertKey)
 	bindBool(fs, "enable-http2", "MERIDIO_ENABLE_HTTP2", &c.EnableHTTP2)
+}
+
+// GetTableIDMappingFile returns the table ID mapping file path.
+func (c *SidecarConfig) GetTableIDMappingFile() string {
+	return c.TableIDMappingFile
 }

--- a/internal/controller/sidecar/controller.go
+++ b/internal/controller/sidecar/controller.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net"
 
+	"github.com/go-logr/logr"
 	meridio2v1alpha1 "github.com/nordix/meridio-2/api/v1alpha1"
 	"github.com/vishvananda/netlink"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -318,44 +319,40 @@ func (c *Controller) isOwnedByPod(enc *meridio2v1alpha1.EndpointNetworkConfigura
 	return false
 }
 
-// SetupWithManager sets up the controller with the Manager.
-func (c *Controller) SetupWithManager(mgr ctrl.Manager, cfg interface{ GetTableIDMappingFile() string }) error {
-	// Store mapping file path from config
-	c.mappingFile = cfg.GetTableIDMappingFile()
-
-	// Initialize allocator and load persisted mapping before reconciliation starts
+// recoverState initializes allocator and managedVIPs, restoring from persisted
+// mapping and kernel state. Logs warnings on partial recovery but continues.
+func (c *Controller) recoverState(log logr.Logger) {
 	c.tableIDs = newTableIDAllocator(c.MinTableID, c.MaxTableID)
 	c.managedVIPs = make(map[string]map[string]struct{})
 
-	setupLog := mgr.GetLogger().WithName("sidecar-setup")
-
 	// Load persisted table ID mapping
 	if err := loadMapping(c.tableIDs, c.mappingFile); err != nil {
-		// Log warning but continue - reconcile will rebuild state from ENC
-		setupLog.Error(err, "failed to load table ID mapping, starting fresh")
-	} else if c.mappingFile != "" {
-		mapping := c.tableIDs.snapshot()
-		if len(mapping) > 0 {
-			setupLog.Info("loaded table ID mapping from file", "gateways", len(mapping))
-		} else {
-			setupLog.Info("no persisted table ID mapping found (first run or clean state)")
-		}
+		log.Error(err, "failed to load table ID mapping, starting fresh")
+	} else if len(c.tableIDs.snapshot()) > 0 {
+		log.Info("loaded table ID mapping from file", "gateways", len(c.tableIDs.snapshot()))
 	}
 
-	// Scan kernel for existing VIPs to seed managedVIPs (prevents VIP leak on restart)
+	// Scan kernel for existing VIPs
 	nl := &netlink.Handle{}
-	if scannedVIPs, err := scanManagedVIPs(nl); err != nil {
-		setupLog.Error(err, "failed to scan existing VIPs, starting fresh")
-	} else {
-		c.managedVIPs = scannedVIPs
-		totalVIPs := 0
-		for _, vips := range scannedVIPs {
-			totalVIPs += len(vips)
-		}
-		if totalVIPs > 0 {
-			setupLog.Info("scanned existing VIPs from kernel", "interfaces", len(scannedVIPs), "vips", totalVIPs)
-		}
+	scannedVIPs, err := scanManagedVIPs(nl)
+	if err != nil {
+		log.Error(err, "failed to scan existing VIPs, starting fresh")
+		return
 	}
+	c.managedVIPs = scannedVIPs
+	totalVIPs := 0
+	for _, vips := range scannedVIPs {
+		totalVIPs += len(vips)
+	}
+	if totalVIPs > 0 {
+		log.Info("scanned existing VIPs from kernel", "interfaces", len(scannedVIPs), "vips", totalVIPs)
+	}
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (c *Controller) SetupWithManager(mgr ctrl.Manager, cfg interface{ GetTableIDMappingFile() string }) error {
+	c.mappingFile = cfg.GetTableIDMappingFile()
+	c.recoverState(mgr.GetLogger().WithName("sidecar-setup"))
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&meridio2v1alpha1.EndpointNetworkConfiguration{}).

--- a/internal/controller/sidecar/controller.go
+++ b/internal/controller/sidecar/controller.go
@@ -71,10 +71,7 @@ type domainState struct {
 func (c *Controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := logf.FromContext(ctx)
 
-	if c.tableIDs == nil {
-		c.tableIDs = newTableIDAllocator(c.MinTableID, c.MaxTableID)
-		c.managedVIPs = make(map[string]map[string]bool)
-	}
+	// Initialize netlink handle if not already set (test hook)
 	if c.nl == nil {
 		c.nl = &netlink.Handle{}
 	}
@@ -138,6 +135,12 @@ func (c *Controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			c.tableIDs.release(gwName)
 			log.Info("cleaned up stale gateway", "gateway", gwName, "tableID", tableID)
 		}
+	}
+
+	// Persist table ID mapping after successful configuration
+	if err := saveMapping(c.tableIDs); err != nil {
+		log.Error(err, "failed to save table ID mapping")
+		// Non-fatal: continue with status update
 	}
 
 	// Success
@@ -316,6 +319,40 @@ func (c *Controller) isOwnedByPod(enc *meridio2v1alpha1.EndpointNetworkConfigura
 
 // SetupWithManager sets up the controller with the Manager.
 func (c *Controller) SetupWithManager(mgr ctrl.Manager) error {
+	// Initialize allocator and load persisted mapping before reconciliation starts
+	c.tableIDs = newTableIDAllocator(c.MinTableID, c.MaxTableID)
+	c.managedVIPs = make(map[string]map[string]bool)
+
+	setupLog := mgr.GetLogger().WithName("sidecar-setup")
+
+	// Load persisted table ID mapping
+	if err := loadMapping(c.tableIDs); err != nil {
+		// Log warning but continue - reconcile will rebuild state from ENC
+		setupLog.Error(err, "failed to load table ID mapping, starting fresh")
+	} else {
+		mapping := c.tableIDs.snapshot()
+		if len(mapping) > 0 {
+			setupLog.Info("loaded table ID mapping from file", "gateways", len(mapping))
+		} else {
+			setupLog.Info("no persisted table ID mapping found (first run or clean state)")
+		}
+	}
+
+	// Scan kernel for existing VIPs to seed managedVIPs (prevents VIP leak on restart)
+	nl := &netlink.Handle{}
+	if scannedVIPs, err := scanManagedVIPs(nl); err != nil {
+		setupLog.Error(err, "failed to scan existing VIPs, starting fresh")
+	} else {
+		c.managedVIPs = scannedVIPs
+		totalVIPs := 0
+		for _, vips := range scannedVIPs {
+			totalVIPs += len(vips)
+		}
+		if totalVIPs > 0 {
+			setupLog.Info("scanned existing VIPs from kernel", "interfaces", len(scannedVIPs), "vips", totalVIPs)
+		}
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&meridio2v1alpha1.EndpointNetworkConfiguration{}).
 		Named("sidecar").

--- a/internal/controller/sidecar/controller.go
+++ b/internal/controller/sidecar/controller.go
@@ -325,6 +325,11 @@ func (c *Controller) recoverState(log logr.Logger) {
 	c.tableIDs = newTableIDAllocator(c.MinTableID, c.MaxTableID)
 	c.managedVIPs = make(map[string]map[string]struct{})
 
+	// Initialize netlink handle if not already set (test hook)
+	if c.nl == nil {
+		c.nl = &netlink.Handle{}
+	}
+
 	// Load persisted table ID mapping
 	if err := loadMapping(c.tableIDs, c.mappingFile); err != nil {
 		log.Error(err, "failed to load table ID mapping, starting fresh")
@@ -333,8 +338,7 @@ func (c *Controller) recoverState(log logr.Logger) {
 	}
 
 	// Scan kernel for existing VIPs
-	nl := &netlink.Handle{}
-	scannedVIPs, err := scanManagedVIPs(nl)
+	scannedVIPs, err := scanManagedVIPs(c.nl)
 	if err != nil {
 		log.Error(err, "failed to scan existing VIPs, starting fresh")
 		return

--- a/internal/controller/sidecar/controller.go
+++ b/internal/controller/sidecar/controller.go
@@ -47,11 +47,12 @@ import (
 //   - Container capability: NET_ADMIN
 type Controller struct {
 	client.Client
-	Scheme     *runtime.Scheme
-	PodName    string
-	PodUID     string
-	MinTableID int
-	MaxTableID int
+	Scheme      *runtime.Scheme
+	PodName     string
+	PodUID      string
+	MinTableID  int
+	MaxTableID  int
+	mappingFile string
 
 	nl          netlinkOps
 	tableIDs    *tableIDAllocator
@@ -138,7 +139,7 @@ func (c *Controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 
 	// Persist table ID mapping after successful configuration
-	if err := saveMapping(c.tableIDs); err != nil {
+	if err := saveMapping(c.tableIDs, c.mappingFile); err != nil {
 		log.Error(err, "failed to save table ID mapping")
 		// Non-fatal: continue with status update
 	}
@@ -318,7 +319,10 @@ func (c *Controller) isOwnedByPod(enc *meridio2v1alpha1.EndpointNetworkConfigura
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (c *Controller) SetupWithManager(mgr ctrl.Manager) error {
+func (c *Controller) SetupWithManager(mgr ctrl.Manager, cfg interface{ GetTableIDMappingFile() string }) error {
+	// Store mapping file path from config
+	c.mappingFile = cfg.GetTableIDMappingFile()
+
 	// Initialize allocator and load persisted mapping before reconciliation starts
 	c.tableIDs = newTableIDAllocator(c.MinTableID, c.MaxTableID)
 	c.managedVIPs = make(map[string]map[string]struct{})
@@ -326,10 +330,10 @@ func (c *Controller) SetupWithManager(mgr ctrl.Manager) error {
 	setupLog := mgr.GetLogger().WithName("sidecar-setup")
 
 	// Load persisted table ID mapping
-	if err := loadMapping(c.tableIDs); err != nil {
+	if err := loadMapping(c.tableIDs, c.mappingFile); err != nil {
 		// Log warning but continue - reconcile will rebuild state from ENC
 		setupLog.Error(err, "failed to load table ID mapping, starting fresh")
-	} else {
+	} else if c.mappingFile != "" {
 		mapping := c.tableIDs.snapshot()
 		if len(mapping) > 0 {
 			setupLog.Info("loaded table ID mapping from file", "gateways", len(mapping))

--- a/internal/controller/sidecar/controller.go
+++ b/internal/controller/sidecar/controller.go
@@ -55,7 +55,7 @@ type Controller struct {
 
 	nl          netlinkOps
 	tableIDs    *tableIDAllocator
-	managedVIPs map[string]map[string]bool // interface name → VIP string → true
+	managedVIPs map[string]map[string]struct{} // interface name → VIP string set
 }
 
 // domainState holds the desired network state for a single domain.
@@ -284,7 +284,7 @@ func (c *Controller) cleanupAll(ctx context.Context) {
 		// requeue on partial cleanup failure instead of silently succeeding.
 		_, _ = syncVIPs(c.nl, link, nil, managed)
 	}
-	c.managedVIPs = make(map[string]map[string]bool)
+	c.managedVIPs = make(map[string]map[string]struct{})
 }
 
 func (c *Controller) updateStatus(ctx context.Context, enc *meridio2v1alpha1.EndpointNetworkConfiguration, reconcileErr error) error {
@@ -321,7 +321,7 @@ func (c *Controller) isOwnedByPod(enc *meridio2v1alpha1.EndpointNetworkConfigura
 func (c *Controller) SetupWithManager(mgr ctrl.Manager) error {
 	// Initialize allocator and load persisted mapping before reconciliation starts
 	c.tableIDs = newTableIDAllocator(c.MinTableID, c.MaxTableID)
-	c.managedVIPs = make(map[string]map[string]bool)
+	c.managedVIPs = make(map[string]map[string]struct{})
 
 	setupLog := mgr.GetLogger().WithName("sidecar-setup")
 

--- a/internal/controller/sidecar/controller_test.go
+++ b/internal/controller/sidecar/controller_test.go
@@ -71,13 +71,15 @@ func setupController(nl *mockNetlink, objects ...client.Object) (*Controller, cl
 		Build()
 
 	return &Controller{
-		Client:     fakeClient,
-		Scheme:     newScheme(),
-		PodName:    testPodName,
-		PodUID:     testPodUID,
-		MinTableID: 50000,
-		MaxTableID: 55000,
-		nl:         nl,
+		Client:      fakeClient,
+		Scheme:      newScheme(),
+		PodName:     testPodName,
+		PodUID:      testPodUID,
+		MinTableID:  50000,
+		MaxTableID:  55000,
+		nl:          nl,
+		tableIDs:    newTableIDAllocator(50000, 55000),
+		managedVIPs: make(map[string]map[string]bool),
 	}, fakeClient
 }
 
@@ -801,4 +803,87 @@ func TestFlushTable_OutOfRange_NoOp(t *testing.T) {
 func TestVipToIPNet(t *testing.T) {
 	assert.Equal(t, "20.0.0.1/32", vipToIPNet(net.ParseIP("20.0.0.1")).String())
 	assert.Equal(t, "2001:db8::1/128", vipToIPNet(net.ParseIP("2001:db8::1")).String())
+}
+
+func TestScanManagedVIPs_EmptyInterfaces(t *testing.T) {
+	nl := newMockNetlink()
+
+	result, err := scanManagedVIPs(nl)
+
+	assert.NoError(t, err)
+	assert.Empty(t, result)
+}
+
+func TestScanManagedVIPs_SkipsPrimaryInterfaces(t *testing.T) {
+	nl := newMockNetlink()
+	nl.addLink("lo", 1, "127.0.0.1/8")
+	nl.addLink("eth0", 2, "10.244.1.5/24")
+
+	result, err := scanManagedVIPs(nl)
+
+	assert.NoError(t, err)
+	assert.Empty(t, result, "should skip lo and eth0")
+}
+
+func TestScanManagedVIPs_FindsVIPsOnSecondaryInterfaces(t *testing.T) {
+	nl := newMockNetlink()
+	nl.addLink("net1", 3, "192.168.100.10/24")
+	nl.addLink("net2", 4, "192.168.200.10/24")
+
+	// Add VIPs (/32 and /128)
+	link1, _ := nl.LinkByName("net1")
+	_ = nl.AddrAdd(link1, &netlink.Addr{IPNet: mustParseCIDR("20.0.0.1/32")})
+	_ = nl.AddrAdd(link1, &netlink.Addr{IPNet: mustParseCIDR("20.0.0.2/32")})
+
+	link2, _ := nl.LinkByName("net2")
+	_ = nl.AddrAdd(link2, &netlink.Addr{IPNet: mustParseCIDR("2001:db8::1/128")})
+
+	result, err := scanManagedVIPs(nl)
+
+	assert.NoError(t, err)
+	assert.Len(t, result, 2)
+	assert.Len(t, result["net1"], 2)
+	assert.True(t, result["net1"]["20.0.0.1"])
+	assert.True(t, result["net1"]["20.0.0.2"])
+	assert.Len(t, result["net2"], 1)
+	assert.True(t, result["net2"]["2001:db8::1"])
+}
+
+func TestScanManagedVIPs_IgnoresNonHostAddresses(t *testing.T) {
+	nl := newMockNetlink()
+	nl.addLink("net1", 3, "192.168.100.10/24") // /24 should be ignored
+
+	link, _ := nl.LinkByName("net1")
+	_ = nl.AddrAdd(link, &netlink.Addr{IPNet: mustParseCIDR("20.0.0.1/32")}) // /32 should be found
+
+	result, err := scanManagedVIPs(nl)
+
+	assert.NoError(t, err)
+	assert.Len(t, result["net1"], 1)
+	assert.True(t, result["net1"]["20.0.0.1"])
+	assert.False(t, result["net1"]["192.168.100.10"], "should not include /24 address")
+}
+
+func TestScanManagedVIPs_DualStack(t *testing.T) {
+	nl := newMockNetlink()
+	nl.addLink("net1", 3, "192.168.100.10/24")
+
+	link, _ := nl.LinkByName("net1")
+	_ = nl.AddrAdd(link, &netlink.Addr{IPNet: mustParseCIDR("20.0.0.1/32")})
+	_ = nl.AddrAdd(link, &netlink.Addr{IPNet: mustParseCIDR("2001:db8::1/128")})
+
+	result, err := scanManagedVIPs(nl)
+
+	assert.NoError(t, err)
+	assert.Len(t, result["net1"], 2)
+	assert.True(t, result["net1"]["20.0.0.1"])
+	assert.True(t, result["net1"]["2001:db8::1"])
+}
+
+func mustParseCIDR(s string) *net.IPNet {
+	_, ipnet, err := net.ParseCIDR(s)
+	if err != nil {
+		panic(err)
+	}
+	return ipnet
 }

--- a/internal/controller/sidecar/controller_test.go
+++ b/internal/controller/sidecar/controller_test.go
@@ -79,7 +79,7 @@ func setupController(nl *mockNetlink, objects ...client.Object) (*Controller, cl
 		MaxTableID:  55000,
 		nl:          nl,
 		tableIDs:    newTableIDAllocator(50000, 55000),
-		managedVIPs: make(map[string]map[string]bool),
+		managedVIPs: make(map[string]map[string]struct{}),
 	}, fakeClient
 }
 
@@ -153,8 +153,8 @@ func TestReconcile_ENCNotFound_CleansUpState(t *testing.T) {
 	// Pre-populate state
 	c.tableIDs = newTableIDAllocator(50000, 55000)
 	_, _ = c.tableIDs.allocate("gw-a")
-	c.managedVIPs = map[string]map[string]bool{
-		"net1": {"20.0.0.1": true},
+	c.managedVIPs = map[string]map[string]struct{}{
+		"net1": {"20.0.0.1": struct{}{}},
 	}
 
 	_, err := c.Reconcile(context.Background(), reconcileRequest())
@@ -843,10 +843,13 @@ func TestScanManagedVIPs_FindsVIPsOnSecondaryInterfaces(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, result, 2)
 	assert.Len(t, result["net1"], 2)
-	assert.True(t, result["net1"]["20.0.0.1"])
-	assert.True(t, result["net1"]["20.0.0.2"])
+	_, exists := result["net1"]["20.0.0.1"]
+	assert.True(t, exists)
+	_, exists = result["net1"]["20.0.0.2"]
+	assert.True(t, exists)
 	assert.Len(t, result["net2"], 1)
-	assert.True(t, result["net2"]["2001:db8::1"])
+	_, exists = result["net2"]["2001:db8::1"]
+	assert.True(t, exists)
 }
 
 func TestScanManagedVIPs_IgnoresNonHostAddresses(t *testing.T) {
@@ -860,8 +863,10 @@ func TestScanManagedVIPs_IgnoresNonHostAddresses(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Len(t, result["net1"], 1)
-	assert.True(t, result["net1"]["20.0.0.1"])
-	assert.False(t, result["net1"]["192.168.100.10"], "should not include /24 address")
+	_, exists := result["net1"]["20.0.0.1"]
+	assert.True(t, exists)
+	_, exists = result["net1"]["192.168.100.10"]
+	assert.False(t, exists, "should not include /24 address")
 }
 
 func TestScanManagedVIPs_DualStack(t *testing.T) {
@@ -876,8 +881,10 @@ func TestScanManagedVIPs_DualStack(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Len(t, result["net1"], 2)
-	assert.True(t, result["net1"]["20.0.0.1"])
-	assert.True(t, result["net1"]["2001:db8::1"])
+	_, exists := result["net1"]["20.0.0.1"]
+	assert.True(t, exists)
+	_, exists = result["net1"]["2001:db8::1"]
+	assert.True(t, exists)
 }
 
 func mustParseCIDR(s string) *net.IPNet {

--- a/internal/controller/sidecar/network.go
+++ b/internal/controller/sidecar/network.go
@@ -85,6 +85,44 @@ func interfaceMatchesSubnet(nl netlinkOps, link netlink.Link, subnet *net.IPNet)
 	return false
 }
 
+// scanManagedVIPs scans all secondary interfaces for /32 and /128 addresses.
+// Returns map[interfaceName]map[vipString]true for seeding managedVIPs on startup.
+// Excludes primary interface (lo, eth0) to avoid touching cluster networking.
+func scanManagedVIPs(nl netlinkOps) (map[string]map[string]bool, error) {
+	result := make(map[string]map[string]bool)
+
+	links, err := nl.LinkList()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list interfaces: %w", err)
+	}
+
+	for _, link := range links {
+		ifName := link.Attrs().Name
+		// Skip primary interfaces
+		if ifName == "lo" || ifName == "eth0" {
+			continue
+		}
+
+		addrs, err := nl.AddrList(link, netlink.FAMILY_ALL)
+		if err != nil {
+			continue // Skip interfaces we can't read
+		}
+
+		for _, addr := range addrs {
+			// Only consider /32 (IPv4) and /128 (IPv6) as VIPs
+			ones, bits := addr.Mask.Size()
+			if ones == bits { // /32 or /128
+				if result[ifName] == nil {
+					result[ifName] = make(map[string]bool)
+				}
+				result[ifName][addr.IP.String()] = true
+			}
+		}
+	}
+
+	return result, nil
+}
+
 // syncVIPs ensures exactly the desired VIPs are present on the interface.
 // Adds missing VIPs, removes stale ones (only within the managed set).
 // Always returns the current managed set reflecting actual kernel state,

--- a/internal/controller/sidecar/network.go
+++ b/internal/controller/sidecar/network.go
@@ -88,8 +88,8 @@ func interfaceMatchesSubnet(nl netlinkOps, link netlink.Link, subnet *net.IPNet)
 // scanManagedVIPs scans all secondary interfaces for /32 and /128 addresses.
 // Returns map[interfaceName]map[vipString]true for seeding managedVIPs on startup.
 // Excludes primary interface (lo, eth0) to avoid touching cluster networking.
-func scanManagedVIPs(nl netlinkOps) (map[string]map[string]bool, error) {
-	result := make(map[string]map[string]bool)
+func scanManagedVIPs(nl netlinkOps) (map[string]map[string]struct{}, error) {
+	result := make(map[string]map[string]struct{})
 
 	links, err := nl.LinkList()
 	if err != nil {
@@ -113,9 +113,9 @@ func scanManagedVIPs(nl netlinkOps) (map[string]map[string]bool, error) {
 			ones, bits := addr.Mask.Size()
 			if ones == bits { // /32 or /128
 				if result[ifName] == nil {
-					result[ifName] = make(map[string]bool)
+					result[ifName] = make(map[string]struct{})
 				}
-				result[ifName][addr.IP.String()] = true
+				result[ifName][addr.IP.String()] = struct{}{}
 			}
 		}
 	}
@@ -127,21 +127,21 @@ func scanManagedVIPs(nl netlinkOps) (map[string]map[string]bool, error) {
 // Adds missing VIPs, removes stale ones (only within the managed set).
 // Always returns the current managed set reflecting actual kernel state,
 // even on error, so the caller can track partially-applied changes.
-func syncVIPs(nl netlinkOps, link netlink.Link, desiredVIPs []net.IP, managedVIPs map[string]bool) (map[string]bool, error) {
+func syncVIPs(nl netlinkOps, link netlink.Link, desiredVIPs []net.IP, managedVIPs map[string]struct{}) (map[string]struct{}, error) {
 	// Clone managed set — we mutate it incrementally to track actual state
-	current := make(map[string]bool, len(managedVIPs)+len(desiredVIPs))
+	current := make(map[string]struct{}, len(managedVIPs)+len(desiredVIPs))
 	for k := range managedVIPs {
-		current[k] = true
+		current[k] = struct{}{}
 	}
 
-	desired := make(map[string]bool, len(desiredVIPs))
+	desired := make(map[string]struct{}, len(desiredVIPs))
 	for _, vip := range desiredVIPs {
-		desired[vip.String()] = true
+		desired[vip.String()] = struct{}{}
 	}
 
 	// Remove stale managed VIPs (update current on each success)
 	for vipStr := range managedVIPs {
-		if desired[vipStr] {
+		if _, exists := desired[vipStr]; exists {
 			continue
 		}
 		ip := net.ParseIP(vipStr)
@@ -159,7 +159,7 @@ func syncVIPs(nl netlinkOps, link netlink.Link, desiredVIPs []net.IP, managedVIP
 	// Add missing VIPs (update current on each success)
 	for _, vip := range desiredVIPs {
 		vipStr := vip.String()
-		if current[vipStr] {
+		if _, exists := current[vipStr]; exists {
 			continue // already present
 		}
 		addr := &netlink.Addr{IPNet: vipToIPNet(vip)}
@@ -169,7 +169,7 @@ func syncVIPs(nl netlinkOps, link netlink.Link, desiredVIPs []net.IP, managedVIP
 		if err := nl.AddrAdd(link, addr); err != nil && !errors.Is(err, syscall.EEXIST) {
 			return current, fmt.Errorf("failed to add VIP %s: %w", vipStr, err)
 		}
-		current[vipStr] = true
+		current[vipStr] = struct{}{}
 	}
 
 	return current, nil

--- a/internal/controller/sidecar/persistence.go
+++ b/internal/controller/sidecar/persistence.go
@@ -17,10 +17,14 @@ limitations under the License.
 // Package sidecar implements the network sidecar controller.
 //
 // Restart Recovery:
-// The controller persists table ID mappings to /var/run/meridio/table-id-mapping.json
-// (emptyDir volume) to prevent table ID shifts across container restarts. On startup,
-// it also scans the kernel for existing VIPs (/32 and /128 addresses on secondary
-// interfaces) to enable cleanup of stale VIPs even if the mapping file is lost.
+// The controller can persist table ID mappings to an emptyDir volume to prevent
+// table ID shifts across container restarts. The path is configurable via
+// --table-id-mapping-file (default: /var/run/meridio/table-id-mapping.json).
+// Set to empty string to disable persistence.
+//
+// On startup, it also scans the kernel for existing VIPs (/32 and /128 addresses
+// on secondary interfaces) to enable cleanup of stale VIPs even if the mapping
+// file is lost or persistence is disabled.
 package sidecar
 
 import (
@@ -29,13 +33,16 @@ import (
 	"os"
 )
 
-const mappingFile = "/var/run/meridio/table-id-mapping.json"
-
 // loadMapping reads the persisted table ID mapping and seeds the allocator.
+// If path is empty, persistence is disabled and this is a no-op.
 // Returns nil if file doesn't exist (first run).
 // Returns error if file is corrupted or contains invalid data.
-func loadMapping(allocator *tableIDAllocator) error {
-	data, err := os.ReadFile(mappingFile)
+func loadMapping(allocator *tableIDAllocator, path string) error {
+	if path == "" {
+		return nil // Persistence disabled
+	}
+
+	data, err := os.ReadFile(path)
 	if os.IsNotExist(err) {
 		return nil // First run, no file yet
 	}
@@ -59,8 +66,13 @@ func loadMapping(allocator *tableIDAllocator) error {
 }
 
 // saveMapping writes the current allocator state to disk atomically.
+// If path is empty, persistence is disabled and this is a no-op.
 // Non-fatal errors are returned but should not stop reconciliation.
-func saveMapping(allocator *tableIDAllocator) error {
+func saveMapping(allocator *tableIDAllocator, path string) error {
+	if path == "" {
+		return nil // Persistence disabled
+	}
+
 	mapping := allocator.snapshot()
 	data, err := json.Marshal(mapping)
 	if err != nil {
@@ -68,12 +80,12 @@ func saveMapping(allocator *tableIDAllocator) error {
 	}
 
 	// Atomic write: write to temp file, then rename
-	tmpFile := mappingFile + ".tmp"
+	tmpFile := path + ".tmp"
 	if err := os.WriteFile(tmpFile, data, 0600); err != nil {
 		return fmt.Errorf("failed to write temp file: %w", err)
 	}
 
-	if err := os.Rename(tmpFile, mappingFile); err != nil {
+	if err := os.Rename(tmpFile, path); err != nil {
 		return fmt.Errorf("failed to rename temp file: %w", err)
 	}
 

--- a/internal/controller/sidecar/persistence.go
+++ b/internal/controller/sidecar/persistence.go
@@ -14,6 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package sidecar implements the network sidecar controller.
+//
+// Restart Recovery:
+// The controller persists table ID mappings to /var/run/meridio/table-id-mapping.json
+// (emptyDir volume) to prevent table ID shifts across container restarts. On startup,
+// it also scans the kernel for existing VIPs (/32 and /128 addresses on secondary
+// interfaces) to enable cleanup of stale VIPs even if the mapping file is lost.
 package sidecar
 
 import (

--- a/internal/controller/sidecar/persistence.go
+++ b/internal/controller/sidecar/persistence.go
@@ -1,0 +1,74 @@
+/*
+Copyright (c) 2026 OpenInfra Foundation Europe. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sidecar
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+const mappingFile = "/var/run/meridio/table-id-mapping.json"
+
+// loadMapping reads the persisted table ID mapping and seeds the allocator.
+// Returns nil if file doesn't exist (first run).
+// Returns error if file is corrupted or contains invalid data.
+func loadMapping(allocator *tableIDAllocator) error {
+	data, err := os.ReadFile(mappingFile)
+	if os.IsNotExist(err) {
+		return nil // First run, no file yet
+	}
+	if err != nil {
+		return fmt.Errorf("failed to read mapping file: %w", err)
+	}
+
+	var mapping map[string]int
+	if err := json.Unmarshal(data, &mapping); err != nil {
+		return fmt.Errorf("failed to parse mapping file: %w", err)
+	}
+
+	// Restore each gateway mapping with validation
+	for gateway, tableID := range mapping {
+		if err := allocator.restore(gateway, tableID); err != nil {
+			return fmt.Errorf("failed to restore mapping for gateway %s: %w", gateway, err)
+		}
+	}
+
+	return nil
+}
+
+// saveMapping writes the current allocator state to disk atomically.
+// Non-fatal errors are returned but should not stop reconciliation.
+func saveMapping(allocator *tableIDAllocator) error {
+	mapping := allocator.snapshot()
+	data, err := json.Marshal(mapping)
+	if err != nil {
+		return fmt.Errorf("failed to marshal mapping: %w", err)
+	}
+
+	// Atomic write: write to temp file, then rename
+	tmpFile := mappingFile + ".tmp"
+	if err := os.WriteFile(tmpFile, data, 0600); err != nil {
+		return fmt.Errorf("failed to write temp file: %w", err)
+	}
+
+	if err := os.Rename(tmpFile, mappingFile); err != nil {
+		return fmt.Errorf("failed to rename temp file: %w", err)
+	}
+
+	return nil
+}

--- a/internal/controller/sidecar/persistence_test.go
+++ b/internal/controller/sidecar/persistence_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package sidecar
 
 import (
-	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -34,47 +33,12 @@ func createTestMappingFile(t *testing.T, content string) string {
 	return testFile
 }
 
-// Helper to load from a custom path
-func loadMappingFrom(path string, a *tableIDAllocator) error {
-	data, err := os.ReadFile(path)
-	if os.IsNotExist(err) {
-		return nil
-	}
-	if err != nil {
-		return err
-	}
-	var mapping map[string]int
-	if err := json.Unmarshal(data, &mapping); err != nil {
-		return err
-	}
-	for gw, id := range mapping {
-		if err := a.restore(gw, id); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// Helper to save to a custom path
-func saveMappingTo(path string, a *tableIDAllocator) error {
-	mapping := a.snapshot()
-	data, err := json.Marshal(mapping)
-	if err != nil {
-		return err
-	}
-	tmpFile := path + ".tmp"
-	if err := os.WriteFile(tmpFile, data, 0600); err != nil {
-		return err
-	}
-	return os.Rename(tmpFile, path)
-}
-
 func TestLoadMapping_FileNotFound(t *testing.T) {
 	tmpDir := t.TempDir()
 	testFile := filepath.Join(tmpDir, "nonexistent.json")
 
 	a := newTableIDAllocator(100, 200)
-	err := loadMappingFrom(testFile, a)
+	err := loadMapping(a, testFile)
 
 	assert.NoError(t, err, "missing file should not be an error")
 	assert.Empty(t, a.snapshot())
@@ -84,7 +48,7 @@ func TestLoadMapping_ValidFile(t *testing.T) {
 	testFile := createTestMappingFile(t, `{"gw-a":100,"gw-b":101}`)
 
 	a := newTableIDAllocator(100, 200)
-	err := loadMappingFrom(testFile, a)
+	err := loadMapping(a, testFile)
 
 	assert.NoError(t, err)
 	snapshot := a.snapshot()
@@ -97,7 +61,7 @@ func TestLoadMapping_CorruptedJSON(t *testing.T) {
 	testFile := createTestMappingFile(t, `{"gw-a":100,invalid json`)
 
 	a := newTableIDAllocator(100, 200)
-	err := loadMappingFrom(testFile, a)
+	err := loadMapping(a, testFile)
 
 	assert.Error(t, err)
 }
@@ -106,7 +70,7 @@ func TestLoadMapping_InvalidTableID(t *testing.T) {
 	testFile := createTestMappingFile(t, `{"gw-a":999}`)
 
 	a := newTableIDAllocator(100, 200)
-	err := loadMappingFrom(testFile, a)
+	err := loadMapping(a, testFile)
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "out of range")
@@ -116,9 +80,20 @@ func TestLoadMapping_DuplicateTableID(t *testing.T) {
 	testFile := createTestMappingFile(t, `{"gw-a":100,"gw-b":100}`)
 
 	a := newTableIDAllocator(100, 200)
-	err := loadMappingFrom(testFile, a)
+	err := loadMapping(a, testFile)
 
 	assert.Error(t, err)
+}
+
+func TestLoadMapping_EmptyPath(t *testing.T) {
+	a := newTableIDAllocator(100, 200)
+	_, _ = a.allocate("gw-a")
+
+	err := loadMapping(a, "")
+
+	assert.NoError(t, err, "empty path should be a no-op")
+	// Allocator should be unchanged
+	assert.Len(t, a.snapshot(), 1)
 }
 
 func TestSaveMapping_CreatesFile(t *testing.T) {
@@ -129,7 +104,7 @@ func TestSaveMapping_CreatesFile(t *testing.T) {
 	_, _ = a.allocate("gw-a")
 	_, _ = a.allocate("gw-b")
 
-	err := saveMappingTo(testFile, a)
+	err := saveMapping(a, testFile)
 	assert.NoError(t, err)
 
 	// Verify file exists and is readable
@@ -146,7 +121,7 @@ func TestSaveMapping_AtomicWrite(t *testing.T) {
 	a := newTableIDAllocator(100, 200)
 	_, _ = a.allocate("gw-a")
 
-	err := saveMappingTo(testFile, a)
+	err := saveMapping(a, testFile)
 	require.NoError(t, err)
 
 	// Verify temp file was cleaned up
@@ -161,13 +136,23 @@ func TestSaveMapping_EmptyAllocator(t *testing.T) {
 
 	a := newTableIDAllocator(100, 200)
 
-	err := saveMappingTo(testFile, a)
+	err := saveMapping(a, testFile)
 	assert.NoError(t, err)
 
 	// Verify file contains empty JSON object
 	data, err := os.ReadFile(testFile)
 	require.NoError(t, err)
 	assert.Equal(t, "{}", string(data))
+}
+
+func TestSaveMapping_EmptyPath(t *testing.T) {
+	a := newTableIDAllocator(100, 200)
+	_, _ = a.allocate("gw-a")
+
+	err := saveMapping(a, "")
+
+	assert.NoError(t, err, "empty path should be a no-op")
+	// Verify no file was created (can't really test this without knowing where it would go)
 }
 
 func TestRoundTrip_SaveAndLoad(t *testing.T) {
@@ -181,12 +166,12 @@ func TestRoundTrip_SaveAndLoad(t *testing.T) {
 	_, _ = a1.allocate("gw-c")
 	a1.release("gw-b") // Release one
 
-	err := saveMappingTo(testFile, a1)
+	err := saveMapping(a1, testFile)
 	require.NoError(t, err)
 
 	// Load
 	a2 := newTableIDAllocator(100, 200)
-	err = loadMappingFrom(testFile, a2)
+	err = loadMapping(a2, testFile)
 	require.NoError(t, err)
 
 	// Verify

--- a/internal/controller/sidecar/persistence_test.go
+++ b/internal/controller/sidecar/persistence_test.go
@@ -1,0 +1,197 @@
+/*
+Copyright (c) 2026 OpenInfra Foundation Europe. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sidecar
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Helper to create a test mapping file
+func createTestMappingFile(t *testing.T, content string) string {
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "mapping.json")
+	require.NoError(t, os.WriteFile(testFile, []byte(content), 0600))
+	return testFile
+}
+
+// Helper to load from a custom path
+func loadMappingFrom(path string, a *tableIDAllocator) error {
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	var mapping map[string]int
+	if err := json.Unmarshal(data, &mapping); err != nil {
+		return err
+	}
+	for gw, id := range mapping {
+		if err := a.restore(gw, id); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Helper to save to a custom path
+func saveMappingTo(path string, a *tableIDAllocator) error {
+	mapping := a.snapshot()
+	data, err := json.Marshal(mapping)
+	if err != nil {
+		return err
+	}
+	tmpFile := path + ".tmp"
+	if err := os.WriteFile(tmpFile, data, 0600); err != nil {
+		return err
+	}
+	return os.Rename(tmpFile, path)
+}
+
+func TestLoadMapping_FileNotFound(t *testing.T) {
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "nonexistent.json")
+
+	a := newTableIDAllocator(100, 200)
+	err := loadMappingFrom(testFile, a)
+
+	assert.NoError(t, err, "missing file should not be an error")
+	assert.Empty(t, a.snapshot())
+}
+
+func TestLoadMapping_ValidFile(t *testing.T) {
+	testFile := createTestMappingFile(t, `{"gw-a":100,"gw-b":101}`)
+
+	a := newTableIDAllocator(100, 200)
+	err := loadMappingFrom(testFile, a)
+
+	assert.NoError(t, err)
+	snapshot := a.snapshot()
+	assert.Len(t, snapshot, 2)
+	assert.Equal(t, 100, snapshot["gw-a"])
+	assert.Equal(t, 101, snapshot["gw-b"])
+}
+
+func TestLoadMapping_CorruptedJSON(t *testing.T) {
+	testFile := createTestMappingFile(t, `{"gw-a":100,invalid json`)
+
+	a := newTableIDAllocator(100, 200)
+	err := loadMappingFrom(testFile, a)
+
+	assert.Error(t, err)
+}
+
+func TestLoadMapping_InvalidTableID(t *testing.T) {
+	testFile := createTestMappingFile(t, `{"gw-a":999}`)
+
+	a := newTableIDAllocator(100, 200)
+	err := loadMappingFrom(testFile, a)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "out of range")
+}
+
+func TestLoadMapping_DuplicateTableID(t *testing.T) {
+	testFile := createTestMappingFile(t, `{"gw-a":100,"gw-b":100}`)
+
+	a := newTableIDAllocator(100, 200)
+	err := loadMappingFrom(testFile, a)
+
+	assert.Error(t, err)
+}
+
+func TestSaveMapping_CreatesFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "mapping.json")
+
+	a := newTableIDAllocator(100, 200)
+	_, _ = a.allocate("gw-a")
+	_, _ = a.allocate("gw-b")
+
+	err := saveMappingTo(testFile, a)
+	assert.NoError(t, err)
+
+	// Verify file exists and is readable
+	data, err := os.ReadFile(testFile)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "gw-a")
+	assert.Contains(t, string(data), "gw-b")
+}
+
+func TestSaveMapping_AtomicWrite(t *testing.T) {
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "mapping.json")
+
+	a := newTableIDAllocator(100, 200)
+	_, _ = a.allocate("gw-a")
+
+	err := saveMappingTo(testFile, a)
+	require.NoError(t, err)
+
+	// Verify temp file was cleaned up
+	tmpFile := testFile + ".tmp"
+	_, err = os.Stat(tmpFile)
+	assert.True(t, os.IsNotExist(err), "temp file should be removed after rename")
+}
+
+func TestSaveMapping_EmptyAllocator(t *testing.T) {
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "mapping.json")
+
+	a := newTableIDAllocator(100, 200)
+
+	err := saveMappingTo(testFile, a)
+	assert.NoError(t, err)
+
+	// Verify file contains empty JSON object
+	data, err := os.ReadFile(testFile)
+	require.NoError(t, err)
+	assert.Equal(t, "{}", string(data))
+}
+
+func TestRoundTrip_SaveAndLoad(t *testing.T) {
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "mapping.json")
+
+	// Save
+	a1 := newTableIDAllocator(100, 200)
+	_, _ = a1.allocate("gw-a")
+	_, _ = a1.allocate("gw-b")
+	_, _ = a1.allocate("gw-c")
+	a1.release("gw-b") // Release one
+
+	err := saveMappingTo(testFile, a1)
+	require.NoError(t, err)
+
+	// Load
+	a2 := newTableIDAllocator(100, 200)
+	err = loadMappingFrom(testFile, a2)
+	require.NoError(t, err)
+
+	// Verify
+	snapshot1 := a1.snapshot()
+	snapshot2 := a2.snapshot()
+	assert.Equal(t, snapshot1, snapshot2)
+	assert.Len(t, snapshot2, 2) // gw-a and gw-c (gw-b was released)
+}

--- a/internal/controller/sidecar/tableid.go
+++ b/internal/controller/sidecar/tableid.go
@@ -84,10 +84,9 @@ func (a *tableIDAllocator) activeGateways() map[string]int {
 }
 
 // snapshot returns the current gateway → tableID mapping for persistence.
+// Delegates to activeGateways to avoid duplication.
 func (a *tableIDAllocator) snapshot() map[string]int {
-	result := make(map[string]int, len(a.assigned))
-	maps.Copy(result, a.assigned)
-	return result
+	return a.activeGateways()
 }
 
 // restore seeds the allocator with a saved mapping. Validates table IDs are in range.

--- a/internal/controller/sidecar/tableid.go
+++ b/internal/controller/sidecar/tableid.go
@@ -82,3 +82,34 @@ func (a *tableIDAllocator) activeGateways() map[string]int {
 	maps.Copy(result, a.assigned)
 	return result
 }
+
+// snapshot returns the current gateway → tableID mapping for persistence.
+func (a *tableIDAllocator) snapshot() map[string]int {
+	result := make(map[string]int, len(a.assigned))
+	maps.Copy(result, a.assigned)
+	return result
+}
+
+// restore seeds the allocator with a saved mapping. Validates table IDs are in range.
+// Returns error if any table ID is out of range or if there are duplicate IDs.
+func (a *tableIDAllocator) restore(gatewayName string, tableID int) error {
+	if tableID < a.minID || tableID > a.maxID {
+		return fmt.Errorf("table ID %d for gateway %s is out of range [%d, %d]", tableID, gatewayName, a.minID, a.maxID)
+	}
+
+	// Check for duplicate table IDs
+	for gw, id := range a.assigned {
+		if id == tableID {
+			return fmt.Errorf("table ID %d already assigned to gateway %s, cannot assign to %s", tableID, gw, gatewayName)
+		}
+	}
+
+	a.assigned[gatewayName] = tableID
+
+	// Update nextID to avoid reusing restored IDs
+	if tableID >= a.nextID {
+		a.nextID = tableID + 1
+	}
+
+	return nil
+}

--- a/internal/controller/sidecar/tableid_test.go
+++ b/internal/controller/sidecar/tableid_test.go
@@ -99,3 +99,96 @@ func TestTableIDAllocator_ActiveGateways(t *testing.T) {
 	assert.Len(t, active, 1)
 	assert.Contains(t, active, "gw-b")
 }
+
+func TestTableIDAllocator_Snapshot(t *testing.T) {
+	t.Run("EmptyAllocator", func(t *testing.T) {
+		a := newTableIDAllocator(100, 200)
+		snapshot := a.snapshot()
+		assert.Empty(t, snapshot)
+	})
+
+	t.Run("WithAllocations", func(t *testing.T) {
+		a := newTableIDAllocator(100, 200)
+		_, _ = a.allocate("gw-a")
+		_, _ = a.allocate("gw-b")
+
+		snapshot := a.snapshot()
+		assert.Len(t, snapshot, 2)
+		assert.Equal(t, 100, snapshot["gw-a"])
+		assert.Equal(t, 101, snapshot["gw-b"])
+	})
+
+	t.Run("SnapshotIsCopy", func(t *testing.T) {
+		a := newTableIDAllocator(100, 200)
+		_, _ = a.allocate("gw-a")
+
+		snapshot := a.snapshot()
+		snapshot["gw-b"] = 999 // Mutate snapshot
+
+		// Original should be unchanged
+		_, exists := a.lookup("gw-b")
+		assert.False(t, exists)
+	})
+}
+
+func TestTableIDAllocator_Restore(t *testing.T) {
+	t.Run("ValidRestore", func(t *testing.T) {
+		a := newTableIDAllocator(100, 200)
+
+		err := a.restore("gw-a", 150)
+		assert.NoError(t, err)
+
+		id, exists := a.lookup("gw-a")
+		assert.True(t, exists)
+		assert.Equal(t, 150, id)
+	})
+
+	t.Run("OutOfRangeLow", func(t *testing.T) {
+		a := newTableIDAllocator(100, 200)
+
+		err := a.restore("gw-a", 99)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "out of range")
+	})
+
+	t.Run("OutOfRangeHigh", func(t *testing.T) {
+		a := newTableIDAllocator(100, 200)
+
+		err := a.restore("gw-a", 201)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "out of range")
+	})
+
+	t.Run("DuplicateTableID", func(t *testing.T) {
+		a := newTableIDAllocator(100, 200)
+
+		_ = a.restore("gw-a", 150)
+		err := a.restore("gw-b", 150)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "already assigned")
+	})
+
+	t.Run("UpdatesNextID", func(t *testing.T) {
+		a := newTableIDAllocator(100, 200)
+
+		_ = a.restore("gw-a", 150)
+
+		// Next allocation should be 151, not 100
+		id, _ := a.allocate("gw-b")
+		assert.Equal(t, 151, id)
+	})
+
+	t.Run("RestoreMultiple", func(t *testing.T) {
+		a := newTableIDAllocator(100, 200)
+
+		_ = a.restore("gw-a", 105)
+		_ = a.restore("gw-b", 110)
+		_ = a.restore("gw-c", 102)
+
+		assert.Equal(t, 3, len(a.activeGateways()))
+
+		// Next allocation should be 111 (max restored + 1)
+		id, _ := a.allocate("gw-d")
+		assert.Equal(t, 111, id)
+	})
+}

--- a/test/e2e/e2e_suite_appnetwork_test.go
+++ b/test/e2e/e2e_suite_appnetwork_test.go
@@ -438,7 +438,14 @@ var _ = Describe("E2E Test Suites", func() {
 							g.Expect(out).To(Equal("true"))
 						}).Should(Succeed())
 
-						time.Sleep(5 * time.Second) // Let it reconcile
+						By("waiting for ENC to be Ready after restart")
+						Eventually(func(g Gomega) {
+							cmd := exec.Command("kubectl", "get", "enc", targetPod, "-n", suite.namespace,
+								"-o", "jsonpath={.status.conditions[?(@.type=='Ready')].status}")
+							out, err := utils.Run(cmd)
+							g.Expect(err).NotTo(HaveOccurred())
+							g.Expect(out).To(Equal("True"))
+						}).Should(Succeed())
 
 						By(fmt.Sprintf("verifying %s table ID unchanged and no orphaned rules/tables", gw1.name))
 						cmd = exec.Command("kubectl", "exec", "-n", suite.namespace, targetPod,

--- a/test/e2e/e2e_suite_appnetwork_test.go
+++ b/test/e2e/e2e_suite_appnetwork_test.go
@@ -447,6 +447,15 @@ var _ = Describe("E2E Test Suites", func() {
 							g.Expect(out).To(Equal("True"))
 						}).Should(Succeed())
 
+						By(fmt.Sprintf("waiting for %s VIP to be removed", gw2.name))
+						Eventually(func(g Gomega) {
+							cmd := exec.Command("kubectl", "exec", "-n", suite.namespace, targetPod,
+								"-c", "network-sidecar", "--", "ip", "addr", "show")
+							out, err := utils.Run(cmd)
+							g.Expect(err).NotTo(HaveOccurred())
+							g.Expect(out).NotTo(ContainSubstring(gw2.vip))
+						}, 30*time.Second, 1*time.Second).Should(Succeed())
+
 						By(fmt.Sprintf("verifying %s table ID unchanged and no orphaned rules/tables", gw1.name))
 						cmd = exec.Command("kubectl", "exec", "-n", suite.namespace, targetPod,
 							"-c", "network-sidecar", "--", "ip", "rule", "show")

--- a/test/e2e/e2e_suite_appnetwork_test.go
+++ b/test/e2e/e2e_suite_appnetwork_test.go
@@ -6,6 +6,9 @@ package e2e
 import (
 	"fmt"
 	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -258,6 +261,219 @@ var _ = Describe("E2E Test Suites", func() {
 					}
 				})
 			})
+
+			// Sidecar restart recovery test (for suites with 2+ gateways)
+			if len(suite.gateways) >= 2 {
+				Context("Sidecar Restart Recovery", func() {
+					var (
+						targetPod string
+						gw1       gwTestCase // First gateway (will be preserved)
+						gw2       gwTestCase // Second gateway (will be deleted)
+						tableID1  string
+						tableID2  string
+					)
+
+					BeforeAll(func() {
+						gw1 = suite.gateways[0]
+						gw2 = suite.gateways[1]
+
+						By("selecting first target pod")
+						Eventually(func(g Gomega) {
+							cmd := exec.Command("kubectl", "get", "pods", "-n", suite.namespace,
+								"-l", "app="+suite.targetApp, "--field-selector=status.phase=Running",
+								"-o", "jsonpath={.items[0].metadata.name}")
+							out, err := utils.Run(cmd)
+							g.Expect(err).NotTo(HaveOccurred())
+							targetPod = strings.TrimSpace(out)
+							g.Expect(targetPod).NotTo(BeEmpty())
+						}).Should(Succeed())
+
+						By("waiting for ENC to be Ready")
+						Eventually(func(g Gomega) {
+							cmd := exec.Command("kubectl", "get", "enc", targetPod, "-n", suite.namespace,
+								"-o", "jsonpath={.status.conditions[?(@.type=='Ready')].status}")
+							out, err := utils.Run(cmd)
+							g.Expect(err).NotTo(HaveOccurred())
+							g.Expect(out).To(Equal("True"))
+						}).Should(Succeed())
+
+						By("capturing initial table IDs")
+						cmd := exec.Command("kubectl", "exec", "-n", suite.namespace, targetPod,
+							"-c", "network-sidecar", "--", "ip", "rule", "show")
+						out, err := utils.Run(cmd)
+						Expect(err).NotTo(HaveOccurred())
+
+						for _, line := range strings.Split(out, "\n") {
+							if strings.Contains(line, gw1.vip) {
+								fields := strings.Fields(line)
+								for i, f := range fields {
+									if f == "lookup" && i+1 < len(fields) {
+										tableID1 = fields[i+1]
+										break
+									}
+								}
+							} else if strings.Contains(line, gw2.vip) {
+								fields := strings.Fields(line)
+								for i, f := range fields {
+									if f == "lookup" && i+1 < len(fields) {
+										tableID2 = fields[i+1]
+										break
+									}
+								}
+							}
+						}
+						Expect(tableID1).NotTo(BeEmpty(), "should find table ID for %s", gw1.name)
+						Expect(tableID2).NotTo(BeEmpty(), "should find table ID for %s", gw2.name)
+
+						By("setting restart gate marker")
+						cmd = exec.Command("kubectl", "exec", "-n", suite.namespace, targetPod,
+							"-c", "network-sidecar", "--", "sh", "-c",
+							"touch /restart-gate/already-started && rm -f /restart-gate/release-restart")
+						_, err = utils.Run(cmd)
+						Expect(err).NotTo(HaveOccurred())
+					})
+
+					AfterAll(func() {
+						By(fmt.Sprintf("restoring %s gateway for subsequent tests", gw2.name))
+						// Find the gateway.yaml relative to this test file
+						_, filename, _, ok := runtime.Caller(0)
+						Expect(ok).To(BeTrue(), "failed to get test file path")
+						testDir := filepath.Dir(filename)
+
+						// Derive suite directory from suite name
+						var suiteDir string
+						switch suite.name {
+						case "Common App Network":
+							suiteDir = "common-appnetwork"
+						case "Separate App Network":
+							suiteDir = "separate-appnetwork"
+						default:
+							Skip(fmt.Sprintf("Unknown suite: %s", suite.name))
+						}
+
+						gatewayPath := filepath.Join(testDir, "suites", suiteDir, "gateway.yaml")
+						cmd := exec.Command("kubectl", "apply", "-f", gatewayPath, "-n", suite.namespace)
+						_, err := utils.Run(cmd)
+						Expect(err).NotTo(HaveOccurred())
+
+						By(fmt.Sprintf("waiting for %s to be Accepted", gw2.name))
+						Eventually(func(g Gomega) {
+							cmd := exec.Command("kubectl", "get", "gateway", gw2.name, "-n", suite.namespace,
+								"-o", "jsonpath={.status.conditions[?(@.type=='Accepted')].status}")
+							out, err := utils.Run(cmd)
+							g.Expect(err).NotTo(HaveOccurred())
+							g.Expect(out).To(Equal("True"))
+						}).Should(Succeed())
+
+						By(fmt.Sprintf("waiting for %s to be Programmed", gw2.name))
+						Eventually(func(g Gomega) {
+							cmd := exec.Command("kubectl", "get", "gateway", gw2.name, "-n", suite.namespace,
+								"-o", "jsonpath={.status.conditions[?(@.type=='Programmed')].status}")
+							out, err := utils.Run(cmd)
+							g.Expect(err).NotTo(HaveOccurred())
+							g.Expect(out).To(Equal("True"))
+						}).Should(Succeed())
+
+						By(fmt.Sprintf("waiting for %s ENC to include %s", targetPod, gw2.name))
+						Eventually(func(g Gomega) {
+							cmd := exec.Command("kubectl", "get", "enc", targetPod, "-n", suite.namespace,
+								"-o", "jsonpath={.spec.gateways[*].name}")
+							out, err := utils.Run(cmd)
+							g.Expect(err).NotTo(HaveOccurred())
+							g.Expect(out).To(ContainSubstring(gw2.name))
+						}).Should(Succeed())
+
+						By(fmt.Sprintf("waiting for sidecar to configure %s VIP", gw2.name))
+						Eventually(func(g Gomega) {
+							cmd := exec.Command("kubectl", "exec", "-n", suite.namespace, targetPod,
+								"-c", "network-sidecar", "--", "ip", "addr", "show")
+							out, err := utils.Run(cmd)
+							g.Expect(err).NotTo(HaveOccurred())
+							g.Expect(out).To(ContainSubstring(gw2.vip))
+						}).Should(Succeed())
+					})
+
+					It("should preserve table IDs and clean up deleted gateway state", func() {
+						By("killing sidecar container (will pause at restart gate)")
+						cmd := exec.Command("kubectl", "exec", "-n", suite.namespace, targetPod,
+							"-c", "network-sidecar", "--", "kill", "1")
+						utils.Run(cmd) // Ignore error (container dies)
+
+						By("waiting for sidecar to reach restart gate")
+						Eventually(func(g Gomega) {
+							cmd := exec.Command("kubectl", "logs", "-n", suite.namespace, targetPod,
+								"-c", "network-sidecar", "--tail=5")
+							out, err := utils.Run(cmd)
+							g.Expect(err).NotTo(HaveOccurred())
+							g.Expect(out).To(ContainSubstring("Restart detected"))
+						}).Should(Succeed())
+
+						By(fmt.Sprintf("deleting %s gateway while sidecar is paused", gw2.name))
+						cmd = exec.Command("kubectl", "delete", "gateway", gw2.name, "-n", suite.namespace)
+						_, err := utils.Run(cmd)
+						Expect(err).NotTo(HaveOccurred())
+
+						By(fmt.Sprintf("waiting for ENC controller to remove %s from ENC", gw2.name))
+						Eventually(func(g Gomega) {
+							cmd := exec.Command("kubectl", "get", "enc", targetPod, "-n", suite.namespace,
+								"-o", "jsonpath={.spec.gateways[*].name}")
+							out, err := utils.Run(cmd)
+							g.Expect(err).NotTo(HaveOccurred())
+							g.Expect(out).NotTo(ContainSubstring(gw2.name))
+							g.Expect(out).To(ContainSubstring(gw1.name))
+						}).Should(Succeed())
+
+						By("releasing restart gate")
+						cmd = exec.Command("kubectl", "exec", "-n", suite.namespace, targetPod,
+							"-c", "network-sidecar", "--", "touch", "/restart-gate/release-restart")
+						_, err = utils.Run(cmd)
+						Expect(err).NotTo(HaveOccurred())
+
+						By("waiting for sidecar to become ready")
+						Eventually(func(g Gomega) {
+							cmd := exec.Command("kubectl", "get", "pod", targetPod, "-n", suite.namespace,
+								"-o", "jsonpath={.status.containerStatuses[?(@.name=='network-sidecar')].ready}")
+							out, err := utils.Run(cmd)
+							g.Expect(err).NotTo(HaveOccurred())
+							g.Expect(out).To(Equal("true"))
+						}).Should(Succeed())
+
+						time.Sleep(5 * time.Second) // Let it reconcile
+
+						By(fmt.Sprintf("verifying %s table ID unchanged and no orphaned rules/tables", gw1.name))
+						cmd = exec.Command("kubectl", "exec", "-n", suite.namespace, targetPod,
+							"-c", "network-sidecar", "--", "ip", "rule", "show")
+						out, err := utils.Run(cmd)
+						Expect(err).NotTo(HaveOccurred())
+
+						var newTableID1 string
+						for _, line := range strings.Split(out, "\n") {
+							if strings.Contains(line, gw1.vip) {
+								fields := strings.Fields(line)
+								for i, f := range fields {
+									if f == "lookup" && i+1 < len(fields) {
+										newTableID1 = fields[i+1]
+										break
+									}
+								}
+							}
+						}
+						Expect(newTableID1).To(Equal(tableID1), "%s table ID should be preserved", gw1.name)
+						Expect(out).To(ContainSubstring(gw1.vip), "%s rule should be present", gw1.name)
+						Expect(out).NotTo(ContainSubstring(gw2.vip), "%s rule should be removed (no orphan)", gw2.name)
+						hasOrphanedTable := strings.Contains(out, "lookup "+tableID2)
+						Expect(hasOrphanedTable).To(BeFalse(), "%s old table %s should be cleaned up (no orphan)", gw2.name, tableID2)
+
+						By(fmt.Sprintf("verifying no VIP leak (%s VIP removed)", gw2.name))
+						cmd = exec.Command("kubectl", "exec", "-n", suite.namespace, targetPod,
+							"-c", "network-sidecar", "--", "ip", "addr", "show")
+						out, err = utils.Run(cmd)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(out).To(ContainSubstring(gw1.vip), "%s VIP should be present", gw1.name)
+						Expect(out).NotTo(ContainSubstring(gw2.vip), "%s VIP should be removed (no leak)", gw2.name)
+					})
+				})
+			}
 		})
 	}
 

--- a/test/e2e/suites/common-appnetwork/targets.yaml
+++ b/test/e2e/suites/common-appnetwork/targets.yaml
@@ -18,6 +18,11 @@ spec:
         k8s.v1.cni.cncf.io/networks: app-net-b
     spec:
       serviceAccountName: meridio-2-network-sidecar
+      volumes:
+      - name: restart-gate
+        emptyDir: {}
+      - name: sidecar-state
+        emptyDir: {}
       containers:
       - name: example-target
         image: registry.nordix.org/cloud-native/meridio-2/example-target:latest
@@ -36,11 +41,23 @@ spec:
       - name: network-sidecar
         image: registry.nordix.org/cloud-native/meridio-2/network-sidecar:latest
         imagePullPolicy: IfNotPresent
+        command: ["/bin/sh", "-c"]
         args:
-        - --pod-name=$(POD_NAME)
-        - --pod-namespace=$(POD_NAMESPACE)
-        - --pod-uid=$(POD_UID)
-        - --log-level=debug
+        - |
+          if [ -f /restart-gate/already-started ]; then
+            echo "Restart detected - waiting for release signal"
+            while [ ! -f /restart-gate/release-restart ]; do
+              sleep 1
+            done
+            echo "Release signal received - proceeding with startup"
+          fi
+          touch /restart-gate/already-started
+          exec ./network-sidecar run --pod-name="$POD_NAME" --pod-namespace="$POD_NAMESPACE" --pod-uid="$POD_UID" --log-level=debug
+        volumeMounts:
+        - name: restart-gate
+          mountPath: /restart-gate
+        - name: sidecar-state
+          mountPath: /var/run/meridio
         env:
         - name: POD_NAME
           valueFrom:

--- a/test/e2e/suites/low-mtu/targets.yaml
+++ b/test/e2e/suites/low-mtu/targets.yaml
@@ -18,6 +18,9 @@ spec:
         k8s.v1.cni.cncf.io/networks: app-net-mtu1200
     spec:
       serviceAccountName: meridio-2-network-sidecar
+      volumes:
+      - name: sidecar-state
+        emptyDir: {}
       containers:
       - name: example-target
         image: registry.nordix.org/cloud-native/meridio-2/example-target:latest
@@ -41,6 +44,9 @@ spec:
         - --pod-namespace=$(POD_NAMESPACE)
         - --pod-uid=$(POD_UID)
         - --log-level=debug
+        volumeMounts:
+        - name: sidecar-state
+          mountPath: /var/run/meridio
         env:
         - name: POD_NAME
           valueFrom:

--- a/test/e2e/suites/sctp-multihoming/targets.yaml
+++ b/test/e2e/suites/sctp-multihoming/targets.yaml
@@ -18,6 +18,9 @@ spec:
         k8s.v1.cni.cncf.io/networks: app-net-sctp1, app-net-sctp2
     spec:
       serviceAccountName: meridio-2-network-sidecar
+      volumes:
+      - name: sidecar-state
+        emptyDir: {}
       containers:
       - name: example-target
         image: registry.nordix.org/cloud-native/meridio-2/example-target:latest
@@ -39,6 +42,9 @@ spec:
         - --pod-namespace=$(POD_NAMESPACE)
         - --pod-uid=$(POD_UID)
         - --log-level=debug
+        volumeMounts:
+        - name: sidecar-state
+          mountPath: /var/run/meridio
         env:
         - name: POD_NAME
           valueFrom:

--- a/test/e2e/suites/separate-appnetwork/targets.yaml
+++ b/test/e2e/suites/separate-appnetwork/targets.yaml
@@ -18,6 +18,11 @@ spec:
         k8s.v1.cni.cncf.io/networks: app-net-a1, app-net-a2
     spec:
       serviceAccountName: meridio-2-network-sidecar
+      volumes:
+      - name: restart-gate
+        emptyDir: {}
+      - name: sidecar-state
+        emptyDir: {}
       containers:
       - name: example-target
         image: registry.nordix.org/cloud-native/meridio-2/example-target:latest
@@ -36,11 +41,23 @@ spec:
       - name: network-sidecar
         image: registry.nordix.org/cloud-native/meridio-2/network-sidecar:latest
         imagePullPolicy: IfNotPresent
+        command: ["/bin/sh", "-c"]
         args:
-        - --pod-name=$(POD_NAME)
-        - --pod-namespace=$(POD_NAMESPACE)
-        - --pod-uid=$(POD_UID)
-        - --log-level=debug
+        - |
+          if [ -f /restart-gate/already-started ]; then
+            echo "Restart detected - waiting for release signal"
+            while [ ! -f /restart-gate/release-restart ]; do
+              sleep 1
+            done
+            echo "Release signal received - proceeding with startup"
+          fi
+          touch /restart-gate/already-started
+          exec ./network-sidecar run --pod-name="$POD_NAME" --pod-namespace="$POD_NAMESPACE" --pod-uid="$POD_UID" --log-level=debug
+        volumeMounts:
+        - name: restart-gate
+          mountPath: /restart-gate
+        - name: sidecar-state
+          mountPath: /var/run/meridio
         env:
         - name: POD_NAME
           valueFrom:


### PR DESCRIPTION
### Summary

Implements restart recovery for the network sidecar to eliminate three known bugs that occur when the sidecar container restarts while the ENC is modified:

1. **VIP leak** - VIPs from deleted gateways remain on interfaces
2. **Orphaned routes** - Stale routes persist after table ID reallocation
3. **Orphaned policy rules** - Stale rules persist after table ID reallocation

### Solution

Hybrid approach combining two mechanisms:

- **emptyDir table ID persistence** (`/var/run/meridio/table-id-mapping.json`) - Preserves `gatewayName → tableID` mapping across container restarts, preventing table ID shifts
- **Kernel VIP scanning** - Seeds `managedVIPs` from kernel state (`/32` and `/128` addresses on secondary interfaces) on startup, enabling cleanup of stale VIPs

### Implementation

**Core changes:**
- `internal/controller/sidecar/persistence.go` - `loadMapping()`/`saveMapping()` with atomic writes
- `internal/controller/sidecar/network.go` - `scanManagedVIPs()` scans kernel interfaces
- `internal/controller/sidecar/tableid.go` - `snapshot()`/`restore()` methods for allocator
- `internal/controller/sidecar/controller.go` - Initialize state in `SetupWithManager()`, save after successful reconcile

**Testing:**
- Unit tests: 79.2% coverage, all passing
- E2E tests: Comprehensive restart recovery validation for Common/Separate App Network suites using restart gate mechanism

### Test Design

The e2e test validates all three bugs are fixed:

1. Captures initial table IDs for two gateways
2. Sets restart gate marker to pause sidecar on next restart
3. Kills sidecar container (pauses at gate)
4. Deletes one gateway while sidecar is down
5. Releases gate, allowing sidecar to start with persisted state
6. Validates:
   - Preserved gateway keeps original table ID (no shift)
   - Deleted gateway's VIP is removed (no leak)
   - Deleted gateway's policy rules are removed (no orphans)
   - Deleted gateway's routing table is cleaned (no orphans)

Test runs automatically for suites with 2+ gateways and is fully idempotent (restores deleted gateway in `AfterAll`).

### Files Changed

**Implementation:**
- `internal/controller/sidecar/persistence.go` (new)
- `internal/controller/sidecar/persistence_test.go` (new)
- `internal/controller/sidecar/controller.go`
- `internal/controller/sidecar/network.go`
- `internal/controller/sidecar/tableid.go`
- `internal/controller/sidecar/tableid_test.go`
- `internal/controller/sidecar/controller_test.go`

**E2E tests:**
- `test/e2e/e2e_suite_appnetwork_test.go`
- `test/e2e/suites/common-appnetwork/targets.yaml`
- `test/e2e/suites/separate-appnetwork/targets.yaml`

### Related Issue

#94 