### PR TITLE
Remove CRD default for maxEndpoints, require explicit value (#118)

### DIFF
--- a/api/v1alpha1/distributiongroup_types.go
+++ b/api/v1alpha1/distributiongroup_types.go
@@ -25,7 +25,8 @@ type DistributionGroupType string
 const (
 	DistributionGroupTypeMaglev DistributionGroupType = "Maglev"
 	// DefaultMaglevMaxEndpoints is the default capacity for Maglev hash table
-	DefaultMaglevMaxEndpoints int32 = 32
+	// when MaglevConfig is omitted from the DistributionGroup spec.
+	DefaultMaglevMaxEndpoints int32 = 102
 )
 
 // ParentReference mirrors Gateway API's ParentReference
@@ -67,7 +68,6 @@ type MaglevConfig struct {
 	//
 	// To change capacity, create a new DistributionGroup with the desired MaxEndpoints.
 	//
-	// +kubebuilder:default=32
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="MaxEndpoints is immutable"
 	MaxEndpoints int32 `json:"maxEndpoints"`

--- a/config/crd/bases/meridio-2.nordix.org_distributiongroups.yaml
+++ b/config/crd/bases/meridio-2.nordix.org_distributiongroups.yaml
@@ -73,7 +73,6 @@ spec:
                   conditional defaults.
                 properties:
                   maxEndpoints:
-                    default: 32
                     description: |-
                       MaxEndpoints is the table capacity. This field is immutable after creation.
 

--- a/config/samples/meridio-2_v1alpha1_gatewayconfiguration.yaml
+++ b/config/samples/meridio-2_v1alpha1_gatewayconfiguration.yaml
@@ -36,11 +36,6 @@ spec:
             memory: "128Mi"
             cpu: "500m"
         enforceResources: true
-        resizePolicy:
-          - resourceName: cpu
-            restartPolicy: NotRequired
-          - resourceName: memory
-            restartPolicy: RestartContainer
       - name: router
         resources:
           requests:
@@ -50,8 +45,3 @@ spec:
             memory: "128Mi"
             cpu: "500m"
         enforceResources: true
-        resizePolicy:
-          - resourceName: cpu
-            restartPolicy: NotRequired
-          - resourceName: memory
-            restartPolicy: RestartContainer

--- a/docs/controllers/distributiongroup.md
+++ b/docs/controllers/distributiongroup.md
@@ -14,7 +14,7 @@ The DistributionGroup controller manages EndpointSlices for secondary network en
 - Subnet CIDR (e.g., `192.168.100.0/24`)
 - Attachment type (`NAD` for Multus, `DRA` for Dynamic Resource Allocation)
 
-**Maglev ID**: A stable integer (0-31 by default) assigned to each Pod for consistent hashing. Stored in EndpointSlice's `zone` field as `maglev:<id>`. Scoped per DistributionGroup and per Gateway — the same Pod gets the same ID across all networks (IPv4/IPv6) within a Gateway, but may have different IDs in different DGs.
+**Maglev ID**: A stable integer (0 to maxEndpoints-1) assigned to each Pod for consistent hashing. Stored in EndpointSlice's `zone` field as `maglev:<id>`. Scoped per DistributionGroup and per Gateway — the same Pod gets the same ID across all networks (IPv4/IPv6) within a Gateway, but may have different IDs in different DGs.
 
 **Why shared allocation across networks:** The LoadBalancer uses a single NFQLB hash table per DistributionGroup. This hash table maps identifiers to fwmarks, and fwmarks determine routing tables. If different networks assigned different IDs to the same Pod, the single hash table would have conflicting entries — one Pod's route would overwrite another's, causing non-deterministic routing and cross-Pod identifier collisions. Shared allocation ensures each identifier maps to exactly one Pod across all IP families, and the LB creates per-family routes under the same fwmark (IPv4 and IPv6 routing tables are independent in Linux). See [#70](https://github.com/Nordix/Meridio-2/issues/70) for full problem description and [#106](https://github.com/Nordix/Meridio-2/issues/106) for related cross-component contract considerations.
 

--- a/docs/operations/constraints-and-limitations.md
+++ b/docs/operations/constraints-and-limitations.md
@@ -98,9 +98,9 @@ The network sidecar allocates kernel routing table IDs from the range 50000–55
 
 ## DistributionGroup Controller
 
-**21. Default `maxEndpoints` per DistributionGroup is 32**
+**21. ~~Default `maxEndpoints` per DistributionGroup is 32~~ (Resolved)**
 
-When `DistributionGroup.spec.maglev.maxEndpoints` is not set, the controller defaults to 32 endpoints. This is the current MVP default and may be revised. The equivalent parameter in Meridio v1 (`MaxTargets`) defaulted to 100.
+The CRD-level default for `maxEndpoints` has been removed. When the `maglev` block is specified, `maxEndpoints` must be set explicitly — the API server rejects `maglev: {}` without it. When the entire `maglev` block is omitted (DG defaults to type Maglev), the controller applies the built-in default of 102 (defined by `DefaultMaglevMaxEndpoints` in the API package).
 
 **22. Node failure detection not implemented**
 

--- a/internal/controller/loadbalancer/instance.go
+++ b/internal/controller/loadbalancer/instance.go
@@ -24,8 +24,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-const defaultMaxEndpoints = 32
-
 // reconcileNFQLBInstance creates or retrieves the NFQLB service for a DistributionGroup.
 func (c *Controller) reconcileNFQLBInstance(ctx context.Context, distGroup *meridio2v1alpha1.DistributionGroup) error {
 	logr := log.FromContext(ctx)
@@ -46,7 +44,7 @@ func (c *Controller) reconcileNFQLBInstance(ctx context.Context, distGroup *meri
 	}
 
 	// Get maxEndpoints from spec
-	n := int32(defaultMaxEndpoints)
+	n := meridio2v1alpha1.DefaultMaglevMaxEndpoints
 	if distGroup.Spec.Maglev != nil && distGroup.Spec.Maglev.MaxEndpoints > 0 {
 		n = distGroup.Spec.Maglev.MaxEndpoints
 	}


### PR DESCRIPTION
#118

MaxEndpoints must now be explicitly set when the maglev block is specified. The API server rejects `maglev: {}` without it. When the entire maglev block is omitted, the controller applies the built-in default of 102 (DefaultMaglevMaxEndpoints).

Changes:
- Remove +kubebuilder:default=32 from MaxEndpoints field
- Change DefaultMaglevMaxEndpoints from 32 to 102
- Remove duplicate defaultMaxEndpoints const from LB controller,
  use API-level constant consistently
- Remove misleading resizePolicy from GatewayConfiguration sample
- Regenerate CRD manifests
- Update documentation
