### PR TITLE
Fix DeleteTarget partial failure: retry on next reconcile

### DIFF
--- a/docs/design/nfqlb-target-recovery-invariants.md
+++ b/docs/design/nfqlb-target-recovery-invariants.md
@@ -1,0 +1,60 @@
+# NFQLB Target Management: Recovery Invariants
+
+## Overview
+
+The LB controller manages NFQLB targets (activate/deactivate slots, create/delete policy routes). The recovery model relies on several implicit invariants that must be preserved for self-healing to work correctly.
+
+## Invariants
+
+### 1. Operation ordering: routes before activate
+
+`AddTarget` creates policy routes before activating the NFQLB slot. This order ensures:
+- If routes fail → no nfqlb slot is activated, no traffic reaches partial routes
+- If activate fails after routes → target is marked broken, routes exist but harmless (invariant #3)
+- On retry, routes are re-applied idempotently then activate is retried
+
+This order is preferred because an active slot with missing routes would cause traffic drops, while routes without an active slot receive no traffic (NFQLB hasn't marked packets with the fwmark yet).
+
+### 2. No context timeouts on nfqlb CLI calls
+
+The `doExec` calls to `nfqlb activate`/`deactivate` use the reconcile context without additional timeouts. This guarantees an unambiguous outcome: the call either succeeds or fails, never times out mid-operation. Adding a custom timeout would break the recovery model — a timed-out activate might have succeeded in NFQLB's shared memory, but the caller wouldn't know whether to retry or clean up.
+
+**Constraint**: Do not wrap nfqlb CLI calls in shortened-timeout contexts.
+
+### 3. Orphaned routes are harmless
+
+Policy routes (fwmark-based) only receive traffic if NFQLB actively sets the corresponding fwmark on packets. A route without an active NFQLB slot never gets traffic. This means:
+- Failed route deletions don't cause traffic blackholes
+- Stale routes from a previous activation are overwritten by `RouteReplace` on retry
+
+**Dependency**: This relies on the fwmark routing design where NFQLB is the sole source of fwmarks. If any other component sets fwmarks in the same range, orphaned routes could receive unintended traffic.
+
+### 4. `s.targets` commit position determines recovery behavior
+
+- `AddTarget`: commits `s.targets[id] = ips` on any partial progress (routes created or activate attempted). If any step fails, the target is in `s.targets` and marked broken. On retry, the "IPs unchanged" path re-applies routes and retries activate if needed.
+- `DeleteTarget`: removes `delete(s.targets, id)` only after all operations succeed (deactivate + route deletion). If any step fails, the identifier stays in `s.targets` and is marked broken so the next reconcile will retry `DeleteTarget`.
+
+The reconciler layer always commits `c.targets = newTargets ∪ failedDeletes`, ensuring the diff on next reconcile triggers DeleteTarget for disappeared-but-failed targets.
+
+### 5. Idempotent nfqlb and route operations
+
+The recovery model relies on:
+- `nfqlb activate` on an already-active slot: no-op (returns success)
+- `nfqlb deactivate` on an inactive slot: no-op (returns success)
+- `RouteReplace`: overwrites existing routes (idempotent by design)
+- `ensureRule`: skips if rule already exists (checks before adding)
+- `doDeletePolicyRoute`: tolerates ENOENT/ESRCH (route/rule not found)
+
+If any of these operations became non-idempotent (e.g., returning errors for "already exists" or "not found"), retries would fail or loop indefinitely.
+
+## Broken State Tracking
+
+The `broken` map (`map[int]struct{}`) tracks identifiers where activate succeeded but route creation failed. This prevents the stuck state where:
+1. AddTarget: activate succeeds, routes fail → target in `s.targets`, marked broken
+2. Target disappears from EndpointSlices before retry
+3. Without broken tracking: nobody calls DeleteTarget (identifier not in stale `c.targets` nor `newTargets`)
+4. With broken tracking: reconcile loop cleans up broken targets not in `newTargets`
+
+The broken flag is cleared on:
+- Successful route creation (all paths: new, same-IPs, changed-IPs)
+- DeleteTarget (regardless of outcome)

--- a/docs/design/nfqlb-target-recovery-invariants.md
+++ b/docs/design/nfqlb-target-recovery-invariants.md
@@ -17,9 +17,7 @@ This order is preferred because an active slot with missing routes would cause t
 
 ### 2. No context timeouts on nfqlb CLI calls
 
-The `doExec` calls to `nfqlb activate`/`deactivate` use the reconcile context without additional timeouts. This guarantees an unambiguous outcome: the call either succeeds or fails, never times out mid-operation. Adding a custom timeout would break the recovery model — a timed-out activate might have succeeded in NFQLB's shared memory, but the caller wouldn't know whether to retry or clean up.
-
-**Constraint**: Do not wrap nfqlb CLI calls in shortened-timeout contexts.
+The `doExec` calls to `nfqlb activate`/`deactivate` use the reconcile context without additional timeouts. This guarantees an unambiguous outcome: the call either succeeds or fails, never times out mid-operation. A timed-out activate might have succeeded in NFQLB's shared memory, but the caller wouldn't know whether to retry or clean up. With broken-state tracking, a timeout would be handled as a broken state (mark broken, retry on next reconcile), so custom timeouts would not break recovery — but they add complexity without clear benefit.
 
 ### 3. Orphaned routes are harmless
 

--- a/docs/design/nfqlb-target-recovery-invariants.md
+++ b/docs/design/nfqlb-target-recovery-invariants.md
@@ -49,12 +49,24 @@ If any of these operations became non-idempotent (e.g., returning errors for "al
 
 ## Broken State Tracking
 
-The `broken` map (`map[int]struct{}`) tracks identifiers where activate succeeded but route creation failed. This prevents the stuck state where:
-1. AddTarget: activate succeeds, routes fail → target in `s.targets`, marked broken
+The `broken` map (`map[int]struct{}`) tracks identifiers in an inconsistent state — where any operation in AddTarget or DeleteTarget partially failed. An identifier is marked broken when:
+
+1. **AddTarget — route creation fails** (activate never attempted): routes may be partially created, no nfqlb slot active. Target committed to `s.targets` as broken.
+2. **AddTarget — activate fails** (routes were created successfully): routes exist, nfqlb slot state unknown. Target committed to `s.targets` as broken.
+3. **AddTarget — IPs-unchanged or IPs-changed re-apply path**: route or activate retry fails. Marked broken.
+4. **DeleteTarget — deactivate fails**: slot may still be active, routes still exist. Stays in `s.targets`, marked broken.
+5. **DeleteTarget — route deletion fails** (deactivate succeeded): slot inactive, routes partially remain. Stays in `s.targets`, marked broken.
+
+Without broken tracking, the following stuck state occurs:
+1. AddTarget: routes fail → target in `s.targets`, no retry trigger
 2. Target disappears from EndpointSlices before retry
-3. Without broken tracking: nobody calls DeleteTarget (identifier not in stale `c.targets` nor `newTargets`)
+3. Nobody calls DeleteTarget (identifier not in stale `c.targets` nor `newTargets`)
 4. With broken tracking: reconcile loop cleans up broken targets not in `newTargets`
 
-The broken flag is cleared on:
-- Successful route creation (all paths: new, same-IPs, changed-IPs)
-- DeleteTarget (regardless of outcome)
+The broken flag is cleared only when **all** operations in AddTarget or DeleteTarget complete successfully:
+- AddTarget: routes created + activate succeeded (applies to all paths: new, same-IPs, IPs-changed)
+- DeleteTarget: deactivate + all route deletions succeeded → entry removed from both maps
+
+All paths (same-IPs, IPs-changed) include an `activate` call after route creation. Since `activate` is idempotent (no-op on already-active slot per invariant #5), this ensures recovery when the previous failure was an activate failure — not just a route failure.
+
+**Note on DeleteTarget clearance**: The `delete(s.broken, identifier)` at the end of a successful DeleteTarget also removes the target from `s.targets`. If DeleteTarget fails at any step, the identifier remains in both `s.targets` and `broken`, ensuring the next reconcile retries the deletion.

--- a/internal/controller/loadbalancer/controller.go
+++ b/internal/controller/loadbalancer/controller.go
@@ -71,7 +71,7 @@ type Controller struct {
 	mu          sync.Mutex
 	instances   map[string]nfqlbInstance                         // key: DistributionGroup name
 	nftManager  nftablesManager                                  // Shared nftables manager for all DGs
-	targets     map[string]map[int][]string                      // key: DistributionGroup name -> identifier -> IPs
+	targets     map[string]map[int]struct{}                      // key: DistributionGroup name -> active identifiers
 	flows       map[string]map[string]*meridio2v1alpha1.L34Route // key: DistributionGroup name -> L34Route name
 	currentVIPs []string                                         // Currently configured VIPs (to avoid redundant updates)
 }

--- a/internal/controller/loadbalancer/controller_test.go
+++ b/internal/controller/loadbalancer/controller_test.go
@@ -99,20 +99,9 @@ func (m *mockNFQLBInstance) AddTarget(_ context.Context, ips []string, identifie
 	return nil
 }
 
-func (m *mockNFQLBInstance) DeleteTarget(_ context.Context, _ []string, identifier int) error {
+func (m *mockNFQLBInstance) DeleteTarget(_ context.Context, identifier int) error {
 	delete(m.targets, identifier)
 	return nil
-}
-
-func (m *mockNFQLBInstance) BrokenTargets() map[int]struct{} {
-	return map[int]struct{}{}
-}
-
-func (m *mockNFQLBInstance) Targets() map[int][]string {
-	if m.targets == nil {
-		return map[int][]string{}
-	}
-	return m.targets
 }
 
 var _ = Describe("LoadBalancer Controller", func() {
@@ -616,9 +605,9 @@ var _ = Describe("LoadBalancer Controller", func() {
 
 		It("should deactivate removed targets with correct index", func() {
 			// Setup: activate a target first (identifier=0)
-			controller.targets = map[string]map[int][]string{
+			controller.targets = map[string]map[int]struct{}{
 				distGroup.Name: {
-					0: {"10.0.0.1"},
+					0: {},
 				},
 			}
 
@@ -1423,13 +1412,13 @@ var _ = Describe("LoadBalancer Controller", func() {
 				controller.flows = make(map[string]map[string]*meridio2v1alpha1.L34Route)
 			}
 			if controller.targets == nil {
-				controller.targets = make(map[string]map[int][]string)
+				controller.targets = make(map[string]map[int]struct{})
 			}
 
 			controller.instances[distGroup.Name] = mockInstance
 			controller.nftManager = mockNftMgr // Use shared manager
 			controller.flows[distGroup.Name] = make(map[string]*meridio2v1alpha1.L34Route)
-			controller.targets[distGroup.Name] = make(map[int][]string)
+			controller.targets[distGroup.Name] = make(map[int]struct{})
 
 			// Simulate DistributionGroup deletion by returning NotFound
 			fakeClient = fake.NewClientBuilder().

--- a/internal/controller/loadbalancer/controller_test.go
+++ b/internal/controller/loadbalancer/controller_test.go
@@ -104,6 +104,17 @@ func (m *mockNFQLBInstance) DeleteTarget(_ context.Context, _ []string, identifi
 	return nil
 }
 
+func (m *mockNFQLBInstance) BrokenTargets() map[int]struct{} {
+	return map[int]struct{}{}
+}
+
+func (m *mockNFQLBInstance) Targets() map[int][]string {
+	if m.targets == nil {
+		return map[int][]string{}
+	}
+	return m.targets
+}
+
 var _ = Describe("LoadBalancer Controller", func() {
 	var (
 		scheme      *runtime.Scheme

--- a/internal/controller/loadbalancer/instance.go
+++ b/internal/controller/loadbalancer/instance.go
@@ -35,7 +35,7 @@ func (c *Controller) reconcileNFQLBInstance(ctx context.Context, distGroup *meri
 		c.instances = make(map[string]nfqlbInstance)
 	}
 	if c.targets == nil {
-		c.targets = make(map[string]map[int][]string)
+		c.targets = make(map[string]map[int]struct{})
 	}
 
 	// Check if service already exists
@@ -58,7 +58,7 @@ func (c *Controller) reconcileNFQLBInstance(ctx context.Context, distGroup *meri
 	}
 
 	c.instances[distGroup.Name] = service
-	c.targets[distGroup.Name] = make(map[int][]string)
+	c.targets[distGroup.Name] = make(map[int]struct{})
 
 	logr.Info("Created NFQLB service", "distGroup", distGroup.Name, "maxTargets", n)
 

--- a/internal/controller/loadbalancer/nfqlb_iface.go
+++ b/internal/controller/loadbalancer/nfqlb_iface.go
@@ -34,6 +34,8 @@ type nfqlbInstance interface {
 	DeleteFlow(ctx context.Context, flow nfqlb.Flow) error
 	AddTarget(ctx context.Context, ips []string, identifier int) error
 	DeleteTarget(ctx context.Context, ips []string, identifier int) error
+	BrokenTargets() map[int]struct{}
+	Targets() map[int][]string
 }
 
 // NFQLBManagerAdapter wraps *nfqlb.NFQueueLoadBalancer to implement nfqlbManager.

--- a/internal/controller/loadbalancer/nfqlb_iface.go
+++ b/internal/controller/loadbalancer/nfqlb_iface.go
@@ -33,9 +33,7 @@ type nfqlbInstance interface {
 	AddFlow(ctx context.Context, flow nfqlb.Flow) error
 	DeleteFlow(ctx context.Context, flow nfqlb.Flow) error
 	AddTarget(ctx context.Context, ips []string, identifier int) error
-	DeleteTarget(ctx context.Context, ips []string, identifier int) error
-	BrokenTargets() map[int]struct{}
-	Targets() map[int][]string
+	DeleteTarget(ctx context.Context, identifier int) error
 }
 
 // NFQLBManagerAdapter wraps *nfqlb.NFQueueLoadBalancer to implement nfqlbManager.

--- a/internal/controller/loadbalancer/targets.go
+++ b/internal/controller/loadbalancer/targets.go
@@ -20,7 +20,6 @@ import (
 	"cmp"
 	"context"
 	"errors"
-	"maps"
 	"slices"
 	"strconv"
 
@@ -64,7 +63,7 @@ func (c *Controller) reconcileTargets(ctx context.Context, distGroup *meridio2v1
 	// Get current targets
 	currentTargets := c.targets[distGroup.Name]
 	if currentTargets == nil {
-		currentTargets = make(map[int][]string)
+		currentTargets = make(map[int]struct{})
 		c.targets[distGroup.Name] = currentTargets
 	}
 
@@ -98,13 +97,13 @@ func (c *Controller) reconcileTargets(ctx context.Context, distGroup *meridio2v1
 
 	// Deactivate removed targets (nfqlb handles policy route cleanup internally)
 	var errFinal error
-	failedDeletes := make(map[int][]string)
-	for identifier, ips := range currentTargets {
+	failedDeletes := make(map[int]struct{})
+	for identifier := range currentTargets {
 		if _, exists := newTargets[identifier]; !exists {
-			if err := service.DeleteTarget(ctx, ips, identifier); err != nil {
+			if err := service.DeleteTarget(ctx, identifier); err != nil {
 				logr.Error(err, "Failed to deactivate target", "identifier", identifier)
 				errFinal = errors.Join(errFinal, err)
-				failedDeletes[identifier] = ips
+				failedDeletes[identifier] = struct{}{}
 			} else {
 				logr.Info("Deactivated target", "distGroup", distGroup.Name, "identifier", identifier)
 			}
@@ -139,19 +138,21 @@ func (c *Controller) reconcileTargets(ctx context.Context, distGroup *meridio2v1
 		}
 	}
 
+	// Commit c.targets: identifiers from newTargets ∪ failed-delete IDs.
+	// This ensures next reconcile retries DeleteTarget for failed deletions
+	// and retries AddTarget for failed additions (idempotent).
+	committed := make(map[int]struct{}, len(newTargets)+len(failedDeletes))
+	for id := range newTargets {
+		committed[id] = struct{}{}
+	}
+	for id := range failedDeletes {
+		committed[id] = struct{}{}
+	}
+	c.targets[distGroup.Name] = committed
+
 	if errFinal != nil {
-		// Commit c.targets = newTargets ∪ failed-delete IDs.
-		// This ensures next reconcile retries DeleteTarget for failed deletions
-		// and retries AddTarget for failed additions (idempotent).
-		committed := make(map[int][]string, len(newTargets)+len(failedDeletes))
-		maps.Copy(committed, newTargets)
-		maps.Copy(committed, failedDeletes)
-		c.targets[distGroup.Name] = committed
 		return errFinal
 	}
-
-	// Update tracked targets on full success
-	c.targets[distGroup.Name] = newTargets
 
 	logr.Info("Reconciled targets", "distGroup", distGroup.Name, "count", len(newTargets))
 	return nil

--- a/internal/controller/loadbalancer/targets.go
+++ b/internal/controller/loadbalancer/targets.go
@@ -20,6 +20,7 @@ import (
 	"cmp"
 	"context"
 	"errors"
+	"maps"
 	"slices"
 	"strconv"
 
@@ -97,18 +98,37 @@ func (c *Controller) reconcileTargets(ctx context.Context, distGroup *meridio2v1
 
 	// Deactivate removed targets (nfqlb handles policy route cleanup internally)
 	var errFinal error
+	failedDeletes := make(map[int][]string)
 	for identifier, ips := range currentTargets {
 		if _, exists := newTargets[identifier]; !exists {
 			if err := service.DeleteTarget(ctx, ips, identifier); err != nil {
 				logr.Error(err, "Failed to deactivate target", "identifier", identifier)
 				errFinal = errors.Join(errFinal, err)
+				failedDeletes[identifier] = ips
 			} else {
 				logr.Info("Deactivated target", "distGroup", distGroup.Name, "identifier", identifier)
 			}
 		}
 	}
 
-	// Activate new/updated targets (nfqlb handles policy route creation internally)
+	// Clean up broken targets that are no longer desired.
+	for id := range service.BrokenTargets() {
+		if _, wanted := newTargets[id]; !wanted {
+			if _, alreadyHandled := failedDeletes[id]; alreadyHandled {
+				continue
+			}
+			logr.Info("Cleaning up broken target", "distGroup", distGroup.Name, "identifier", id)
+			if ips, inState := service.Targets()[id]; inState {
+				if err := service.DeleteTarget(ctx, ips, id); err != nil {
+					errFinal = errors.Join(errFinal, err)
+					failedDeletes[id] = ips
+				}
+			}
+		}
+	}
+
+	// Activate all desired targets unconditionally — nfqlb layer handles idempotency
+	// and drift recovery internally.
 	for identifier, ips := range newTargets {
 		// Sort IPs for deterministic comparison in AddTarget (avoids false
 		// "IPs changed" triggers when IPv4/IPv6 slices are processed in different order)
@@ -135,12 +155,17 @@ func (c *Controller) reconcileTargets(ctx context.Context, distGroup *meridio2v1
 	}
 
 	if errFinal != nil {
-		// Don't commit c.targets — on requeue the diff against stale currentTargets
-		// will retry failed deletions. Successful adds are idempotent on retry.
+		// Commit c.targets = newTargets ∪ failed-delete IDs.
+		// This ensures next reconcile retries DeleteTarget for failed deletions
+		// and retries AddTarget for failed additions (idempotent).
+		committed := make(map[int][]string, len(newTargets)+len(failedDeletes))
+		maps.Copy(committed, newTargets)
+		maps.Copy(committed, failedDeletes)
+		c.targets[distGroup.Name] = committed
 		return errFinal
 	}
 
-	// Update tracked targets only on full success
+	// Update tracked targets on full success
 	c.targets[distGroup.Name] = newTargets
 
 	logr.Info("Reconciled targets", "distGroup", distGroup.Name, "count", len(newTargets))

--- a/internal/controller/loadbalancer/targets.go
+++ b/internal/controller/loadbalancer/targets.go
@@ -111,24 +111,9 @@ func (c *Controller) reconcileTargets(ctx context.Context, distGroup *meridio2v1
 		}
 	}
 
-	// Clean up broken targets that are no longer desired.
-	for id := range service.BrokenTargets() {
-		if _, wanted := newTargets[id]; !wanted {
-			if _, alreadyHandled := failedDeletes[id]; alreadyHandled {
-				continue
-			}
-			logr.Info("Cleaning up broken target", "distGroup", distGroup.Name, "identifier", id)
-			if ips, inState := service.Targets()[id]; inState {
-				if err := service.DeleteTarget(ctx, ips, id); err != nil {
-					errFinal = errors.Join(errFinal, err)
-					failedDeletes[id] = ips
-				}
-			}
-		}
-	}
-
 	// Activate all desired targets unconditionally — nfqlb layer handles idempotency
 	// and drift recovery internally.
+	var anyTargetReady bool
 	for identifier, ips := range newTargets {
 		// Sort IPs for deterministic comparison in AddTarget (avoids false
 		// "IPs changed" triggers when IPv4/IPv6 slices are processed in different order)
@@ -137,14 +122,14 @@ func (c *Controller) reconcileTargets(ctx context.Context, distGroup *meridio2v1
 			logr.Error(err, "Failed to activate target", "identifier", identifier, "ips", ips)
 			errFinal = errors.Join(errFinal, err)
 		} else {
+			anyTargetReady = true
 			logr.Info("Activated target", "distGroup", distGroup.Name, "identifier", identifier, "ips", ips)
 		}
 	}
 
-	// Manage readiness file based on desired endpoint count (before error check,
-	// so VIP advertisement reflects actual target availability regardless of
-	// partial deletion failures)
-	if len(newTargets) > 0 {
+	// Manage readiness file: advertise VIPs only when at least one target is
+	// successfully activated (avoids blackhole when all AddTarget calls fail).
+	if anyTargetReady {
 		if err := c.Readiness.Set(distGroup.Name); err != nil {
 			logr.Error(err, "Failed to create readiness file", "distGroup", distGroup.Name)
 		}

--- a/internal/controller/loadbalancer/targets.go
+++ b/internal/controller/loadbalancer/targets.go
@@ -121,10 +121,9 @@ func (c *Controller) reconcileTargets(ctx context.Context, distGroup *meridio2v1
 		}
 	}
 
-	// Update tracked targets
-	c.targets[distGroup.Name] = newTargets
-
-	// Manage readiness file based on endpoint count
+	// Manage readiness file based on desired endpoint count (before error check,
+	// so VIP advertisement reflects actual target availability regardless of
+	// partial deletion failures)
 	if len(newTargets) > 0 {
 		if err := c.Readiness.Set(distGroup.Name); err != nil {
 			logr.Error(err, "Failed to create readiness file", "distGroup", distGroup.Name)
@@ -135,6 +134,15 @@ func (c *Controller) reconcileTargets(ctx context.Context, distGroup *meridio2v1
 		}
 	}
 
+	if errFinal != nil {
+		// Don't commit c.targets — on requeue the diff against stale currentTargets
+		// will retry failed deletions. Successful adds are idempotent on retry.
+		return errFinal
+	}
+
+	// Update tracked targets only on full success
+	c.targets[distGroup.Name] = newTargets
+
 	logr.Info("Reconciled targets", "distGroup", distGroup.Name, "count", len(newTargets))
-	return errFinal
+	return nil
 }

--- a/internal/nfqlb/nfqlb.go
+++ b/internal/nfqlb/nfqlb.go
@@ -223,7 +223,7 @@ type Instance struct {
 	*nfqlbInstanceConfig
 	name                              string
 	targets                           map[int][]string // Key: identifier ; Value: IPs
-	broken                            map[int]struct{} // identifiers activated but with incomplete routes
+	broken                            map[int]struct{} // identifiers in inconsistent state (partial route or activate failure)
 	offset                            int
 	mu                                sync.Mutex
 	updateNfQueueDestinationCIDRsFunc func(ctx context.Context) error
@@ -477,8 +477,9 @@ func (s *Instance) AddTarget(ctx context.Context, ips []string, identifier int) 
 	existingIPs, exists := s.targets[identifier]
 	if exists {
 		if slicesEqual(existingIPs, ips) {
-			// IPs unchanged — re-apply routes to recover from potential kernel drift.
-			// RouteReplace and ensureRule are idempotent — no traffic disruption.
+			// IPs unchanged — re-apply routes and re-activate to recover from
+			// potential kernel drift or a previously broken state.
+			// RouteReplace, ensureRule, and activate are all idempotent.
 			fwmark := identifier + s.offset
 			var errFinal error
 			for _, ip := range ips {
@@ -488,10 +489,19 @@ func (s *Instance) AddTarget(ctx context.Context, ips []string, identifier int) 
 			}
 			if errFinal != nil {
 				s.broken[identifier] = struct{}{}
-			} else {
-				delete(s.broken, identifier)
+				return errFinal
 			}
-			return errFinal
+			output, err := s.doExec(ctx, "activate",
+				fmt.Sprintf("--index=%d", identifier),
+				fmt.Sprintf("--shm=%s", s.name),
+				strconv.Itoa(identifier+s.offset),
+			)
+			if err != nil {
+				s.broken[identifier] = struct{}{}
+				return fmt.Errorf("failed activating nfqlb target ; %w; %s", err, output)
+			}
+			delete(s.broken, identifier)
+			return nil
 		}
 		// IPs changed — clean old neighbors, delete old routes, apply new ones
 		ctrl.LoggerFrom(ctx).Info("nfqlb: target IPs changed, updating routes",
@@ -516,15 +526,25 @@ func (s *Instance) AddTarget(ctx context.Context, ips []string, identifier int) 
 		}
 		if errFinal != nil {
 			s.broken[identifier] = struct{}{}
-		} else {
-			delete(s.broken, identifier)
+			return errFinal
 		}
-		return errFinal
+		output, err := s.doExec(ctx, "activate",
+			fmt.Sprintf("--index=%d", identifier),
+			fmt.Sprintf("--shm=%s", s.name),
+			strconv.Itoa(identifier+s.offset),
+		)
+		if err != nil {
+			s.broken[identifier] = struct{}{}
+			return fmt.Errorf("failed activating nfqlb target ; %w; %s", err, output)
+		}
+		delete(s.broken, identifier)
+		return nil
 	}
 
 	ctrl.LoggerFrom(ctx).Info("nfqlb: add target", "instance", s.name, "ips", ips, "identifier", identifier)
 
 	fwmark := identifier + s.offset
+	s.targets[identifier] = ips
 
 	// Create policy routes first — if this fails, no nfqlb slot is activated.
 	var errFinal error
@@ -534,7 +554,6 @@ func (s *Instance) AddTarget(ctx context.Context, ips []string, identifier int) 
 		}
 	}
 	if errFinal != nil {
-		s.targets[identifier] = ips
 		s.broken[identifier] = struct{}{}
 		return errFinal
 	}
@@ -545,12 +564,10 @@ func (s *Instance) AddTarget(ctx context.Context, ips []string, identifier int) 
 		strconv.Itoa(identifier+s.offset),
 	)
 	if err != nil {
-		s.targets[identifier] = ips
 		s.broken[identifier] = struct{}{}
 		return fmt.Errorf("failed activating nfqlb target ; %w; %s", err, output)
 	}
 
-	s.targets[identifier] = ips
 	delete(s.broken, identifier)
 	ctrl.LoggerFrom(ctx).Info("nfqlb: target added", "instance", s.name, "ips", ips, "identifier", identifier)
 

--- a/internal/nfqlb/nfqlb.go
+++ b/internal/nfqlb/nfqlb.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"net"
 	"os/exec"
 	"strconv"
@@ -222,6 +223,7 @@ type Instance struct {
 	*nfqlbInstanceConfig
 	name                              string
 	targets                           map[int][]string // Key: identifier ; Value: IPs
+	broken                            map[int]struct{} // identifiers activated but with incomplete routes
 	offset                            int
 	mu                                sync.Mutex
 	updateNfQueueDestinationCIDRsFunc func(ctx context.Context) error
@@ -271,6 +273,7 @@ func (nfqlb *NFQueueLoadBalancer) AddInstance(ctx context.Context,
 		name:                              name,
 		nfqlbInstanceConfig:               config,
 		targets:                           map[int][]string{},
+		broken:                            map[int]struct{}{},
 		updateNfQueueDestinationCIDRsFunc: nfqlb.updateNfQueueDestinationCIDRs,
 		offset:                            offset,
 		nfqlbPath:                         nfqlb.nfqlbPath,
@@ -483,6 +486,11 @@ func (s *Instance) AddTarget(ctx context.Context, ips []string, identifier int) 
 					errFinal = errors.Join(errFinal, err)
 				}
 			}
+			if errFinal != nil {
+				s.broken[identifier] = struct{}{}
+			} else {
+				delete(s.broken, identifier)
+			}
 			return errFinal
 		}
 		// IPs changed — clean old neighbors, delete old routes, apply new ones
@@ -506,10 +514,30 @@ func (s *Instance) AddTarget(ctx context.Context, ips []string, identifier int) 
 				errFinal = errors.Join(errFinal, err)
 			}
 		}
+		if errFinal != nil {
+			s.broken[identifier] = struct{}{}
+		} else {
+			delete(s.broken, identifier)
+		}
 		return errFinal
 	}
 
 	ctrl.LoggerFrom(ctx).Info("nfqlb: add target", "instance", s.name, "ips", ips, "identifier", identifier)
+
+	fwmark := identifier + s.offset
+
+	// Create policy routes first — if this fails, no nfqlb slot is activated.
+	var errFinal error
+	for _, ip := range ips {
+		if err := s.doCreatePolicyRoute(fwmark, ip); err != nil {
+			errFinal = errors.Join(errFinal, err)
+		}
+	}
+	if errFinal != nil {
+		s.targets[identifier] = ips
+		s.broken[identifier] = struct{}{}
+		return errFinal
+	}
 
 	output, err := s.doExec(ctx, "activate",
 		fmt.Sprintf("--index=%d", identifier),
@@ -517,23 +545,16 @@ func (s *Instance) AddTarget(ctx context.Context, ips []string, identifier int) 
 		strconv.Itoa(identifier+s.offset),
 	)
 	if err != nil {
+		s.targets[identifier] = ips
+		s.broken[identifier] = struct{}{}
 		return fmt.Errorf("failed activating nfqlb target ; %w; %s", err, output)
 	}
 
 	s.targets[identifier] = ips
-
-	fwmark := identifier + s.offset
-
-	var errFinal error
-	for _, ip := range ips {
-		if err := s.doCreatePolicyRoute(fwmark, ip); err != nil {
-			errFinal = errors.Join(errFinal, err)
-		}
-	}
-
+	delete(s.broken, identifier)
 	ctrl.LoggerFrom(ctx).Info("nfqlb: target added", "instance", s.name, "ips", ips, "identifier", identifier)
 
-	return errFinal
+	return nil
 }
 
 // doCreatePolicyRoute uses the injected function or falls back to the package-level one.
@@ -574,8 +595,29 @@ func slicesEqual(a, b []string) bool {
 	return true
 }
 
-// DeleteTarget deletes a target identifier to the nfqlb instance
-// and deletes the policy route associated.
+// BrokenTargets returns identifiers that were activated but have incomplete routes.
+// The caller should call DeleteTarget for any broken identifier no longer in the desired set.
+func (s *Instance) BrokenTargets() map[int]struct{} {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	result := make(map[int]struct{}, len(s.broken))
+	for id := range s.broken {
+		result[id] = struct{}{}
+	}
+	return result
+}
+
+// Targets returns a copy of the current targets map.
+func (s *Instance) Targets() map[int][]string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	result := make(map[int][]string, len(s.targets))
+	maps.Copy(result, s.targets)
+	return result
+}
+
+// DeleteTarget deactivates a target identifier in the nfqlb instance
+// and deletes the associated policy routes.
 func (s *Instance) DeleteTarget(ctx context.Context, ips []string, identifier int) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -596,17 +638,24 @@ func (s *Instance) deleteTargetNoLock(ctx context.Context, ips []string, identif
 		fmt.Sprintf("--shm=%s", s.name),
 	)
 	if err != nil {
+		s.broken[identifier] = struct{}{}
 		return fmt.Errorf("failed deactivating nfqlb target ; %w; %s", err, output)
 	}
 
-	// Remove from map only after successful deactivation.
-	// If deactivation fails, the identifier stays in s.targets so the next
-	// reconcile will retry DeleteTarget.
-	delete(s.targets, identifier)
-
+	var errFinal error
 	for _, ip := range ips {
-		_ = s.doDeletePolicyRoute(identifier+s.offset, ip)
+		if err := s.doDeletePolicyRoute(identifier+s.offset, ip); err != nil {
+			errFinal = errors.Join(errFinal, err)
+		}
 	}
+	if errFinal != nil {
+		s.broken[identifier] = struct{}{}
+		return errFinal
+	}
+
+	// Remove from maps only after all operations succeed.
+	delete(s.targets, identifier)
+	delete(s.broken, identifier)
 
 	ctrl.LoggerFrom(ctx).Info("nfqlb: target deleted", "instance", s.name, "ips", ips, "identifier", identifier)
 

--- a/internal/nfqlb/nfqlb.go
+++ b/internal/nfqlb/nfqlb.go
@@ -453,10 +453,6 @@ func (s *Instance) DeleteFlow(ctx context.Context, flowToDelete Flow) error {
 	return nil
 }
 
-// AddTarget adds a target identifier to the nfqlb instance
-// and configures the policy route associated.
-// If the identifier already exists with the same IPs, this is a no-op.
-// If the identifier exists with different IPs, policy routes are updated
 // AddTarget creates policy routes and activates the nfqlb slot for the given identifier.
 // If the target already exists with the same IPs and is not broken, only routes are re-applied
 // (drift recovery) without re-activating in nfqlb (the fwmark is unchanged).

--- a/internal/nfqlb/nfqlb.go
+++ b/internal/nfqlb/nfqlb.go
@@ -591,8 +591,6 @@ func (s *Instance) deleteTargetNoLock(ctx context.Context, ips []string, identif
 
 	ctrl.LoggerFrom(ctx).Info("nfqlb: delete target", "instance", s.name, "ips", ips, "identifier", identifier)
 
-	delete(s.targets, identifier)
-
 	output, err := s.doExec(ctx, "deactivate",
 		fmt.Sprintf("--index=%d", identifier),
 		fmt.Sprintf("--shm=%s", s.name),
@@ -600,6 +598,11 @@ func (s *Instance) deleteTargetNoLock(ctx context.Context, ips []string, identif
 	if err != nil {
 		return fmt.Errorf("failed deactivating nfqlb target ; %w; %s", err, output)
 	}
+
+	// Remove from map only after successful deactivation.
+	// If deactivation fails, the identifier stays in s.targets so the next
+	// reconcile will retry DeleteTarget.
+	delete(s.targets, identifier)
 
 	for _, ip := range ips {
 		_ = s.doDeletePolicyRoute(identifier+s.offset, ip)

--- a/internal/nfqlb/nfqlb.go
+++ b/internal/nfqlb/nfqlb.go
@@ -22,9 +22,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"maps"
 	"net"
 	"os/exec"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -339,8 +339,8 @@ func (nfqlb *NFQueueLoadBalancer) DeleteInstance(ctx context.Context, name strin
 
 	var errs []error
 
-	for targetIdentifier, targetIPs := range nfqlbInstance.targets {
-		if err := nfqlbInstance.deleteTargetNoLock(ctx, targetIPs, targetIdentifier); err != nil {
+	for targetIdentifier := range nfqlbInstance.targets {
+		if err := nfqlbInstance.deleteTargetNoLock(ctx, targetIdentifier); err != nil {
 			errs = append(errs, fmt.Errorf("delete target %d: %w", targetIdentifier, err))
 		}
 	}
@@ -457,8 +457,10 @@ func (s *Instance) DeleteFlow(ctx context.Context, flowToDelete Flow) error {
 // and configures the policy route associated.
 // If the identifier already exists with the same IPs, this is a no-op.
 // If the identifier exists with different IPs, policy routes are updated
-// without re-activating in nfqlb (the fwmark is unchanged).
-func (s *Instance) AddTarget(ctx context.Context, ips []string, identifier int) error {
+// AddTarget creates policy routes and activates the nfqlb slot for the given identifier.
+// If the target already exists with the same IPs and is not broken, only routes are re-applied
+// (drift recovery) without re-activating in nfqlb (the fwmark is unchanged).
+func (s *Instance) AddTarget(ctx context.Context, ips []string, identifier int) (err error) {
 	if len(ips) == 0 {
 		return fmt.Errorf("target IPs must not be empty")
 	}
@@ -474,104 +476,63 @@ func (s *Instance) AddTarget(ctx context.Context, ips []string, identifier int) 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	existingIPs, exists := s.targets[identifier]
-	if exists {
-		if slicesEqual(existingIPs, ips) {
-			// IPs unchanged — re-apply routes and re-activate to recover from
-			// potential kernel drift or a previously broken state.
-			// RouteReplace, ensureRule, and activate are all idempotent.
-			fwmark := identifier + s.offset
-			var errFinal error
-			for _, ip := range ips {
-				if err := s.doCreatePolicyRoute(fwmark, ip); err != nil {
-					errFinal = errors.Join(errFinal, err)
-				}
-			}
-			if errFinal != nil {
-				s.broken[identifier] = struct{}{}
-				return errFinal
-			}
-			output, err := s.doExec(ctx, "activate",
-				fmt.Sprintf("--index=%d", identifier),
-				fmt.Sprintf("--shm=%s", s.name),
-				strconv.Itoa(identifier+s.offset),
-			)
-			if err != nil {
-				s.broken[identifier] = struct{}{}
-				return fmt.Errorf("failed activating nfqlb target ; %w; %s", err, output)
-			}
+	defer func() {
+		if err != nil {
+			s.broken[identifier] = struct{}{}
+		} else {
 			delete(s.broken, identifier)
-			return nil
 		}
-		// IPs changed — clean old neighbors, delete old routes, apply new ones
+	}()
+
+	existingIPs, exists := s.targets[identifier]
+	_, broken := s.broken[identifier]
+	skipActivate := exists && !broken
+
+	// Handle existing target: clean up stale state for changed IPs
+	if exists && !slicesEqual(existingIPs, ips) {
 		ctrl.LoggerFrom(ctx).Info("nfqlb: target IPs changed, updating routes",
 			"instance", s.name, "identifier", identifier, "oldIPs", existingIPs, "newIPs", ips)
 		fwmark := identifier + s.offset
 		for _, ip := range existingIPs {
-			if err := cleanNeighbor(net.ParseIP(ip)); err != nil {
-				ctrl.LoggerFrom(ctx).V(1).Info("failed to clean neighbor (may not exist)",
-					"ip", ip, "error", err)
-			}
-			if err := s.doDeletePolicyRoute(fwmark, ip); err != nil {
-				ctrl.LoggerFrom(ctx).V(1).Info("failed to delete old route (may not exist)",
-					"ip", ip, "error", err)
+			// IP change may imply Pod replacement (new MAC for all IPs)
+			_ = cleanNeighbor(net.ParseIP(ip))
+			if !slices.Contains(ips, ip) {
+				_ = s.doDeletePolicyRoute(fwmark, ip)
 			}
 		}
-		s.targets[identifier] = ips
-		var errFinal error
-		for _, ip := range ips {
-			if err := s.doCreatePolicyRoute(fwmark, ip); err != nil {
-				errFinal = errors.Join(errFinal, err)
-			}
-		}
-		if errFinal != nil {
-			s.broken[identifier] = struct{}{}
-			return errFinal
-		}
-		output, err := s.doExec(ctx, "activate",
-			fmt.Sprintf("--index=%d", identifier),
-			fmt.Sprintf("--shm=%s", s.name),
-			strconv.Itoa(identifier+s.offset),
-		)
-		if err != nil {
-			s.broken[identifier] = struct{}{}
-			return fmt.Errorf("failed activating nfqlb target ; %w; %s", err, output)
-		}
-		delete(s.broken, identifier)
-		return nil
+	} else if !exists {
+		ctrl.LoggerFrom(ctx).Info("nfqlb: add target", "instance", s.name, "ips", ips, "identifier", identifier)
 	}
 
-	ctrl.LoggerFrom(ctx).Info("nfqlb: add target", "instance", s.name, "ips", ips, "identifier", identifier)
-
-	fwmark := identifier + s.offset
+	// Update stored IPs and create routes
 	s.targets[identifier] = ips
+	fwmark := identifier + s.offset
 
-	// Create policy routes first — if this fails, no nfqlb slot is activated.
-	var errFinal error
 	for _, ip := range ips {
-		if err := s.doCreatePolicyRoute(fwmark, ip); err != nil {
-			errFinal = errors.Join(errFinal, err)
+		if e := s.doCreatePolicyRoute(fwmark, ip); e != nil {
+			err = errors.Join(err, e)
 		}
 	}
-	if errFinal != nil {
-		s.broken[identifier] = struct{}{}
-		return errFinal
+	if err != nil {
+		return err
 	}
 
-	output, err := s.doExec(ctx, "activate",
+	// Activate only for new targets or recovery from broken state
+	if skipActivate {
+		return err
+	}
+
+	var output []byte
+	output, err = s.doExec(ctx, "activate",
 		fmt.Sprintf("--index=%d", identifier),
 		fmt.Sprintf("--shm=%s", s.name),
 		strconv.Itoa(identifier+s.offset),
 	)
 	if err != nil {
-		s.broken[identifier] = struct{}{}
-		return fmt.Errorf("failed activating nfqlb target ; %w; %s", err, output)
+		err = fmt.Errorf("failed activating nfqlb target ; %w; %s", err, output)
 	}
 
-	delete(s.broken, identifier)
-	ctrl.LoggerFrom(ctx).Info("nfqlb: target added", "instance", s.name, "ips", ips, "identifier", identifier)
-
-	return nil
+	return err
 }
 
 // doCreatePolicyRoute uses the injected function or falls back to the package-level one.
@@ -612,69 +573,47 @@ func slicesEqual(a, b []string) bool {
 	return true
 }
 
-// BrokenTargets returns identifiers that were activated but have incomplete routes.
-// The caller should call DeleteTarget for any broken identifier no longer in the desired set.
-func (s *Instance) BrokenTargets() map[int]struct{} {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	result := make(map[int]struct{}, len(s.broken))
-	for id := range s.broken {
-		result[id] = struct{}{}
-	}
-	return result
-}
-
-// Targets returns a copy of the current targets map.
-func (s *Instance) Targets() map[int][]string {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	result := make(map[int][]string, len(s.targets))
-	maps.Copy(result, s.targets)
-	return result
-}
-
 // DeleteTarget deactivates a target identifier in the nfqlb instance
 // and deletes the associated policy routes.
-func (s *Instance) DeleteTarget(ctx context.Context, ips []string, identifier int) error {
+func (s *Instance) DeleteTarget(ctx context.Context, identifier int) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	return s.deleteTargetNoLock(ctx, ips, identifier)
+	return s.deleteTargetNoLock(ctx, identifier)
 }
 
-func (s *Instance) deleteTargetNoLock(ctx context.Context, ips []string, identifier int) error {
-	_, exists := s.targets[identifier]
+func (s *Instance) deleteTargetNoLock(ctx context.Context, identifier int) (err error) {
+	storedIPs, exists := s.targets[identifier]
 	if !exists {
 		return nil
 	}
 
-	ctrl.LoggerFrom(ctx).Info("nfqlb: delete target", "instance", s.name, "ips", ips, "identifier", identifier)
+	ctrl.LoggerFrom(ctx).Info("nfqlb: delete target", "instance", s.name, "ips", storedIPs, "identifier", identifier)
 
-	output, err := s.doExec(ctx, "deactivate",
+	defer func() {
+		if err != nil {
+			s.broken[identifier] = struct{}{}
+		} else {
+			delete(s.targets, identifier)
+			delete(s.broken, identifier)
+		}
+	}()
+
+	var output []byte
+	output, err = s.doExec(ctx, "deactivate",
 		fmt.Sprintf("--index=%d", identifier),
 		fmt.Sprintf("--shm=%s", s.name),
 	)
 	if err != nil {
-		s.broken[identifier] = struct{}{}
-		return fmt.Errorf("failed deactivating nfqlb target ; %w; %s", err, output)
+		err = fmt.Errorf("failed deactivating nfqlb target ; %w; %s", err, output)
+		return err
 	}
 
-	var errFinal error
-	for _, ip := range ips {
-		if err := s.doDeletePolicyRoute(identifier+s.offset, ip); err != nil {
-			errFinal = errors.Join(errFinal, err)
+	for _, ip := range storedIPs {
+		if e := s.doDeletePolicyRoute(identifier+s.offset, ip); e != nil {
+			err = errors.Join(err, e)
 		}
 	}
-	if errFinal != nil {
-		s.broken[identifier] = struct{}{}
-		return errFinal
-	}
 
-	// Remove from maps only after all operations succeed.
-	delete(s.targets, identifier)
-	delete(s.broken, identifier)
-
-	ctrl.LoggerFrom(ctx).Info("nfqlb: target deleted", "instance", s.name, "ips", ips, "identifier", identifier)
-
-	return nil
+	return err
 }

--- a/internal/nfqlb/target_test.go
+++ b/internal/nfqlb/target_test.go
@@ -104,8 +104,9 @@ var _ = Describe("Instance.AddTarget", func() {
 		err := instance.AddTarget(ctx, []string{"10.0.0.1"}, 0)
 		Expect(err).ToNot(HaveOccurred())
 
-		// No exec calls (no re-activation), but routes are re-applied for drift recovery
-		Expect(executor.calls).To(BeEmpty())
+		// Re-applies routes and re-activates (idempotent) to recover from broken state
+		Expect(executor.calls).To(HaveLen(1))
+		Expect(executor.calls[0]).To(ContainElements("activate", "--index=0", "--shm=test-instance", "5000"))
 		Expect(routing.created).To(ConsistOf(routeCall{5000, "10.0.0.1"}))
 		Expect(routing.deleted).To(BeEmpty())
 	})
@@ -116,8 +117,9 @@ var _ = Describe("Instance.AddTarget", func() {
 		err := instance.AddTarget(ctx, []string{"10.0.0.2"}, 0)
 		Expect(err).ToNot(HaveOccurred())
 
-		// Should NOT re-activate in nfqlb (fwmark unchanged)
-		Expect(executor.calls).To(BeEmpty())
+		// Re-activates (idempotent) to recover from potential broken state
+		Expect(executor.calls).To(HaveLen(1))
+		Expect(executor.calls[0]).To(ContainElements("activate", "--index=0", "--shm=test-instance", "5000"))
 		// Should delete old route and create new route
 		Expect(routing.deleted).To(ConsistOf(routeCall{5000, "10.0.0.1"}))
 		Expect(routing.created).To(ConsistOf(routeCall{5000, "10.0.0.2"}))
@@ -162,7 +164,8 @@ var _ = Describe("Instance.AddTarget", func() {
 		err := instance.AddTarget(ctx, []string{"192.168.100.10", "2001:db8:100::10"}, 0)
 		Expect(err).ToNot(HaveOccurred())
 
-		Expect(executor.calls).To(BeEmpty())
+		Expect(executor.calls).To(HaveLen(1))
+		Expect(executor.calls[0]).To(ContainElements("activate", "--index=0", "--shm=test-instance", "5000"))
 		Expect(routing.created).To(ConsistOf(
 			routeCall{5000, "192.168.100.10"},
 			routeCall{5000, "2001:db8:100::10"},

--- a/internal/nfqlb/target_test.go
+++ b/internal/nfqlb/target_test.go
@@ -49,11 +49,12 @@ func (m *mockRouting) delete(fwmark int, ip string) error {
 // mockExec records nfqlb CLI calls and returns success.
 type mockExec struct {
 	calls [][]string
+	err   error
 }
 
 func (m *mockExec) run(_ context.Context, args ...string) ([]byte, error) {
 	m.calls = append(m.calls, args)
-	return nil, nil
+	return nil, m.err
 }
 
 // newTestInstance creates an Instance with mock routing and exec for testing.
@@ -62,6 +63,7 @@ func newTestInstance(name string, offset, maxTargets int, routing *mockRouting, 
 		nfqlbInstanceConfig:               &nfqlbInstanceConfig{maxTargets: maxTargets},
 		name:                              name,
 		targets:                           map[int][]string{},
+		broken:                            map[int]struct{}{},
 		offset:                            offset,
 		nfqlbPath:                         "nfqlb",
 		updateNfQueueDestinationCIDRsFunc: func(_ context.Context) error { return nil },
@@ -240,5 +242,68 @@ var _ = Describe("Instance.AddTarget validation", func() {
 	It("should reject identifier >= maxTargets", func() {
 		err := instance.AddTarget(ctx, []string{"10.0.0.1"}, 32)
 		Expect(err).To(MatchError(ContainSubstring("out of range")))
+	})
+})
+
+var _ = Describe("Instance.BrokenTargets", func() {
+	var (
+		instance *Instance
+		routing  *mockRouting
+		executor *mockExec
+		ctx      context.Context
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		routing = &mockRouting{}
+		executor = &mockExec{}
+		instance = newTestInstance("test-instance", 5000, 32, routing, executor)
+	})
+
+	It("should mark target as broken when route creation fails", func() {
+		routing.createErr = fmt.Errorf("route failure")
+
+		err := instance.AddTarget(ctx, []string{"10.0.0.1"}, 0)
+		Expect(err).To(HaveOccurred())
+
+		Expect(instance.BrokenTargets()).To(HaveKey(0))
+		// Target is still tracked (activate succeeded)
+		Expect(instance.targets).To(HaveKey(0))
+	})
+
+	It("should clear broken state on successful AddTarget", func() {
+		// First call fails routes
+		routing.createErr = fmt.Errorf("route failure")
+		_ = instance.AddTarget(ctx, []string{"10.0.0.1"}, 0)
+		Expect(instance.BrokenTargets()).To(HaveKey(0))
+
+		// Retry succeeds
+		routing.createErr = nil
+		err := instance.AddTarget(ctx, []string{"10.0.0.1"}, 0)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(instance.BrokenTargets()).To(BeEmpty())
+	})
+
+	It("should clear broken state on DeleteTarget", func() {
+		routing.createErr = fmt.Errorf("route failure")
+		_ = instance.AddTarget(ctx, []string{"10.0.0.1"}, 0)
+		Expect(instance.BrokenTargets()).To(HaveKey(0))
+
+		routing.createErr = nil
+		err := instance.DeleteTarget(ctx, []string{"10.0.0.1"}, 0)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(instance.BrokenTargets()).To(BeEmpty())
+		Expect(instance.targets).ToNot(HaveKey(0))
+	})
+
+	It("should mark target as broken when activate fails (routes already created)", func() {
+		executor.err = fmt.Errorf("activate failure")
+
+		err := instance.AddTarget(ctx, []string{"10.0.0.1"}, 0)
+		Expect(err).To(HaveOccurred())
+
+		// Routes succeeded but activate failed — target in targets and broken
+		Expect(instance.BrokenTargets()).To(HaveKey(0))
+		Expect(instance.targets).To(HaveKey(0))
 	})
 })

--- a/internal/nfqlb/target_test.go
+++ b/internal/nfqlb/target_test.go
@@ -104,9 +104,8 @@ var _ = Describe("Instance.AddTarget", func() {
 		err := instance.AddTarget(ctx, []string{"10.0.0.1"}, 0)
 		Expect(err).ToNot(HaveOccurred())
 
-		// Re-applies routes and re-activates (idempotent) to recover from broken state
-		Expect(executor.calls).To(HaveLen(1))
-		Expect(executor.calls[0]).To(ContainElements("activate", "--index=0", "--shm=test-instance", "5000"))
+		// No activate call (target exists and not broken — skipActivate)
+		Expect(executor.calls).To(BeEmpty())
 		Expect(routing.created).To(ConsistOf(routeCall{5000, "10.0.0.1"}))
 		Expect(routing.deleted).To(BeEmpty())
 	})
@@ -117,10 +116,9 @@ var _ = Describe("Instance.AddTarget", func() {
 		err := instance.AddTarget(ctx, []string{"10.0.0.2"}, 0)
 		Expect(err).ToNot(HaveOccurred())
 
-		// Re-activates (idempotent) to recover from potential broken state
-		Expect(executor.calls).To(HaveLen(1))
-		Expect(executor.calls[0]).To(ContainElements("activate", "--index=0", "--shm=test-instance", "5000"))
-		// Should delete old route and create new route
+		// No activate call (target exists and not broken — skipActivate)
+		Expect(executor.calls).To(BeEmpty())
+		// Should delete only removed IPs and create new ones
 		Expect(routing.deleted).To(ConsistOf(routeCall{5000, "10.0.0.1"}))
 		Expect(routing.created).To(ConsistOf(routeCall{5000, "10.0.0.2"}))
 		// Should update tracked IPs
@@ -133,9 +131,8 @@ var _ = Describe("Instance.AddTarget", func() {
 		err := instance.AddTarget(ctx, []string{"10.0.0.1", "10.0.0.3"}, 1)
 		Expect(err).ToNot(HaveOccurred())
 
-		// Delete all old routes, create all new routes
+		// Only delete routes for removed IPs (10.0.0.2), create all new IPs
 		Expect(routing.deleted).To(ConsistOf(
-			routeCall{5001, "10.0.0.1"},
 			routeCall{5001, "10.0.0.2"},
 		))
 		Expect(routing.created).To(ConsistOf(
@@ -164,8 +161,8 @@ var _ = Describe("Instance.AddTarget", func() {
 		err := instance.AddTarget(ctx, []string{"192.168.100.10", "2001:db8:100::10"}, 0)
 		Expect(err).ToNot(HaveOccurred())
 
-		Expect(executor.calls).To(HaveLen(1))
-		Expect(executor.calls[0]).To(ContainElements("activate", "--index=0", "--shm=test-instance", "5000"))
+		// No activate call (exists and not broken)
+		Expect(executor.calls).To(BeEmpty())
 		Expect(routing.created).To(ConsistOf(
 			routeCall{5000, "192.168.100.10"},
 			routeCall{5000, "2001:db8:100::10"},
@@ -269,8 +266,8 @@ var _ = Describe("Instance.BrokenTargets", func() {
 		err := instance.AddTarget(ctx, []string{"10.0.0.1"}, 0)
 		Expect(err).To(HaveOccurred())
 
-		Expect(instance.BrokenTargets()).To(HaveKey(0))
-		// Target is still tracked (activate succeeded)
+		Expect(instance.broken).To(HaveKey(0))
+		// Target is still tracked
 		Expect(instance.targets).To(HaveKey(0))
 	})
 
@@ -278,24 +275,24 @@ var _ = Describe("Instance.BrokenTargets", func() {
 		// First call fails routes
 		routing.createErr = fmt.Errorf("route failure")
 		_ = instance.AddTarget(ctx, []string{"10.0.0.1"}, 0)
-		Expect(instance.BrokenTargets()).To(HaveKey(0))
+		Expect(instance.broken).To(HaveKey(0))
 
 		// Retry succeeds
 		routing.createErr = nil
 		err := instance.AddTarget(ctx, []string{"10.0.0.1"}, 0)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(instance.BrokenTargets()).To(BeEmpty())
+		Expect(instance.broken).To(BeEmpty())
 	})
 
 	It("should clear broken state on DeleteTarget", func() {
 		routing.createErr = fmt.Errorf("route failure")
 		_ = instance.AddTarget(ctx, []string{"10.0.0.1"}, 0)
-		Expect(instance.BrokenTargets()).To(HaveKey(0))
+		Expect(instance.broken).To(HaveKey(0))
 
 		routing.createErr = nil
-		err := instance.DeleteTarget(ctx, []string{"10.0.0.1"}, 0)
+		err := instance.DeleteTarget(ctx, 0)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(instance.BrokenTargets()).To(BeEmpty())
+		Expect(instance.broken).To(BeEmpty())
 		Expect(instance.targets).ToNot(HaveKey(0))
 	})
 
@@ -306,7 +303,7 @@ var _ = Describe("Instance.BrokenTargets", func() {
 		Expect(err).To(HaveOccurred())
 
 		// Routes succeeded but activate failed — target in targets and broken
-		Expect(instance.BrokenTargets()).To(HaveKey(0))
+		Expect(instance.broken).To(HaveKey(0))
 		Expect(instance.targets).To(HaveKey(0))
 	})
 })


### PR DESCRIPTION
Two changes to ensure failed deletions are retried:

1. nfqlb: move delete(s.targets, identifier) to after successful deactivation. If deactivation fails, identifier stays in s.targets so AddTarget detects it on retry.

2. LB controller: don't commit c.targets on error. On requeue, the diff against stale currentTargets will call DeleteTarget again for identifiers that failed. Successful adds are idempotent on retry.

Readiness file is updated before the error check so VIP advertisement reflects actual target availability regardless of deletion failures.

Fixes: gh-151