### PR TITLE
ENC controller: add two-level next-hop filtering helpers

### DIFF
--- a/docs/controllers/router.md
+++ b/docs/controllers/router.md
@@ -175,6 +175,10 @@ The monitoring goroutine sets per-IP-family Pod readiness gate conditions based 
 - **Per-IP-family independence**: IPv4 and IPv6 gates are managed independently with separate hold timers.
 - **Configuration**: Requires `POD_NAME`, `POD_NAMESPACE`, `POD_UID` environment variables (Downward API, injected by Gateway controller in LB Deployment template).
 - **RBAC**: Requires `pods/get` + `pods/status/update` (configured in `config/rbac/lb-serviceaccount.yaml`).
+- **Downstream consumer**: The ENC controller uses these gate conditions to filter LB Pods from next-hop lists via two-level filtering:
+  1. Container readiness — all containers must be Ready and Pod not being deleted
+  2. Per-IP-family gate — `ipv4-connectivity=True` required for IPv4 next-hops, `ipv6-connectivity=True` for IPv6
+  If a gate is not declared for a specific IP family (e.g., IPv4-only Gateway), the Pod is included for that family (gate not applicable).
 
 ### Metrics and Route Monitoring (post-MVP)
 

--- a/docs/operations/constraints-and-limitations.md
+++ b/docs/operations/constraints-and-limitations.md
@@ -54,9 +54,11 @@ The LB controller assigns fwmarks and routing table IDs dynamically per Distribu
 
 The router now gates VIP advertisement on LB readiness. The collocated LB controller writes `lb-ready-<distGroupName>` files to a shared directory when a DistributionGroup has ready targets. The router watches this directory via fsnotify and suppresses VIPs until at least one readiness file exists. Configurable via `--readiness-dir` / `MERIDIO_READINESS_DIR` (default: `/var/run/meridio`).
 
-**11. No connectivity-based readiness signaling to the controller-manager** *(partially resolved)*
+**11. ~~No connectivity-based readiness signaling to the controller-manager~~ (Resolved)**
 
-The router now sets per-IP-family Pod readiness gates (`meridio-2.nordix.org/ipv4-connectivity`, `meridio-2.nordix.org/ipv6-connectivity`) based on BGP session state (PR #142). However, the ENC controller does not yet consume these gates to filter next-hop lists (gh-123). Until step 3 is implemented, application Pods may still route return traffic through an LB that has lost external connectivity.
+~~The router now sets per-IP-family Pod readiness gates (`meridio-2.nordix.org/ipv4-connectivity`, `meridio-2.nordix.org/ipv6-connectivity`) based on BGP session state (PR #142). However, the ENC controller does not yet consume these gates to filter next-hop lists (gh-123). Until step 3 is implemented, application Pods may still route return traffic through an LB that has lost external connectivity.~~
+
+The full three-step solution is now implemented: the gateway controller declares readiness gates (PR #125), the router sets gate conditions based on BGP state with damped transitions (PR #142), and the ENC controller filters next-hops using two-level checks — container readiness plus per-IP-family gate conditions (PR #155).
 
 **12. BIRD error propagation missing**
 

--- a/internal/common/constants/constants.go
+++ b/internal/common/constants/constants.go
@@ -1,0 +1,9 @@
+// Package constants defines shared constants used across controllers.
+package constants
+
+const (
+	// ReadinessGateIPv4 is the Pod readiness gate condition type for IPv4 external connectivity.
+	ReadinessGateIPv4 = "meridio-2.nordix.org/ipv4-connectivity"
+	// ReadinessGateIPv6 is the Pod readiness gate condition type for IPv6 external connectivity.
+	ReadinessGateIPv6 = "meridio-2.nordix.org/ipv6-connectivity"
+)

--- a/internal/controller/endpointnetworkconfiguration/resolve.go
+++ b/internal/controller/endpointnetworkconfiguration/resolve.go
@@ -41,6 +41,9 @@ const (
 	kindDistributionGroup    = "DistributionGroup"
 	labelGatewayName         = "gateway.networking.k8s.io/gateway-name"
 	attachmentTypeNAD        = "NAD"
+	// Readiness gate condition types (to be consolidated to shared package)
+	readinessGateIPv4 = "meridio-2.nordix.org/ipv4-connectivity"
+	readinessGateIPv6 = "meridio-2.nordix.org/ipv6-connectivity"
 )
 
 // resolveGatewayConnections determines which Gateways a Pod participates in
@@ -248,6 +251,10 @@ func (r *Reconciler) getSLLBRNextHops(ctx context.Context, gw *gatewayv1.Gateway
 		if pod.Status.Phase != corev1.PodRunning {
 			continue
 		}
+		// Level 1: container readiness (all non-init containers must be Ready)
+		if !isLBPodReady(&pod) {
+			continue
+		}
 		for cidr, attachmentType := range subnetToType {
 			ip := scraper(&pod, cidr, attachmentType)
 			if ip == "" {
@@ -257,10 +264,15 @@ func (r *Reconciler) getSLLBRNextHops(ctx context.Context, gw *gatewayv1.Gateway
 			if parsed == nil {
 				continue
 			}
+			// Level 2: per-IP-family gate check
 			if parsed.To4() != nil {
-				ipv4 = append(ipv4, ip)
+				if hasConnectivityGate(&pod, readinessGateIPv4) {
+					ipv4 = append(ipv4, ip)
+				}
 			} else {
-				ipv6 = append(ipv6, ip)
+				if hasConnectivityGate(&pod, readinessGateIPv6) {
+					ipv6 = append(ipv6, ip)
+				}
 			}
 		}
 	}

--- a/internal/controller/endpointnetworkconfiguration/resolve.go
+++ b/internal/controller/endpointnetworkconfiguration/resolve.go
@@ -488,3 +488,43 @@ func scrapeInterfaceForSubnet(pod *corev1.Pod, cidr string) string {
 	}
 	return ""
 }
+
+// isLBPodReady(pod) bool - checks all non-init container statuses are Ready. Returns false if any container is not ready or if Pod is being deleted.
+func isLBPodReady(pod *corev1.Pod) bool {
+	if pod.DeletionTimestamp != nil {
+		return false
+	}
+	oneReady := false
+	for _, cs := range pod.Status.ContainerStatuses {
+		if !cs.Ready {
+			return false
+		} else { // At least one container is ready
+			oneReady = true
+		}
+	}
+	return oneReady
+}
+
+// hasConnectivityGate - Checks if a specific readiness gate condition is True on the Pod.
+func hasConnectivityGate(pod *corev1.Pod, conditionType string) bool {
+	// Check if the gate is declared in the Pod spec
+	gateDeclared := false
+	for _, gate := range pod.Spec.ReadinessGates {
+		if string(gate.ConditionType) == conditionType {
+			gateDeclared = true
+			break
+		}
+	}
+	// gate not applicable for this IP family: if gate not declared, include the Pod (skip filtering)
+	if !gateDeclared {
+		return true
+	}
+	// Check if the condition is True in the Pod status
+	for _, condition := range pod.Status.Conditions {
+		if string(condition.Type) == conditionType {
+			return condition.Status == corev1.ConditionTrue
+		}
+	}
+	// Gate declared but condition not found - treat as not ready
+	return false
+}

--- a/internal/controller/endpointnetworkconfiguration/resolve.go
+++ b/internal/controller/endpointnetworkconfiguration/resolve.go
@@ -27,6 +27,7 @@ import (
 
 	netdefv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	meridio2v1alpha1 "github.com/nordix/meridio-2/api/v1alpha1"
+	"github.com/nordix/meridio-2/internal/common/constants"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -41,9 +42,6 @@ const (
 	kindDistributionGroup    = "DistributionGroup"
 	labelGatewayName         = "gateway.networking.k8s.io/gateway-name"
 	attachmentTypeNAD        = "NAD"
-	// Readiness gate condition types (to be consolidated to shared package)
-	readinessGateIPv4 = "meridio-2.nordix.org/ipv4-connectivity"
-	readinessGateIPv6 = "meridio-2.nordix.org/ipv6-connectivity"
 )
 
 // resolveGatewayConnections determines which Gateways a Pod participates in
@@ -266,11 +264,11 @@ func (r *Reconciler) getSLLBRNextHops(ctx context.Context, gw *gatewayv1.Gateway
 			}
 			// Level 2: per-IP-family gate check
 			if parsed.To4() != nil {
-				if hasConnectivityGate(&pod, readinessGateIPv4) {
+				if hasConnectivityGate(&pod, constants.ReadinessGateIPv4) {
 					ipv4 = append(ipv4, ip)
 				}
 			} else {
-				if hasConnectivityGate(&pod, readinessGateIPv6) {
+				if hasConnectivityGate(&pod, constants.ReadinessGateIPv6) {
 					ipv6 = append(ipv6, ip)
 				}
 			}

--- a/internal/controller/endpointnetworkconfiguration/resolve_test.go
+++ b/internal/controller/endpointnetworkconfiguration/resolve_test.go
@@ -720,3 +720,158 @@ func TestSidecarContract_DualStack(t *testing.T) {
 	assert.Equal(t, testSubnetV6, ipv6Domain.Network.Subnet)
 	assert.Equal(t, "net1", ipv6Domain.Network.InterfaceHint)
 }
+
+func TestIsLBPodReady(t *testing.T) {
+	tests := []struct {
+		name     string
+		pod      *corev1.Pod
+		expected bool
+	}{
+		{
+			name: "all containers ready",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "sllb-1"},
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{
+						{Name: "loadbalancer", Ready: true},
+						{Name: "router", Ready: true},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "one container not ready",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "sllb-1"},
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{
+						{Name: "loadbalancer", Ready: true},
+						{Name: "router", Ready: false},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "pod being deleted",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "sllb-1",
+					DeletionTimestamp: &metav1.Time{Time: metav1.Now().Time},
+				},
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{
+						{Name: "loadbalancer", Ready: true},
+						{Name: "router", Ready: true},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "no container statuses yet (startup)",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "sllb-1"},
+				Status:     corev1.PodStatus{},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isLBPodReady(tt.pod)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestHasConnectivityGate(t *testing.T) {
+	tests := []struct {
+		name          string
+		pod           *corev1.Pod
+		conditionType string
+		expected      bool
+	}{
+		{
+			name: "condition True",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					ReadinessGates: []corev1.PodReadinessGate{
+						{ConditionType: "meridio-2.nordix.org/ipv4-connectivity"},
+					},
+				},
+				Status: corev1.PodStatus{
+					Conditions: []corev1.PodCondition{
+						{Type: "meridio-2.nordix.org/ipv4-connectivity", Status: corev1.ConditionTrue},
+					},
+				},
+			},
+			conditionType: "meridio-2.nordix.org/ipv4-connectivity",
+			expected:      true,
+		},
+		{
+			name: "condition False",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					ReadinessGates: []corev1.PodReadinessGate{
+						{ConditionType: "meridio-2.nordix.org/ipv4-connectivity"},
+					},
+				},
+				Status: corev1.PodStatus{
+					Conditions: []corev1.PodCondition{
+						{Type: "meridio-2.nordix.org/ipv4-connectivity", Status: corev1.ConditionFalse},
+					},
+				},
+			},
+			conditionType: "meridio-2.nordix.org/ipv4-connectivity",
+			expected:      false,
+		},
+		{
+			name: "gate not declared — not applicable, include Pod",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{},
+			},
+			conditionType: "meridio-2.nordix.org/ipv4-connectivity",
+			expected:      true,
+		},
+		{
+			name: "gate declared but condition not yet set (readinessGate present, condition missing)",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					ReadinessGates: []corev1.PodReadinessGate{
+						{ConditionType: "meridio-2.nordix.org/ipv4-connectivity"},
+					},
+				},
+				Status: corev1.PodStatus{},
+			},
+			conditionType: "meridio-2.nordix.org/ipv4-connectivity",
+			expected:      false,
+		},
+		{
+			name: "IPv6-only gateway — IPv4 gate not declared, include Pod",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					ReadinessGates: []corev1.PodReadinessGate{
+						{ConditionType: "meridio-2.nordix.org/ipv6-connectivity"},
+					},
+				},
+				Status: corev1.PodStatus{
+					Conditions: []corev1.PodCondition{
+						{Type: "meridio-2.nordix.org/ipv6-connectivity", Status: corev1.ConditionTrue},
+					},
+				},
+			},
+			conditionType: "meridio-2.nordix.org/ipv4-connectivity",
+			expected:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := hasConnectivityGate(tt.pod, tt.conditionType)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/internal/controller/endpointnetworkconfiguration/resolve_test.go
+++ b/internal/controller/endpointnetworkconfiguration/resolve_test.go
@@ -316,14 +316,20 @@ func TestGetSLLBRNextHops_DeterministicOrdering(t *testing.T) {
 			Name: "sllb-sllb-a-111", Namespace: testNamespace,
 			Labels: map[string]string{labelGatewayName: "sllb-a"},
 		},
-		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+		Status: corev1.PodStatus{
+			Phase:             corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{{Name: "lb", Ready: true}},
+		},
 	}
 	pod2 := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "sllb-sllb-a-222", Namespace: testNamespace,
 			Labels: map[string]string{labelGatewayName: "sllb-a"},
 		},
-		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+		Status: corev1.PodStatus{
+			Phase:             corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{{Name: "lb", Ready: true}},
+		},
 	}
 
 	scraper := func(pod *corev1.Pod, cidr, attachmentType string) string {

--- a/internal/controller/endpointnetworkconfiguration/resolve_test.go
+++ b/internal/controller/endpointnetworkconfiguration/resolve_test.go
@@ -18,7 +18,9 @@ package endpointnetworkconfiguration
 
 import (
 	"context"
+	"fmt"
 	"net"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -26,6 +28,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	meridio2v1alpha1 "github.com/nordix/meridio-2/api/v1alpha1"
@@ -289,7 +292,7 @@ func TestGetSLLBRNextHops(t *testing.T) {
 			Namespace: testNamespace,
 			Labels:    map[string]string{labelGatewayName: "sllb-a"},
 		},
-		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning, ContainerStatuses: []corev1.ContainerStatus{{Name: "loadbalancer", Ready: true}, {Name: "router", Ready: true}}},
 	}
 
 	r, _ := setupReconciler(gw, sllbrPod)
@@ -364,7 +367,7 @@ func TestBuildGatewayConnection_SkipsDomainWithNoInterface(t *testing.T) {
 			Namespace: testNamespace,
 			Labels:    map[string]string{labelGatewayName: "sllb-a"},
 		},
-		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning, ContainerStatuses: []corev1.ContainerStatus{{Name: "loadbalancer", Ready: true}, {Name: "router", Ready: true}}},
 	}
 	// Pod only has IPv4 address on net1 — no IPv6
 	targetPod := newPod("app-1", corev1.PodRunning, map[string]string{"app": "web"})
@@ -405,7 +408,7 @@ func TestBuildGatewayConnection_NamingConvention(t *testing.T) {
 			Namespace: testNamespace,
 			Labels:    map[string]string{labelGatewayName: "sllb-a"},
 		},
-		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning, ContainerStatuses: []corev1.ContainerStatus{{Name: "loadbalancer", Ready: true}, {Name: "router", Ready: true}}},
 	}
 	// Target pod with Multus network-status annotation
 	targetPod := newPod("app-1", corev1.PodRunning, map[string]string{"app": "web"})
@@ -474,7 +477,7 @@ func TestResolveGatewayConnections_FullChain(t *testing.T) {
 			Namespace: testNamespace,
 			Labels:    map[string]string{labelGatewayName: "sllb-a"},
 		},
-		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning, ContainerStatuses: []corev1.ContainerStatus{{Name: "loadbalancer", Ready: true}, {Name: "router", Ready: true}}},
 	}
 
 	r, _ := setupReconciler(pod, gw, gc, dg, sllbrPod)
@@ -642,7 +645,7 @@ func TestSidecarContract_DualStack(t *testing.T) {
 			Namespace: testNamespace,
 			Labels:    map[string]string{labelGatewayName: "sllb-a"},
 		},
-		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning, ContainerStatuses: []corev1.ContainerStatus{{Name: "loadbalancer", Ready: true}, {Name: "router", Ready: true}}},
 	}
 
 	r, _ := setupReconciler(pod, gw, gc, dg, sllbrPod)
@@ -873,5 +876,149 @@ func TestHasConnectivityGate(t *testing.T) {
 			result := hasConnectivityGate(tt.pod, tt.conditionType)
 			assert.Equal(t, tt.expected, result)
 		})
+	}
+}
+
+func TestGetSLLBRNextHops_TwoLevelFiltering(t *testing.T) {
+	tests := []struct {
+		name     string
+		pods     []corev1.Pod
+		wantIPv4 []string
+		wantIPv6 []string
+	}{
+		{
+			name: "all pods healthy and connected — all included",
+			pods: []corev1.Pod{
+				makeLBPodWithGates("sllb-1", true, true, true),
+				makeLBPodWithGates("sllb-2", true, true, true),
+			},
+			wantIPv4: []string{"192.168.100.1", "192.168.100.2"},
+		},
+		{
+			name: "one pod container not ready — excluded from both families",
+			pods: []corev1.Pod{
+				makeLBPodWithGates("sllb-1", true, true, true),
+				makeLBPodWithGates("sllb-2", false, true, true), // container not ready
+			},
+			wantIPv4: []string{"192.168.100.1"},
+		},
+		{
+			name: "pod has IPv4 gate True but IPv6 gate False — only in IPv4 hops",
+			pods: []corev1.Pod{
+				makeLBPodWithGates("sllb-1", true, true, false),
+			},
+			wantIPv4: []string{"192.168.100.1"},
+			wantIPv6: nil,
+		},
+		{
+			name: "pod has no readiness gates — included (gate not applicable)",
+			pods: []corev1.Pod{
+				makeLBPodNoGates("sllb-1", true),
+			},
+			wantIPv4: []string{"192.168.100.1"},
+		},
+		{
+			name: "pod being deleted — excluded",
+			pods: []corev1.Pod{
+				makeLBPodDeleting("sllb-1"),
+			},
+			wantIPv4: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &Reconciler{
+				IPScraper: func(pod *corev1.Pod, cidr, _ string) string {
+					// Return a deterministic IP based on pod name and CIDR family
+					idx := pod.Name[len(pod.Name)-1] - '0' // last char as index
+					if strings.Contains(cidr, ":") {
+						return fmt.Sprintf("2001:db8::%d", idx)
+					}
+					return fmt.Sprintf("192.168.100.%d", idx)
+				},
+			}
+
+			gw := &gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-gw", Namespace: "default"},
+			}
+
+			objects := make([]client.Object, 0, len(tt.pods))
+			for i := range tt.pods {
+				tt.pods[i].Namespace = "default"
+				tt.pods[i].Labels = map[string]string{labelGatewayName: "test-gw"}
+				objects = append(objects, &tt.pods[i])
+			}
+
+			fakeClient := fake.NewClientBuilder().WithObjects(objects...).Build()
+			r.Client = fakeClient
+
+			subnetToType := map[string]string{"192.168.100.0/24": "NAD"}
+			if tt.wantIPv6 != nil || tt.name == "pod has IPv4 gate True but IPv6 gate False — only in IPv4 hops" {
+				subnetToType["2001:db8::/64"] = "NAD"
+			}
+
+			ipv4, ipv6, err := r.getSLLBRNextHops(context.Background(), gw, subnetToType)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantIPv4, ipv4)
+			assert.Equal(t, tt.wantIPv6, ipv6)
+		})
+	}
+}
+
+// Helper functions for test Pod construction
+
+//nolint:unparam // test helper designed for varied usage
+func makeLBPodWithGates(name string, containersReady, ipv4GateTrue, ipv6GateTrue bool) corev1.Pod {
+	ipv4Status := corev1.ConditionFalse
+	if ipv4GateTrue {
+		ipv4Status = corev1.ConditionTrue
+	}
+	ipv6Status := corev1.ConditionFalse
+	if ipv6GateTrue {
+		ipv6Status = corev1.ConditionTrue
+	}
+	return corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: corev1.PodSpec{
+			ReadinessGates: []corev1.PodReadinessGate{
+				{ConditionType: "meridio-2.nordix.org/ipv4-connectivity"},
+				{ConditionType: "meridio-2.nordix.org/ipv6-connectivity"},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "loadbalancer", Ready: containersReady},
+				{Name: "router", Ready: containersReady},
+			},
+			Conditions: []corev1.PodCondition{
+				{Type: "meridio-2.nordix.org/ipv4-connectivity", Status: ipv4Status},
+				{Type: "meridio-2.nordix.org/ipv6-connectivity", Status: ipv6Status},
+			},
+		},
+	}
+}
+
+func makeLBPodNoGates(name string, containersReady bool) corev1.Pod {
+	return corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "loadbalancer", Ready: containersReady},
+				{Name: "router", Ready: containersReady},
+			},
+		},
+	}
+}
+
+func makeLBPodDeleting(name string) corev1.Pod {
+	return corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Finalizers: []string{"test"}},
+		Status: corev1.PodStatus{
+			Phase:             corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{},
+		},
 	}
 }

--- a/internal/controller/gateway/const.go
+++ b/internal/controller/gateway/const.go
@@ -42,8 +42,4 @@ const (
 	labelGatewayName = "gateway.networking.k8s.io/gateway-name"
 	labelManagedBy   = "app.kubernetes.io/managed-by"
 	managedByValue   = "gateway-controller.meridio-2.nordix.org"
-
-	// Readiness gates for external connectivity - used by LB Deployment pods to signal connectivity status
-	ReadinessGateIPv4 = "meridio-2.nordix.org/ipv4-connectivity"
-	ReadinessGateIPv6 = "meridio-2.nordix.org/ipv6-connectivity"
 )

--- a/internal/controller/gateway/deployment.go
+++ b/internal/controller/gateway/deployment.go
@@ -26,6 +26,7 @@ import (
 
 	netdefv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	meridio2v1alpha1 "github.com/nordix/meridio-2/api/v1alpha1"
+	"github.com/nordix/meridio-2/internal/common/constants"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
@@ -529,13 +530,13 @@ func applyReadinessGates(deployment *appsv1.Deployment, gatewayConfig *meridio2v
 
 	if hasIPv4 {
 		gates = append(gates, corev1.PodReadinessGate{
-			ConditionType: ReadinessGateIPv4,
+			ConditionType: constants.ReadinessGateIPv4,
 		})
 	}
 
 	if hasIPv6 {
 		gates = append(gates, corev1.PodReadinessGate{
-			ConditionType: ReadinessGateIPv6,
+			ConditionType: constants.ReadinessGateIPv6,
 		})
 	}
 

--- a/internal/controller/gateway/deployment_test.go
+++ b/internal/controller/gateway/deployment_test.go
@@ -24,6 +24,7 @@ import (
 
 	netdefv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	meridio2v1alpha1 "github.com/nordix/meridio-2/api/v1alpha1"
+	"github.com/nordix/meridio-2/internal/common/constants"
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -367,8 +368,8 @@ func TestReconcileLBDeployment(t *testing.T) {
 		}, &deployment)
 		assert.NoError(t, err)
 		assert.Equal(t, []corev1.PodReadinessGate{
-			{ConditionType: ReadinessGateIPv4},
-			{ConditionType: ReadinessGateIPv6},
+			{ConditionType: constants.ReadinessGateIPv4},
+			{ConditionType: constants.ReadinessGateIPv6},
 		}, deployment.Spec.Template.Spec.ReadinessGates)
 	})
 
@@ -391,7 +392,7 @@ func TestReconcileLBDeployment(t *testing.T) {
 		}, &deployment)
 		assert.NoError(t, err)
 		assert.Equal(t, []corev1.PodReadinessGate{
-			{ConditionType: ReadinessGateIPv4},
+			{ConditionType: constants.ReadinessGateIPv4},
 		}, deployment.Spec.Template.Spec.ReadinessGates)
 	})
 

--- a/internal/controller/router/connectivity.go
+++ b/internal/controller/router/connectivity.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	meridio2v1alpha1 "github.com/nordix/meridio-2/api/v1alpha1"
+	"github.com/nordix/meridio-2/internal/common/constants"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -75,17 +76,17 @@ func (cgm *ConnectivityGateManager) DiscoverGates(ctx context.Context) error {
 
 	for _, gate := range pod.Spec.ReadinessGates {
 		switch gate.ConditionType {
-		case ReadinessGateIPv4:
+		case constants.ReadinessGateIPv4:
 			cgm.ipv4Gate = new(bool)
 			for _, c := range pod.Status.Conditions {
-				if string(c.Type) == ReadinessGateIPv4 {
+				if string(c.Type) == constants.ReadinessGateIPv4 {
 					*cgm.ipv4Gate = c.Status == corev1.ConditionTrue
 				}
 			}
-		case ReadinessGateIPv6:
+		case constants.ReadinessGateIPv6:
 			cgm.ipv6Gate = new(bool)
 			for _, c := range pod.Status.Conditions {
-				if string(c.Type) == ReadinessGateIPv6 {
+				if string(c.Type) == constants.ReadinessGateIPv6 {
 					*cgm.ipv6Gate = c.Status == corev1.ConditionTrue
 				}
 			}
@@ -162,12 +163,12 @@ func (cgm *ConnectivityGateManager) patchGateCondition(ctx context.Context, cond
 func (cgm *ConnectivityGateManager) SetAllGatesFalse(ctx context.Context) error {
 	var errFinal error
 	if cgm.ipv4Gate != nil {
-		if err := cgm.patchGateCondition(ctx, ReadinessGateIPv4, false); err != nil {
+		if err := cgm.patchGateCondition(ctx, constants.ReadinessGateIPv4, false); err != nil {
 			errFinal = errors.Join(errFinal, err)
 		}
 	}
 	if cgm.ipv6Gate != nil {
-		if err := cgm.patchGateCondition(ctx, ReadinessGateIPv6, false); err != nil {
+		if err := cgm.patchGateCondition(ctx, constants.ReadinessGateIPv6, false); err != nil {
 			errFinal = errors.Join(errFinal, err)
 		}
 	}
@@ -179,10 +180,10 @@ func (cgm *ConnectivityGateManager) SetAllGatesFalse(ctx context.Context) error 
 // with continuous connectivity before the gate is set to True.
 func (cgm *ConnectivityGateManager) OnStatusUpdate(ctx context.Context, ipv4Connected, ipv6Connected bool) error {
 	var errFinal error
-	if err := cgm.handleGate(ctx, cgm.ipv4Gate, ipv4Connected, &cgm.ipv4UpSince, ReadinessGateIPv4); err != nil {
+	if err := cgm.handleGate(ctx, cgm.ipv4Gate, ipv4Connected, &cgm.ipv4UpSince, constants.ReadinessGateIPv4); err != nil {
 		errFinal = errors.Join(errFinal, err)
 	}
-	if err := cgm.handleGate(ctx, cgm.ipv6Gate, ipv6Connected, &cgm.ipv6UpSince, ReadinessGateIPv6); err != nil {
+	if err := cgm.handleGate(ctx, cgm.ipv6Gate, ipv6Connected, &cgm.ipv6UpSince, constants.ReadinessGateIPv6); err != nil {
 		errFinal = errors.Join(errFinal, err)
 	}
 	return errFinal
@@ -241,7 +242,7 @@ func (cgm *ConnectivityGateManager) handleGate(ctx context.Context, gate *bool, 
 }
 
 func (cgm *ConnectivityGateManager) getDirty(conditionType string) *bool {
-	if conditionType == ReadinessGateIPv4 {
+	if conditionType == constants.ReadinessGateIPv4 {
 		return &cgm.ipv4Dirty
 	}
 	return &cgm.ipv6Dirty

--- a/internal/controller/router/connectivity_test.go
+++ b/internal/controller/router/connectivity_test.go
@@ -23,6 +23,7 @@ import (
 
 	meridio2v1alpha1 "github.com/nordix/meridio-2/api/v1alpha1"
 	"github.com/nordix/meridio-2/internal/bird"
+	"github.com/nordix/meridio-2/internal/common/constants"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -252,7 +253,7 @@ func TestPatchGateCondition(t *testing.T) {
 			Build()
 
 		mgr := NewConnectivityGateManager(fakeClient, "test-pod", "default", "uid-1", 10*time.Second)
-		err := mgr.patchGateCondition(context.Background(), ReadinessGateIPv4, true)
+		err := mgr.patchGateCondition(context.Background(), constants.ReadinessGateIPv4, true)
 		assert.NoError(t, err)
 
 		// Verify condition was set
@@ -262,7 +263,7 @@ func TestPatchGateCondition(t *testing.T) {
 
 		var found bool
 		for _, c := range updated.Status.Conditions {
-			if c.Type == corev1.PodConditionType(ReadinessGateIPv4) {
+			if c.Type == corev1.PodConditionType(constants.ReadinessGateIPv4) {
 				assert.Equal(t, corev1.ConditionTrue, c.Status)
 				found = true
 			}
@@ -285,7 +286,7 @@ func TestPatchGateCondition(t *testing.T) {
 			Build()
 
 		mgr := NewConnectivityGateManager(fakeClient, "test-pod", "default", "uid-1", 10*time.Second)
-		err := mgr.patchGateCondition(context.Background(), ReadinessGateIPv6, false)
+		err := mgr.patchGateCondition(context.Background(), constants.ReadinessGateIPv6, false)
 		assert.NoError(t, err)
 
 		updated := &corev1.Pod{}
@@ -294,7 +295,7 @@ func TestPatchGateCondition(t *testing.T) {
 
 		var found bool
 		for _, c := range updated.Status.Conditions {
-			if c.Type == corev1.PodConditionType(ReadinessGateIPv6) {
+			if c.Type == corev1.PodConditionType(constants.ReadinessGateIPv6) {
 				assert.Equal(t, corev1.ConditionFalse, c.Status)
 				found = true
 			}
@@ -313,7 +314,7 @@ func TestPatchGateCondition(t *testing.T) {
 			Status: corev1.PodStatus{
 				Conditions: []corev1.PodCondition{
 					{
-						Type:   corev1.PodConditionType(ReadinessGateIPv4),
+						Type:   corev1.PodConditionType(constants.ReadinessGateIPv4),
 						Status: corev1.ConditionFalse,
 					},
 				},
@@ -325,7 +326,7 @@ func TestPatchGateCondition(t *testing.T) {
 			Build()
 
 		mgr := NewConnectivityGateManager(fakeClient, "test-pod", "default", "uid-1", 10*time.Second)
-		err := mgr.patchGateCondition(context.Background(), ReadinessGateIPv4, true)
+		err := mgr.patchGateCondition(context.Background(), constants.ReadinessGateIPv4, true)
 		assert.NoError(t, err)
 
 		updated := &corev1.Pod{}
@@ -333,7 +334,7 @@ func TestPatchGateCondition(t *testing.T) {
 		assert.NoError(t, err)
 
 		for _, c := range updated.Status.Conditions {
-			if c.Type == corev1.PodConditionType(ReadinessGateIPv4) {
+			if c.Type == corev1.PodConditionType(constants.ReadinessGateIPv4) {
 				assert.Equal(t, corev1.ConditionTrue, c.Status)
 			}
 		}
@@ -491,7 +492,7 @@ func TestDamping(t *testing.T) {
 		updated := &corev1.Pod{}
 		_ = fakeClient.Get(context.Background(), types.NamespacedName{Name: "test-pod", Namespace: "default"}, updated)
 		for _, c := range updated.Status.Conditions {
-			if string(c.Type) == ReadinessGateIPv4 {
+			if string(c.Type) == constants.ReadinessGateIPv4 {
 				assert.Equal(t, corev1.ConditionTrue, c.Status, "gate should be True before drop")
 			}
 		}
@@ -502,7 +503,7 @@ func TestDamping(t *testing.T) {
 
 		_ = fakeClient.Get(context.Background(), types.NamespacedName{Name: "test-pod", Namespace: "default"}, updated)
 		for _, c := range updated.Status.Conditions {
-			if string(c.Type) == ReadinessGateIPv4 {
+			if string(c.Type) == constants.ReadinessGateIPv4 {
 				assert.Equal(t, corev1.ConditionFalse, c.Status, "gate should be False immediately on down (no damping)")
 			}
 		}
@@ -533,7 +534,7 @@ func TestDamping(t *testing.T) {
 		updated := &corev1.Pod{}
 		_ = fakeClient.Get(context.Background(), types.NamespacedName{Name: "test-pod", Namespace: "default"}, updated)
 		for _, c := range updated.Status.Conditions {
-			if string(c.Type) == ReadinessGateIPv4 {
+			if string(c.Type) == constants.ReadinessGateIPv4 {
 				assert.Equal(t, corev1.ConditionFalse, c.Status, "gate should still be False during hold time")
 			}
 		}
@@ -547,7 +548,7 @@ func TestDamping(t *testing.T) {
 
 		_ = fakeClient.Get(context.Background(), types.NamespacedName{Name: "test-pod", Namespace: "default"}, updated)
 		for _, c := range updated.Status.Conditions {
-			if string(c.Type) == ReadinessGateIPv4 {
+			if string(c.Type) == constants.ReadinessGateIPv4 {
 				assert.Equal(t, corev1.ConditionTrue, c.Status, "gate should be True after hold time")
 			}
 		}
@@ -585,7 +586,7 @@ func TestDamping(t *testing.T) {
 		updated := &corev1.Pod{}
 		_ = fakeClient.Get(context.Background(), types.NamespacedName{Name: "test-pod", Namespace: "default"}, updated)
 		for _, c := range updated.Status.Conditions {
-			if string(c.Type) == ReadinessGateIPv4 {
+			if string(c.Type) == constants.ReadinessGateIPv4 {
 				assert.Equal(t, corev1.ConditionFalse, c.Status, "gate should remain False after flap")
 			}
 		}
@@ -640,6 +641,6 @@ func TestDamping(t *testing.T) {
 		updated := &corev1.Pod{}
 		_ = fakeClient.Get(context.Background(), types.NamespacedName{Name: "test-pod", Namespace: "default"}, updated)
 		assert.Len(t, updated.Status.Conditions, 1)
-		assert.Equal(t, corev1.PodConditionType(ReadinessGateIPv4), updated.Status.Conditions[0].Type)
+		assert.Equal(t, corev1.PodConditionType(constants.ReadinessGateIPv4), updated.Status.Conditions[0].Type)
 	})
 }

--- a/internal/controller/router/constants.go
+++ b/internal/controller/router/constants.go
@@ -1,6 +1,0 @@
-package router
-
-const (
-	ReadinessGateIPv4 = "meridio-2.nordix.org/ipv4-connectivity"
-	ReadinessGateIPv6 = "meridio-2.nordix.org/ipv6-connectivity"
-)


### PR DESCRIPTION
Implement isLBPodReady and hasConnectivityGate for filtering LB Pods from next-hop lists:
- isLBPodReady: checks all container statuses are Ready, excludes deleted Pods and Pods without container statuses
- hasConnectivityGate: checks per-IP-family readiness gate condition, returns true if gate not declared (not applicable for that family)

Ref: gh-123