### PR TITLE
Enhance LB controller for dual-stack IP processing and deduplication

### DIFF
--- a/api/v1alpha1/distributiongroup_types.go
+++ b/api/v1alpha1/distributiongroup_types.go
@@ -56,7 +56,7 @@ type MaglevConfig struct {
 	// MaxEndpoints is the table capacity. This field is immutable after creation.
 	//
 	// Immutability rationale:
-	// - Maglev IDs are assigned per DistributionGroup and per IP family (IPv4/IPv6)
+	// - Maglev IDs are assigned per DistributionGroup and per Gateway
 	// - The same Pod IP may have different Maglev IDs in different DistributionGroups
 	// - Changing MaxEndpoints causes Maglev hash table reshuffle, potentially reassigning
 	//   IDs for many endpoints and disrupting active connections for this DistributionGroup

--- a/config/crd/bases/meridio-2.nordix.org_distributiongroups.yaml
+++ b/config/crd/bases/meridio-2.nordix.org_distributiongroups.yaml
@@ -78,7 +78,7 @@ spec:
                       MaxEndpoints is the table capacity. This field is immutable after creation.
 
                       Immutability rationale:
-                      - Maglev IDs are assigned per DistributionGroup and per IP family (IPv4/IPv6)
+                      - Maglev IDs are assigned per DistributionGroup and per Gateway
                       - The same Pod IP may have different Maglev IDs in different DistributionGroups
                       - Changing MaxEndpoints causes Maglev hash table reshuffle, potentially reassigning
                         IDs for many endpoints and disrupting active connections for this DistributionGroup

--- a/docs/operations/constraints-and-limitations.md
+++ b/docs/operations/constraints-and-limitations.md
@@ -6,9 +6,9 @@ Items marked *(architectural constraint)* reflect deliberate design decisions th
 
 ## Architecture / Cross-Controller
 
-**1. Dual-stack internal networking partially supported (IPv4 + IPv6 simultaneously)**
+**1. ~~Dual-stack internal networking partially supported (IPv4 + IPv6 simultaneously)~~ (Resolved)**
 
-The DistributionGroup controller assigns Maglev IDs per DG per Gateway, shared across all networks (IPv4/IPv6) — the allocation side is complete. However, the LB controller's dual-stack route handling is pending refactor and not yet production-ready. See [#70](https://github.com/Nordix/Meridio-2/issues/70).
+The DistributionGroup controller assigns Maglev IDs per DG per Gateway, shared across all networks (IPv4/IPv6). The LB controller accumulates IPs from both IPv4 and IPv6 EndpointSlices per identifier and creates policy routes for both families. See [#70](https://github.com/Nordix/Meridio-2/issues/70), [#144](https://github.com/Nordix/Meridio-2/issues/144).
 
 **2. ~~RBAC uses ClusterRole instead of namespace-scoped Roles (controller-manager)~~ (Resolved)**
 

--- a/internal/controller/loadbalancer/controller_test.go
+++ b/internal/controller/loadbalancer/controller_test.go
@@ -738,6 +738,60 @@ var _ = Describe("LoadBalancer Controller", func() {
 			Expect(mockInstance.targets).To(HaveLen(1))
 			Expect(mockInstance.targets).To(HaveKey(0)) // Only maglev:0
 		})
+
+		It("should accumulate IPs from IPv4 and IPv6 EndpointSlices for the same identifier", func() {
+			ready := true
+			zone0 := testZoneMaglev0
+
+			epsV4 := &discoveryv1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-eps-v4",
+					Namespace: namespace,
+					Labels: map[string]string{
+						"meridio-2.nordix.org/distribution-group": "test-distgroup",
+					},
+				},
+				AddressType: discoveryv1.AddressTypeIPv4,
+				Endpoints: []discoveryv1.Endpoint{
+					{
+						Addresses:  []string{"192.168.100.10"},
+						Conditions: discoveryv1.EndpointConditions{Ready: &ready},
+						Zone:       &zone0,
+					},
+				},
+			}
+
+			epsV6 := &discoveryv1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-eps-v6",
+					Namespace: namespace,
+					Labels: map[string]string{
+						"meridio-2.nordix.org/distribution-group": "test-distgroup",
+					},
+				},
+				AddressType: discoveryv1.AddressTypeIPv6,
+				Endpoints: []discoveryv1.Endpoint{
+					{
+						Addresses:  []string{"2001:db8:100::10"},
+						Conditions: discoveryv1.EndpointConditions{Ready: &ready},
+						Zone:       &zone0,
+					},
+				},
+			}
+
+			fakeClient = fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(epsV4, epsV6).
+				Build()
+			controller.Client = fakeClient
+
+			err := controller.reconcileTargets(ctx, distGroup)
+			Expect(err).ToNot(HaveOccurred())
+
+			mockInstance := mockNfqlb.instances[distGroup.Name]
+			Expect(mockInstance.targets).To(HaveKey(0))
+			Expect(mockInstance.targets[0]).To(Equal([]string{"192.168.100.10", "2001:db8:100::10"}))
+		})
 	})
 
 	Describe("reconcileFlows", func() {

--- a/internal/controller/loadbalancer/targets.go
+++ b/internal/controller/loadbalancer/targets.go
@@ -19,6 +19,7 @@ package loadbalancer
 import (
 	"context"
 	"errors"
+	"slices"
 	"strconv"
 
 	discoveryv1 "k8s.io/api/discovery/v1"
@@ -49,6 +50,20 @@ func (c *Controller) reconcileTargets(ctx context.Context, distGroup *meridio2v1
 		}); err != nil {
 		return err
 	}
+
+	// Sort EndpointSlices by name for deterministic processing order (cache List
+	// does not guarantee order). Produces stable accumulated IP lists across reconciles,
+	// preventing flapping during transients when the same identifier appears in multiple
+	// slices of the same IP family (e.g., Pod replacement with >100 endpoints).
+	slices.SortFunc(endpointSliceList.Items, func(a, b discoveryv1.EndpointSlice) int {
+		if a.Name < b.Name {
+			return -1
+		}
+		if a.Name > b.Name {
+			return 1
+		}
+		return 0
+	})
 
 	// Get current targets
 	currentTargets := c.targets[distGroup.Name]
@@ -81,7 +96,7 @@ func (c *Controller) reconcileTargets(ctx context.Context, distGroup *meridio2v1
 				logr.Error(err, "Invalid identifier in Zone field", "zone", *endpoint.Zone)
 				continue
 			}
-			newTargets[identifier] = endpoint.Addresses
+			newTargets[identifier] = append(newTargets[identifier], endpoint.Addresses...)
 		}
 	}
 
@@ -100,6 +115,9 @@ func (c *Controller) reconcileTargets(ctx context.Context, distGroup *meridio2v1
 
 	// Activate new/updated targets (nfqlb handles policy route creation internally)
 	for identifier, ips := range newTargets {
+		// Sort IPs for deterministic comparison in AddTarget (avoids false
+		// "IPs changed" triggers when IPv4/IPv6 slices are processed in different order)
+		slices.Sort(ips)
 		if err := service.AddTarget(ctx, ips, identifier); err != nil {
 			logr.Error(err, "Failed to activate target", "identifier", identifier, "ips", ips)
 			errFinal = errors.Join(errFinal, err)

--- a/internal/nfqlb/routing.go
+++ b/internal/nfqlb/routing.go
@@ -73,7 +73,9 @@ func createPolicyRoute(fwMark int, ip string) error {
 
 // ensureRule adds the desired rule only if it doesn't already exist.
 // Linux allows duplicate ip rules, so we check first to avoid accumulating duplicates
-// across reconciles.
+// across reconciles. Priority of -1 means "unset" in vishvananda/netlink (library skips
+// FRA_PRIORITY in the netlink message, causing the kernel to auto-assign a priority).
+// We cannot match on auto-assigned priorities, so skip the comparison when unset.
 func ensureRule(desired *netlink.Rule) error {
 	rules, err := netlink.RuleList(desired.Family)
 	if err != nil {
@@ -82,7 +84,8 @@ func ensureRule(desired *netlink.Rule) error {
 	}
 
 	for _, existing := range rules {
-		if existing.Mark == desired.Mark && existing.Table == desired.Table && existing.Priority == desired.Priority {
+		if existing.Mark == desired.Mark && existing.Table == desired.Table &&
+			(desired.Priority < 0 || existing.Priority == desired.Priority) {
 			return nil // Already exists
 		}
 	}

--- a/internal/nfqlb/target_test.go
+++ b/internal/nfqlb/target_test.go
@@ -141,6 +141,33 @@ var _ = Describe("Instance.AddTarget", func() {
 		Expect(instance.targets[1]).To(Equal([]string{"10.0.0.1", "10.0.0.3"}))
 	})
 
+	It("should create routes for both IPv4 and IPv6 addresses", func() {
+		err := instance.AddTarget(ctx, []string{"192.168.100.10", "2001:db8:100::10"}, 0)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(executor.calls).To(HaveLen(1))
+		Expect(executor.calls[0]).To(ContainElements("activate", "--index=0", "--shm=test-instance", "5000"))
+		Expect(routing.created).To(ConsistOf(
+			routeCall{5000, "192.168.100.10"},
+			routeCall{5000, "2001:db8:100::10"},
+		))
+		Expect(instance.targets[0]).To(Equal([]string{"192.168.100.10", "2001:db8:100::10"}))
+	})
+
+	It("should re-apply dual-stack routes when identifier exists with same IPs", func() {
+		instance.targets[0] = []string{"192.168.100.10", "2001:db8:100::10"}
+
+		err := instance.AddTarget(ctx, []string{"192.168.100.10", "2001:db8:100::10"}, 0)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(executor.calls).To(BeEmpty())
+		Expect(routing.created).To(ConsistOf(
+			routeCall{5000, "192.168.100.10"},
+			routeCall{5000, "2001:db8:100::10"},
+		))
+		Expect(routing.deleted).To(BeEmpty())
+	})
+
 	It("should return error on route creation failure during IP change", func() {
 		routing.createErr = fmt.Errorf("netlink error")
 		instance.targets[0] = []string{"10.0.0.1"}


### PR DESCRIPTION
Fixes #144

## Changes

Dual-stack endpoint processing:
- Accumulate IPs per identifier across IPv4/IPv6 EndpointSlices (append instead of overwrite)
- Sort EndpointSlices by name for deterministic processing order during multi-slice transients
- Sort IPs before AddTarget to prevent false "IPs changed" triggers from ordering differences

Bug fix — duplicate ip rules:
- ensureRule compared Priority=-1 (vishvananda/netlink sentinel for "unset") against kernel-assigned positive priorities, never finding a match — adding a new rule on every reconcile
- Fix: skip Priority comparison when desired.Priority < 0

## Tests

- Dual-stack AddTarget test (new target + drift recovery path) in internal/nfqlb
- Dual-stack IP accumulation test in LB controller

Verified manually in Kind.

dedicated issue to handle e2e tests: https://github.com/Nordix/Meridio-2/issues/159
