### PR TITLE
E2e readiness gates verification

### DIFF
--- a/cmd/router/cmd/run.go
+++ b/cmd/router/cmd/run.go
@@ -222,7 +222,6 @@ func monitorConnectivity(
 	}
 
 	// Build family map from GatewayRouters (refreshed on each status update)
-	var familyMap map[string]string
 	var lastCount int
 	firstUpdate := true
 
@@ -253,16 +252,11 @@ func monitorConnectivity(
 
 			// Update readiness gates
 			if gateMgr != nil {
-				// Rebuild family map if nil or if protocols exist but map yields no matches
-				// (handles late GatewayRouter creation)
-				if familyMap == nil || (len(status.Protocols) > 0 && len(familyMap) == 0) {
-					routers, err := getGatewayRoutersFromCache(ctx, mgr.GetClient(), cfg.GatewayName, cfg.GatewayNamespace)
-					if err == nil && len(routers) > 0 {
-						familyMap = router.BuildFamilyMap(routers)
-					}
-				}
-				if familyMap != nil {
-					ipv4, ipv6 := router.ClassifyConnectivityByFamily(status.Protocols, familyMap)
+				// Rebuild family map on every tick — reads from informer cache (no API call)
+				// and BuildFamilyMap is a trivial loop. Handles GatewayRouter add/remove/replace.
+				routers, err := getGatewayRoutersFromCache(ctx, mgr.GetClient(), cfg.GatewayName, cfg.GatewayNamespace)
+				if err == nil && len(routers) > 0 {
+					ipv4, ipv6 := router.ClassifyConnectivityByFamily(status.Protocols, router.BuildFamilyMap(routers))
 					if err := gateMgr.OnStatusUpdate(ctx, ipv4, ipv6); err != nil {
 						log.Error(err, "failed to update readiness gates")
 					}

--- a/cmd/router/cmd/run.go
+++ b/cmd/router/cmd/run.go
@@ -25,10 +25,12 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
@@ -167,7 +169,7 @@ func runRouter(ctx context.Context, cfg *config.RouterConfig) error {
 	})
 
 	g.Go(func() error {
-		return monitorConnectivity(ctx, mgr, birdInstance)
+		return monitorConnectivity(ctx, mgr, birdInstance, cfg)
 	})
 
 	g.Go(func() error {
@@ -182,13 +184,35 @@ func runRouter(ctx context.Context, cfg *config.RouterConfig) error {
 	return nil
 }
 
-// monitorConnectivity monitors BGP connectivity and logs status changes
-func monitorConnectivity(ctx context.Context, mgr ctrl.Manager, birdInstance *bird.Bird) error {
+// monitorConnectivity monitors BGP connectivity and manages readiness gates
+func monitorConnectivity(
+	ctx context.Context, mgr ctrl.Manager, birdInstance *bird.Bird, cfg *config.RouterConfig,
+) error {
 	log := ctrl.Log.WithName("monitor")
 
 	// Wait for manager cache to sync
 	if !mgr.GetCache().WaitForCacheSync(ctx) {
 		return fmt.Errorf("failed to wait for cache sync")
+	}
+
+	// Initialize connectivity gate manager (if Pod identity is configured)
+	var gateMgr *router.ConnectivityGateManager
+	if cfg.PodName != "" && cfg.PodNamespace != "" {
+		gateMgr = router.NewConnectivityGateManager(
+			mgr.GetClient(), cfg.PodName, cfg.PodNamespace,
+			types.UID(cfg.PodUID), cfg.ConnectivityHoldTime,
+		)
+		if err := gateMgr.DiscoverGates(ctx); err != nil {
+			log.Error(err, "failed to discover readiness gates, continuing without gate management")
+			gateMgr = nil
+		} else if gateMgr.HasIPv4Gate() || gateMgr.HasIPv6Gate() {
+			log.Info("readiness gates discovered", "ipv4", gateMgr.HasIPv4Gate(), "ipv6", gateMgr.HasIPv6Gate())
+			if err := gateMgr.SetAllGatesFalse(ctx); err != nil {
+				log.Error(err, "failed to set gates to False on startup")
+			}
+		} else {
+			gateMgr = nil // No gates declared, skip gate management
+		}
 	}
 
 	// Start monitoring with 1 second interval
@@ -197,6 +221,8 @@ func monitorConnectivity(ctx context.Context, mgr ctrl.Manager, birdInstance *bi
 		return fmt.Errorf("failed to start monitoring: %w", err)
 	}
 
+	// Build family map from GatewayRouters (refreshed on each status update)
+	var familyMap map[string]string
 	var lastCount int
 	firstUpdate := true
 
@@ -221,12 +247,50 @@ func monitorConnectivity(ctx context.Context, mgr ctrl.Manager, birdInstance *bi
 				} else {
 					log.Info("Gateway connectivity lost", "status", status.StatusString())
 				}
-
 				lastCount = count
 				firstUpdate = false
 			}
+
+			// Update readiness gates
+			if gateMgr != nil {
+				// Rebuild family map if nil or if protocols exist but map yields no matches
+				// (handles late GatewayRouter creation)
+				if familyMap == nil || (len(status.Protocols) > 0 && len(familyMap) == 0) {
+					routers, err := getGatewayRoutersFromCache(ctx, mgr.GetClient(), cfg.GatewayName, cfg.GatewayNamespace)
+					if err == nil && len(routers) > 0 {
+						familyMap = router.BuildFamilyMap(routers)
+					}
+				}
+				if familyMap != nil {
+					ipv4, ipv6 := router.ClassifyConnectivityByFamily(status.Protocols, familyMap)
+					if err := gateMgr.OnStatusUpdate(ctx, ipv4, ipv6); err != nil {
+						log.Error(err, "failed to update readiness gates")
+					}
+				}
+			}
 		}
 	}
+}
+
+func getGatewayRoutersFromCache(
+	ctx context.Context, c client.Client, gatewayName, gatewayNamespace string,
+) ([]*meridio2v1alpha1.GatewayRouter, error) {
+	list := &meridio2v1alpha1.GatewayRouterList{}
+	if err := c.List(ctx, list, client.InNamespace(gatewayNamespace)); err != nil {
+		return nil, err
+	}
+	var result []*meridio2v1alpha1.GatewayRouter
+	for i := range list.Items {
+		ref := list.Items[i].Spec.GatewayRef
+		ns := list.Items[i].Namespace
+		if ref.Namespace != nil {
+			ns = string(*ref.Namespace)
+		}
+		if string(ref.Name) == gatewayName && ns == gatewayNamespace {
+			result = append(result, &list.Items[i])
+		}
+	}
+	return result, nil
 }
 
 func protocolsUp(protocols []bird.ProtocolStatus) int {

--- a/cmd/router/cmd/run.go
+++ b/cmd/router/cmd/run.go
@@ -255,8 +255,12 @@ func monitorConnectivity(
 				// Rebuild family map on every tick — reads from informer cache (no API call)
 				// and BuildFamilyMap is a trivial loop. Handles GatewayRouter add/remove/replace.
 				routers, err := getGatewayRoutersFromCache(ctx, mgr.GetClient(), cfg.GatewayName, cfg.GatewayNamespace)
-				if err == nil && len(routers) > 0 {
-					ipv4, ipv6 := router.ClassifyConnectivityByFamily(status.Protocols, router.BuildFamilyMap(routers))
+				if err == nil {
+					var ipv4, ipv6 bool
+					if len(routers) > 0 {
+						ipv4, ipv6 = router.ClassifyConnectivityByFamily(status.Protocols, router.BuildFamilyMap(routers))
+					}
+					// When no routers exist, ipv4/ipv6 stay false — gates set to False
 					if err := gateMgr.OnStatusUpdate(ctx, ipv4, ipv6); err != nil {
 						log.Error(err, "failed to update readiness gates")
 					}

--- a/config/rbac/lb-serviceaccount.yaml
+++ b/config/rbac/lb-serviceaccount.yaml
@@ -51,6 +51,21 @@ rules:
   - get
   - list
   - watch
+# Router controller patches its own Pod status (readiness gates)
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - pods/status
+  verbs:
+  - get
+  - update
+  - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/config/rbac/lb-serviceaccount.yaml
+++ b/config/rbac/lb-serviceaccount.yaml
@@ -58,6 +58,8 @@ rules:
   - pods
   verbs:
   - get
+  - list
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/docs/controllers/router.md
+++ b/docs/controllers/router.md
@@ -137,13 +137,22 @@ The router controller gates VIP advertisement on LB readiness. The collocated LB
 
 - **Startup readiness window**: `running` is set to `true` after `cmd.Start()` (fork), not after BIRD's control socket is ready. A reconcile during this window will attempt `birdc configure` and fail. Self-heals via controller-runtime requeue, but produces noisy error logs at startup.
 
-### Connectivity Signaling (post-MVP)
+### Connectivity Signaling via Readiness Gates
 
-The monitoring goroutine will evolve from log-only to a data source for the controller manager:
+The monitoring goroutine sets per-IP-family Pod readiness gate conditions based on BGP session state:
 
-- **Pod readiness gates**: Router sets per-IP-family readiness conditions (e.g., `ipv4-ready`, `ipv6-ready`) based on BGP session state
-- **Controller manager consumes**: Watches LB Pods, reads readiness gates, builds next-hop lists for `EndpointNetworkConfiguration` from only Pods with relevant gates set to `True`
-- **Why readiness gates, not CR status**: GatewayRouter is a shared cluster resource — N LB Pods reconcile the same CRs. Per-Pod connectivity state belongs on the Pod, not the CR.
+- **Gate condition types**:
+  - `meridio-2.nordix.org/ipv4-connectivity` — set if IPv4 subnets are configured
+  - `meridio-2.nordix.org/ipv6-connectivity` — set if IPv6 subnets are configured
+- **Gate lifecycle**:
+  1. Router starts → sets all declared gates to `False` (defense-in-depth)
+  2. BGP session established → after hold time (default 10s), sets gate to `True`
+  3. BGP session drops → sets gate to `False` immediately (no damping)
+- **Damping**: Up transitions are damped (configurable via `--connectivity-hold-time`) to avoid flapping. Down transitions are immediate for fast failure detection.
+- **Gate discovery**: Router reads its own Pod's `spec.readinessGates` to determine which gates to manage. Only manages declared gates.
+- **Per-IP-family independence**: IPv4 and IPv6 gates are managed independently with separate hold timers.
+- **Configuration**: Requires `POD_NAME`, `POD_NAMESPACE`, `POD_UID` environment variables (Downward API, injected by Gateway controller in LB Deployment template).
+- **RBAC**: Requires `pods/get` + `pods/status/update` (configured in `config/rbac/lb-serviceaccount.yaml`).
 
 ### Configuration Externalization (post-MVP)
 

--- a/docs/controllers/router.md
+++ b/docs/controllers/router.md
@@ -146,7 +146,7 @@ The monitoring goroutine sets per-IP-family Pod readiness gate conditions based 
   - `meridio-2.nordix.org/ipv6-connectivity` — set if IPv6 subnets are configured
 - **Gate lifecycle**:
   1. Router starts → sets all declared gates to `False` (defense-in-depth)
-  2. BGP session established → after hold time (default 10s), sets gate to `True`
+  2. BGP session established → after hold time (default 3s), sets gate to `True`
   3. BGP session drops → sets gate to `False` immediately (no damping)
 - **Damping**: Up transitions are damped (configurable via `--connectivity-hold-time`) to avoid flapping. Down transitions are immediate for fast failure detection.
 - **Gate discovery**: Router reads its own Pod's `spec.readinessGates` to determine which gates to manage. Only manages declared gates.

--- a/docs/operations/constraints-and-limitations.md
+++ b/docs/operations/constraints-and-limitations.md
@@ -54,9 +54,9 @@ The LB controller assigns fwmarks and routing table IDs dynamically per Distribu
 
 The router now gates VIP advertisement on LB readiness. The collocated LB controller writes `lb-ready-<distGroupName>` files to a shared directory when a DistributionGroup has ready targets. The router watches this directory via fsnotify and suppresses VIPs until at least one readiness file exists. Configurable via `--readiness-dir` / `MERIDIO_READINESS_DIR` (default: `/var/run/meridio`).
 
-**11. No connectivity-based readiness signaling to the controller-manager**
+**11. No connectivity-based readiness signaling to the controller-manager** *(partially resolved)*
 
-The router only logs BGP state changes — it does not set Pod readiness gates or signal the controller-manager about external connectivity status. As a result, the ENC controller cannot react to a running LB Pod losing external connectivity. The network sidecar's next-hop list will not be updated when an LB Pod's BGP sessions go down, meaning application Pods may continue routing return traffic through an LB that has lost external connectivity.
+The router now sets per-IP-family Pod readiness gates (`meridio-2.nordix.org/ipv4-connectivity`, `meridio-2.nordix.org/ipv6-connectivity`) based on BGP session state (PR #142). However, the ENC controller does not yet consume these gates to filter next-hop lists (gh-123). Until step 3 is implemented, application Pods may still route return traffic through an LB that has lost external connectivity.
 
 **12. BIRD error propagation missing**
 

--- a/internal/common/config/router.go
+++ b/internal/common/config/router.go
@@ -59,7 +59,7 @@ func (c *RouterConfig) AddFlags(fs *pflag.FlagSet) {
 		"Pod namespace (from Downward API)")
 	fs.StringVar(&c.PodUID, "pod-uid", "",
 		"Pod UID (from Downward API)")
-	fs.DurationVar(&c.ConnectivityHoldTime, "connectivity-hold-time", 10*time.Second,
+	fs.DurationVar(&c.ConnectivityHoldTime, "connectivity-hold-time", 3*time.Second,
 		"Hold time before setting connectivity gate to True after BGP session establishes")
 	fs.StringVar(&c.ProbeAddr, "health-probe-bind-address", ":8082",
 		"The address the probe endpoint binds to.")

--- a/internal/common/config/router.go
+++ b/internal/common/config/router.go
@@ -19,6 +19,7 @@ package config
 import (
 	"os"
 	"strings"
+	"time"
 
 	"github.com/nordix/meridio-2/internal/bird"
 	"github.com/nordix/meridio-2/internal/common/readiness"
@@ -27,19 +28,23 @@ import (
 
 // RouterConfig holds configuration for the router
 type RouterConfig struct {
-	GatewayName        string
-	GatewayNamespace   string
-	ProbeAddr          string
-	LogLevel           string
-	MetricsAddr        string
-	SecureMetrics      bool
-	MetricsCertPath    string
-	MetricsCertName    string
-	MetricsCertKey     string
-	EnableHTTP2        bool
-	BirdLogs           bird.BirdLogParams
-	BirdKernelScanTime int
-	LBReadinessDir     string
+	GatewayName          string
+	GatewayNamespace     string
+	PodName              string
+	PodNamespace         string
+	PodUID               string
+	ConnectivityHoldTime time.Duration
+	ProbeAddr            string
+	LogLevel             string
+	MetricsAddr          string
+	SecureMetrics        bool
+	MetricsCertPath      string
+	MetricsCertName      string
+	MetricsCertKey       string
+	EnableHTTP2          bool
+	BirdLogs             bird.BirdLogParams
+	BirdKernelScanTime   int
+	LBReadinessDir       string
 }
 
 // AddFlags adds configuration flags to the provided FlagSet
@@ -48,6 +53,14 @@ func (c *RouterConfig) AddFlags(fs *pflag.FlagSet) {
 		"Name of the Gateway resource to watch (required)")
 	fs.StringVar(&c.GatewayNamespace, "gateway-namespace", "default",
 		"Namespace of the Gateway resource")
+	fs.StringVar(&c.PodName, "pod-name", "",
+		"Pod name (from Downward API)")
+	fs.StringVar(&c.PodNamespace, "pod-namespace", "",
+		"Pod namespace (from Downward API)")
+	fs.StringVar(&c.PodUID, "pod-uid", "",
+		"Pod UID (from Downward API)")
+	fs.DurationVar(&c.ConnectivityHoldTime, "connectivity-hold-time", 10*time.Second,
+		"Hold time before setting connectivity gate to True after BGP session establishes")
 	fs.StringVar(&c.ProbeAddr, "health-probe-bind-address", ":8082",
 		"The address the probe endpoint binds to.")
 	fs.StringVar(&c.LogLevel, "log-level", "info",
@@ -96,6 +109,10 @@ func (c *RouterConfig) AddFlags(fs *pflag.FlagSet) {
 func (c *RouterConfig) BindEnv(fs *pflag.FlagSet) {
 	bindString(fs, "gateway-name", "MERIDIO_GATEWAY_NAME", &c.GatewayName)
 	bindString(fs, "gateway-namespace", "MERIDIO_GATEWAY_NAMESPACE", &c.GatewayNamespace)
+	bindString(fs, "pod-name", "POD_NAME", &c.PodName)
+	bindString(fs, "pod-namespace", "POD_NAMESPACE", &c.PodNamespace)
+	bindString(fs, "pod-uid", "POD_UID", &c.PodUID)
+	bindDuration(fs, "connectivity-hold-time", "MERIDIO_CONNECTIVITY_HOLD_TIME", &c.ConnectivityHoldTime)
 	bindString(fs, "health-probe-bind-address", "MERIDIO_PROBE_ADDR", &c.ProbeAddr)
 	bindString(fs, "log-level", "MERIDIO_LOG_LEVEL", &c.LogLevel)
 	bindString(fs, "metrics-bind-address", "MERIDIO_METRICS_ADDR", &c.MetricsAddr)

--- a/internal/controller/endpointnetworkconfiguration/resolve.go
+++ b/internal/controller/endpointnetworkconfiguration/resolve.go
@@ -472,3 +472,43 @@ func scrapeInterfaceForSubnet(pod *corev1.Pod, cidr string) string {
 	}
 	return ""
 }
+
+// isLBPodReady(pod) bool - checks all non-init container statuses are Ready. Returns false if any container is not ready or if Pod is being deleted.
+func isLBPodReady(pod *corev1.Pod) bool {
+	if pod.DeletionTimestamp != nil {
+		return false
+	}
+	oneReady := false
+	for _, cs := range pod.Status.ContainerStatuses {
+		if !cs.Ready {
+			return false
+		} else { // At least one container is ready
+			oneReady = true
+		}
+	}
+	return oneReady
+}
+
+// hasConnectivityGate - Checks if a specific readiness gate condition is True on the Pod.
+func hasConnectivityGate(pod *corev1.Pod, conditionType string) bool {
+	// Check if the gate is declared in the Pod spec
+	gateDeclared := false
+	for _, gate := range pod.Spec.ReadinessGates {
+		if string(gate.ConditionType) == conditionType {
+			gateDeclared = true
+			break
+		}
+	}
+	// gate not applicable for this IP family: if gate not declared, include the Pod (skip filtering)
+	if !gateDeclared {
+		return true
+	}
+	// Check if the condition is True in the Pod status
+	for _, condition := range pod.Status.Conditions {
+		if string(condition.Type) == conditionType {
+			return condition.Status == corev1.ConditionTrue
+		}
+	}
+	// Gate declared but condition not found - treat as not ready
+	return false
+}

--- a/internal/controller/endpointnetworkconfiguration/resolve.go
+++ b/internal/controller/endpointnetworkconfiguration/resolve.go
@@ -39,6 +39,9 @@ const (
 	kindDistributionGroup    = "DistributionGroup"
 	labelGatewayName         = "gateway.networking.k8s.io/gateway-name"
 	attachmentTypeNAD        = "NAD"
+	// Readiness gate condition types (to be consolidated to shared package)
+	readinessGateIPv4 = "meridio-2.nordix.org/ipv4-connectivity"
+	readinessGateIPv6 = "meridio-2.nordix.org/ipv6-connectivity"
 )
 
 // resolveGatewayConnections determines which Gateways a Pod participates in
@@ -236,6 +239,10 @@ func (r *Reconciler) getSLLBRNextHops(ctx context.Context, gw *gatewayv1.Gateway
 		if pod.Status.Phase != corev1.PodRunning {
 			continue
 		}
+		// Level 1: container readiness (all non-init containers must be Ready)
+		if !isLBPodReady(&pod) {
+			continue
+		}
 		for cidr, attachmentType := range subnetToType {
 			ip := scraper(&pod, cidr, attachmentType)
 			if ip == "" {
@@ -245,10 +252,15 @@ func (r *Reconciler) getSLLBRNextHops(ctx context.Context, gw *gatewayv1.Gateway
 			if parsed == nil {
 				continue
 			}
+			// Level 2: per-IP-family gate check
 			if parsed.To4() != nil {
-				ipv4 = append(ipv4, ip)
+				if hasConnectivityGate(&pod, readinessGateIPv4) {
+					ipv4 = append(ipv4, ip)
+				}
 			} else {
-				ipv6 = append(ipv6, ip)
+				if hasConnectivityGate(&pod, readinessGateIPv6) {
+					ipv6 = append(ipv6, ip)
+				}
 			}
 		}
 	}

--- a/internal/controller/endpointnetworkconfiguration/resolve_test.go
+++ b/internal/controller/endpointnetworkconfiguration/resolve_test.go
@@ -611,3 +611,158 @@ func TestSidecarContract_DualStack(t *testing.T) {
 	assert.Equal(t, testSubnetV6, ipv6Domain.Network.Subnet)
 	assert.Equal(t, "net1", ipv6Domain.Network.InterfaceHint)
 }
+
+func TestIsLBPodReady(t *testing.T) {
+	tests := []struct {
+		name     string
+		pod      *corev1.Pod
+		expected bool
+	}{
+		{
+			name: "all containers ready",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "sllb-1"},
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{
+						{Name: "loadbalancer", Ready: true},
+						{Name: "router", Ready: true},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "one container not ready",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "sllb-1"},
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{
+						{Name: "loadbalancer", Ready: true},
+						{Name: "router", Ready: false},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "pod being deleted",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "sllb-1",
+					DeletionTimestamp: &metav1.Time{Time: metav1.Now().Time},
+				},
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{
+						{Name: "loadbalancer", Ready: true},
+						{Name: "router", Ready: true},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "no container statuses yet (startup)",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "sllb-1"},
+				Status:     corev1.PodStatus{},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isLBPodReady(tt.pod)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestHasConnectivityGate(t *testing.T) {
+	tests := []struct {
+		name          string
+		pod           *corev1.Pod
+		conditionType string
+		expected      bool
+	}{
+		{
+			name: "condition True",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					ReadinessGates: []corev1.PodReadinessGate{
+						{ConditionType: "meridio-2.nordix.org/ipv4-connectivity"},
+					},
+				},
+				Status: corev1.PodStatus{
+					Conditions: []corev1.PodCondition{
+						{Type: "meridio-2.nordix.org/ipv4-connectivity", Status: corev1.ConditionTrue},
+					},
+				},
+			},
+			conditionType: "meridio-2.nordix.org/ipv4-connectivity",
+			expected:      true,
+		},
+		{
+			name: "condition False",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					ReadinessGates: []corev1.PodReadinessGate{
+						{ConditionType: "meridio-2.nordix.org/ipv4-connectivity"},
+					},
+				},
+				Status: corev1.PodStatus{
+					Conditions: []corev1.PodCondition{
+						{Type: "meridio-2.nordix.org/ipv4-connectivity", Status: corev1.ConditionFalse},
+					},
+				},
+			},
+			conditionType: "meridio-2.nordix.org/ipv4-connectivity",
+			expected:      false,
+		},
+		{
+			name: "gate not declared — not applicable, include Pod",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{},
+			},
+			conditionType: "meridio-2.nordix.org/ipv4-connectivity",
+			expected:      true,
+		},
+		{
+			name: "gate declared but condition not yet set (readinessGate present, condition missing)",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					ReadinessGates: []corev1.PodReadinessGate{
+						{ConditionType: "meridio-2.nordix.org/ipv4-connectivity"},
+					},
+				},
+				Status: corev1.PodStatus{},
+			},
+			conditionType: "meridio-2.nordix.org/ipv4-connectivity",
+			expected:      false,
+		},
+		{
+			name: "IPv6-only gateway — IPv4 gate not declared, include Pod",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					ReadinessGates: []corev1.PodReadinessGate{
+						{ConditionType: "meridio-2.nordix.org/ipv6-connectivity"},
+					},
+				},
+				Status: corev1.PodStatus{
+					Conditions: []corev1.PodCondition{
+						{Type: "meridio-2.nordix.org/ipv6-connectivity", Status: corev1.ConditionTrue},
+					},
+				},
+			},
+			conditionType: "meridio-2.nordix.org/ipv4-connectivity",
+			expected:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := hasConnectivityGate(tt.pod, tt.conditionType)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/internal/controller/endpointnetworkconfiguration/resolve_test.go
+++ b/internal/controller/endpointnetworkconfiguration/resolve_test.go
@@ -18,7 +18,9 @@ package endpointnetworkconfiguration
 
 import (
 	"context"
+	"fmt"
 	"net"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -26,6 +28,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	meridio2v1alpha1 "github.com/nordix/meridio-2/api/v1alpha1"
@@ -289,7 +292,7 @@ func TestGetSLLBRNextHops(t *testing.T) {
 			Namespace: testNamespace,
 			Labels:    map[string]string{labelGatewayName: "sllb-a"},
 		},
-		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning, ContainerStatuses: []corev1.ContainerStatus{{Name: "loadbalancer", Ready: true}, {Name: "router", Ready: true}}},
 	}
 
 	r, _ := setupReconciler(gw, sllbrPod)
@@ -318,7 +321,7 @@ func TestBuildGatewayConnection_SkipsDomainWithNoInterface(t *testing.T) {
 			Namespace: testNamespace,
 			Labels:    map[string]string{labelGatewayName: "sllb-a"},
 		},
-		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning, ContainerStatuses: []corev1.ContainerStatus{{Name: "loadbalancer", Ready: true}, {Name: "router", Ready: true}}},
 	}
 	// Pod only has IPv4 address on net1 — no IPv6
 	targetPod := newPod("app-1", corev1.PodRunning, map[string]string{"app": "web"})
@@ -359,7 +362,7 @@ func TestBuildGatewayConnection_NamingConvention(t *testing.T) {
 			Namespace: testNamespace,
 			Labels:    map[string]string{labelGatewayName: "sllb-a"},
 		},
-		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning, ContainerStatuses: []corev1.ContainerStatus{{Name: "loadbalancer", Ready: true}, {Name: "router", Ready: true}}},
 	}
 	// Target pod with Multus network-status annotation
 	targetPod := newPod("app-1", corev1.PodRunning, map[string]string{"app": "web"})
@@ -428,7 +431,7 @@ func TestResolveGatewayConnections_FullChain(t *testing.T) {
 			Namespace: testNamespace,
 			Labels:    map[string]string{labelGatewayName: "sllb-a"},
 		},
-		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning, ContainerStatuses: []corev1.ContainerStatus{{Name: "loadbalancer", Ready: true}, {Name: "router", Ready: true}}},
 	}
 
 	r, _ := setupReconciler(pod, gw, gc, dg, sllbrPod)
@@ -533,7 +536,7 @@ func TestSidecarContract_DualStack(t *testing.T) {
 			Namespace: testNamespace,
 			Labels:    map[string]string{labelGatewayName: "sllb-a"},
 		},
-		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning, ContainerStatuses: []corev1.ContainerStatus{{Name: "loadbalancer", Ready: true}, {Name: "router", Ready: true}}},
 	}
 
 	r, _ := setupReconciler(pod, gw, gc, dg, sllbrPod)
@@ -764,5 +767,149 @@ func TestHasConnectivityGate(t *testing.T) {
 			result := hasConnectivityGate(tt.pod, tt.conditionType)
 			assert.Equal(t, tt.expected, result)
 		})
+	}
+}
+
+func TestGetSLLBRNextHops_TwoLevelFiltering(t *testing.T) {
+	tests := []struct {
+		name     string
+		pods     []corev1.Pod
+		wantIPv4 []string
+		wantIPv6 []string
+	}{
+		{
+			name: "all pods healthy and connected — all included",
+			pods: []corev1.Pod{
+				makeLBPodWithGates("sllb-1", true, true, true),
+				makeLBPodWithGates("sllb-2", true, true, true),
+			},
+			wantIPv4: []string{"192.168.100.1", "192.168.100.2"},
+		},
+		{
+			name: "one pod container not ready — excluded from both families",
+			pods: []corev1.Pod{
+				makeLBPodWithGates("sllb-1", true, true, true),
+				makeLBPodWithGates("sllb-2", false, true, true), // container not ready
+			},
+			wantIPv4: []string{"192.168.100.1"},
+		},
+		{
+			name: "pod has IPv4 gate True but IPv6 gate False — only in IPv4 hops",
+			pods: []corev1.Pod{
+				makeLBPodWithGates("sllb-1", true, true, false),
+			},
+			wantIPv4: []string{"192.168.100.1"},
+			wantIPv6: nil,
+		},
+		{
+			name: "pod has no readiness gates — included (gate not applicable)",
+			pods: []corev1.Pod{
+				makeLBPodNoGates("sllb-1", true),
+			},
+			wantIPv4: []string{"192.168.100.1"},
+		},
+		{
+			name: "pod being deleted — excluded",
+			pods: []corev1.Pod{
+				makeLBPodDeleting("sllb-1"),
+			},
+			wantIPv4: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &Reconciler{
+				IPScraper: func(pod *corev1.Pod, cidr, _ string) string {
+					// Return a deterministic IP based on pod name and CIDR family
+					idx := pod.Name[len(pod.Name)-1] - '0' // last char as index
+					if strings.Contains(cidr, ":") {
+						return fmt.Sprintf("2001:db8::%d", idx)
+					}
+					return fmt.Sprintf("192.168.100.%d", idx)
+				},
+			}
+
+			gw := &gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-gw", Namespace: "default"},
+			}
+
+			objects := make([]client.Object, 0, len(tt.pods))
+			for i := range tt.pods {
+				tt.pods[i].Namespace = "default"
+				tt.pods[i].Labels = map[string]string{labelGatewayName: "test-gw"}
+				objects = append(objects, &tt.pods[i])
+			}
+
+			fakeClient := fake.NewClientBuilder().WithObjects(objects...).Build()
+			r.Client = fakeClient
+
+			subnetToType := map[string]string{"192.168.100.0/24": "NAD"}
+			if tt.wantIPv6 != nil || tt.name == "pod has IPv4 gate True but IPv6 gate False — only in IPv4 hops" {
+				subnetToType["2001:db8::/64"] = "NAD"
+			}
+
+			ipv4, ipv6, err := r.getSLLBRNextHops(context.Background(), gw, subnetToType)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantIPv4, ipv4)
+			assert.Equal(t, tt.wantIPv6, ipv6)
+		})
+	}
+}
+
+// Helper functions for test Pod construction
+
+//nolint:unparam // test helper designed for varied usage
+func makeLBPodWithGates(name string, containersReady, ipv4GateTrue, ipv6GateTrue bool) corev1.Pod {
+	ipv4Status := corev1.ConditionFalse
+	if ipv4GateTrue {
+		ipv4Status = corev1.ConditionTrue
+	}
+	ipv6Status := corev1.ConditionFalse
+	if ipv6GateTrue {
+		ipv6Status = corev1.ConditionTrue
+	}
+	return corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: corev1.PodSpec{
+			ReadinessGates: []corev1.PodReadinessGate{
+				{ConditionType: "meridio-2.nordix.org/ipv4-connectivity"},
+				{ConditionType: "meridio-2.nordix.org/ipv6-connectivity"},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "loadbalancer", Ready: containersReady},
+				{Name: "router", Ready: containersReady},
+			},
+			Conditions: []corev1.PodCondition{
+				{Type: "meridio-2.nordix.org/ipv4-connectivity", Status: ipv4Status},
+				{Type: "meridio-2.nordix.org/ipv6-connectivity", Status: ipv6Status},
+			},
+		},
+	}
+}
+
+func makeLBPodNoGates(name string, containersReady bool) corev1.Pod {
+	return corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "loadbalancer", Ready: containersReady},
+				{Name: "router", Ready: containersReady},
+			},
+		},
+	}
+}
+
+func makeLBPodDeleting(name string) corev1.Pod {
+	return corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Finalizers: []string{"test"}},
+		Status: corev1.PodStatus{
+			Phase:             corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{},
+		},
 	}
 }

--- a/internal/controller/router/connectivity.go
+++ b/internal/controller/router/connectivity.go
@@ -18,6 +18,7 @@ package router
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -171,27 +172,32 @@ func (cgm *ConnectivityGateManager) patchGateCondition(ctx context.Context, cond
 
 // SetAllGatesFalse(ctx) error — called on startup (defense-in-depth)
 func (cgm *ConnectivityGateManager) SetAllGatesFalse(ctx context.Context) error {
+	var errFinal error
 	if cgm.ipv4Gate != nil {
 		if err := cgm.patchGateCondition(ctx, ReadinessGateIPv4, false); err != nil {
-			return fmt.Errorf("error patching IPv4 gate: %w", err)
+			errFinal = errors.Join(errFinal, err)
 		}
 	}
 	if cgm.ipv6Gate != nil {
 		if err := cgm.patchGateCondition(ctx, ReadinessGateIPv6, false); err != nil {
-			return fmt.Errorf("error patching IPv6 gate: %w", err)
+			errFinal = errors.Join(errFinal, err)
 		}
 	}
-	return nil
+	return errFinal
 }
 
 // OnStatusUpdate handles per-IP-family connectivity changes with damping.
 // Down transitions are immediate. Up transitions require holdTime to elapse
 // with continuous connectivity before the gate is set to True.
 func (cgm *ConnectivityGateManager) OnStatusUpdate(ctx context.Context, ipv4Connected, ipv6Connected bool) error {
+	var errFinal error
 	if err := cgm.handleGate(ctx, cgm.ipv4Gate, ipv4Connected, &cgm.ipv4UpSince, ReadinessGateIPv4); err != nil {
-		return err
+		errFinal = errors.Join(errFinal, err)
 	}
-	return cgm.handleGate(ctx, cgm.ipv6Gate, ipv6Connected, &cgm.ipv6UpSince, ReadinessGateIPv6)
+	if err := cgm.handleGate(ctx, cgm.ipv6Gate, ipv6Connected, &cgm.ipv6UpSince, ReadinessGateIPv6); err != nil {
+		errFinal = errors.Join(errFinal, err)
+	}
+	return errFinal
 }
 
 func (cgm *ConnectivityGateManager) handleGate(ctx context.Context, gate *bool, connected bool, upSince *time.Time, conditionType string) error {

--- a/internal/controller/router/connectivity.go
+++ b/internal/controller/router/connectivity.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
+	"net"
 	"time"
 
 	meridio2v1alpha1 "github.com/nordix/meridio-2/api/v1alpha1"
@@ -43,6 +43,9 @@ type ConnectivityGateManager struct {
 	// Current gate states (last written to API)
 	ipv4Gate *bool // nil = not declared, true/false = current value
 	ipv6Gate *bool
+	// Dirty flags: force unconditional write on next tick after any failure
+	ipv4Dirty bool
+	ipv6Dirty bool
 	// Damping: timestamp when connectivity first came up (zero = not up)
 	ipv4UpSince time.Time
 	ipv6UpSince time.Time
@@ -119,55 +122,40 @@ func ClassifyConnectivityByFamily(protocols []bird.ProtocolStatus, familyMap map
 	return
 }
 
-// buildFamilyMap creates a mapping from protocol names to IP families based on the provided GatewayRouters.
+// BuildFamilyMap creates a mapping from protocol names to IP families based on the provided GatewayRouters.
 func BuildFamilyMap(gatewayRouters []*meridio2v1alpha1.GatewayRouter) map[string]string {
 	familyMap := make(map[string]string)
 	for _, gr := range gatewayRouters {
-		address := gr.Spec.Address
-		protocol := "IPv4"
-		if strings.Contains(address, ":") {
-			protocol = "IPv6"
+		family := "IPv4"
+		if ip := net.ParseIP(gr.Spec.Address); ip != nil && ip.To4() == nil {
+			family = "IPv6"
 		}
-		protoName := fmt.Sprintf("NBR-%s", gr.Name)
-		familyMap[protoName] = protocol
+		familyMap[fmt.Sprintf("NBR-%s", gr.Name)] = family
 	}
 	return familyMap
 }
 
-// patchGateCondition(ctx, conditionType, status) error — patches Pod status
+// patchGateCondition patches a single Pod status condition using a strategic merge patch.
+// No Get required — always writes unconditionally. The caller decides whether to call it.
 func (cgm *ConnectivityGateManager) patchGateCondition(ctx context.Context, conditionType string, status bool) error {
-	pod := &corev1.Pod{}
-	if err := cgm.client.Get(ctx, types.NamespacedName{Name: cgm.podName, Namespace: cgm.podNamespace}, pod); err != nil {
-		return fmt.Errorf("error fetching pod for patching: %w", err)
-	}
-
-	newStatus := corev1.ConditionFalse
+	condStatus := corev1.ConditionFalse
 	if status {
-		newStatus = corev1.ConditionTrue
+		condStatus = corev1.ConditionTrue
 	}
 
-	// Find or create the condition
-	found := false
-	for i := range pod.Status.Conditions {
-		if string(pod.Status.Conditions[i].Type) == conditionType {
-			if pod.Status.Conditions[i].Status == newStatus {
-				return nil // No change needed
-			}
-			pod.Status.Conditions[i].Status = newStatus
-			pod.Status.Conditions[i].LastTransitionTime = metav1.Now()
-			found = true
-			break
-		}
-	}
-	if !found {
-		pod.Status.Conditions = append(pod.Status.Conditions, corev1.PodCondition{
-			Type:               corev1.PodConditionType(conditionType),
-			Status:             newStatus,
-			LastTransitionTime: metav1.Now(),
-		})
-	}
+	now := metav1.Now().Format(time.RFC3339)
+	patchJSON := fmt.Sprintf(
+		`{"status":{"conditions":[{"type":%q,"status":%q,"lastTransitionTime":%q}]}}`,
+		conditionType, string(condStatus), now,
+	)
 
-	return cgm.client.Status().Update(ctx, pod)
+	pod := &corev1.Pod{}
+	pod.Name = cgm.podName
+	pod.Namespace = cgm.podNamespace
+
+	return cgm.client.Status().Patch(ctx, pod, client.RawPatch(
+		types.StrategicMergePatchType, []byte(patchJSON),
+	))
 }
 
 // SetAllGatesFalse(ctx) error — called on startup (defense-in-depth)
@@ -205,21 +193,25 @@ func (cgm *ConnectivityGateManager) handleGate(ctx context.Context, gate *bool, 
 		return nil // Gate not declared
 	}
 
+	dirty := cgm.getDirty(conditionType)
+
 	if !connected {
 		// Down: immediate
 		*upSince = time.Time{} // Reset hold timer
-		if *gate {
+		if *gate || *dirty {
 			if err := cgm.patchGateCondition(ctx, conditionType, false); err != nil {
+				*dirty = true
 				return err
 			}
 			*gate = false
+			*dirty = false
 		}
 		return nil
 	}
 
 	// Connected
-	if *gate {
-		return nil // Already True, no-op
+	if *gate && !*dirty {
+		return nil // Already True, no pending write
 	}
 
 	// Start hold timer if not already started
@@ -232,10 +224,19 @@ func (cgm *ConnectivityGateManager) handleGate(ctx context.Context, gate *bool, 
 	// Check if hold time has elapsed
 	if now.Sub(*upSince) >= cgm.holdTime {
 		if err := cgm.patchGateCondition(ctx, conditionType, true); err != nil {
+			*dirty = true
 			return err
 		}
 		*gate = true
+		*dirty = false
 	}
 
 	return nil
+}
+
+func (cgm *ConnectivityGateManager) getDirty(conditionType string) *bool {
+	if conditionType == ReadinessGateIPv4 {
+		return &cgm.ipv4Dirty
+	}
+	return &cgm.ipv6Dirty
 }

--- a/internal/controller/router/connectivity.go
+++ b/internal/controller/router/connectivity.go
@@ -1,0 +1,125 @@
+/*
+Copyright (c) 2026 OpenInfra Foundation Europe. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package router
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	meridio2v1alpha1 "github.com/nordix/meridio-2/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/nordix/meridio-2/internal/bird"
+)
+
+// ConnectivityGateManager manages Pod readiness gate conditions
+type ConnectivityGateManager struct {
+	client       client.Client
+	podName      string
+	podNamespace string
+	podUID       types.UID
+	holdTime     time.Duration
+	// Current gate states (last written to API)
+	ipv4Gate *bool // nil = not declared, true/false = current value
+	ipv6Gate *bool
+}
+
+// NewConnectivityGateManager creates a new instance of ConnectivityGateManager
+func NewConnectivityGateManager(c client.Client, podName, podNamespace string, podUID types.UID, holdTime time.Duration) *ConnectivityGateManager {
+	cgm := &ConnectivityGateManager{
+		client:       c,
+		podName:      podName,
+		podNamespace: podNamespace,
+		podUID:       podUID,
+		holdTime:     holdTime,
+	}
+	return cgm
+}
+
+// DiscoverGates checks the Pod's readiness gates and initializes internal state
+func (cgm *ConnectivityGateManager) DiscoverGates(ctx context.Context) error {
+	pod := &corev1.Pod{}
+	if err := cgm.client.Get(ctx, types.NamespacedName{Name: cgm.podName, Namespace: cgm.podNamespace}, pod); err != nil {
+		if apierrors.IsNotFound(err) {
+			return fmt.Errorf("pod %s/%s not found: %w", cgm.podNamespace, cgm.podName, err)
+		}
+		return fmt.Errorf("error fetching pod %s/%s: %w", cgm.podNamespace, cgm.podName, err)
+	}
+
+	for _, gate := range pod.Spec.ReadinessGates {
+		switch gate.ConditionType {
+		case ReadinessGateIPv4:
+			cgm.ipv4Gate = new(bool) // declared but initial value unknown
+		case ReadinessGateIPv6:
+			cgm.ipv6Gate = new(bool)
+		}
+	}
+	return nil
+}
+
+// HasIPv4Gate returns true if the Pod has the IPv4 connectivity gate declared
+func (cgm *ConnectivityGateManager) HasIPv4Gate() bool {
+	return cgm.ipv4Gate != nil
+}
+
+// HasIPv6Gate returns true if the Pod has the IPv6 connectivity gate declared
+func (cgm *ConnectivityGateManager) HasIPv6Gate() bool {
+	return cgm.ipv6Gate != nil
+}
+
+// classifyConnectivityByFamily determines per-IP-family connectivity from protocol statuses.
+// Returns true for each family if at least one protocol of that family is established.
+// Protocols not in familyMap are ignored.
+func classifyConnectivityByFamily(protocols []bird.ProtocolStatus, familyMap map[string]string) (ipv4Connected, ipv6Connected bool) {
+	for _, p := range protocols {
+		if !p.IsEstablished() {
+			continue
+		}
+		switch familyMap[p.Name] {
+		case "IPv4":
+			ipv4Connected = true
+		case "IPv6":
+			ipv6Connected = true
+		}
+	}
+	return
+}
+
+// buildFamilyMap creates a mapping from protocol names to IP families based on the provided GatewayRouters.
+func buildFamilyMap(gatewayRouters []*meridio2v1alpha1.GatewayRouter) map[string]string {
+	familyMap := make(map[string]string)
+	for _, gr := range gatewayRouters {
+		address := gr.Spec.Address
+		protocol := "IPv4"
+		if strings.Contains(address, ":") {
+			protocol = "IPv6"
+		}
+		protoName := fmt.Sprintf("NBR-%s", gr.Name)
+		familyMap[protoName] = protocol
+	}
+	return familyMap
+}
+
+// TODO
+// - OnStatusUpdate(ipv4Connected, ipv6Connected bool) — called on each monitor tick, handles damping and patches
+// - SetAllGatesFalse(ctx) error — called on startup (defense-in-depth)
+// - patchGateCondition(ctx, conditionType, status) error — patches Pod status

--- a/internal/controller/router/connectivity.go
+++ b/internal/controller/router/connectivity.go
@@ -25,6 +25,7 @@ import (
 	meridio2v1alpha1 "github.com/nordix/meridio-2/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -119,7 +120,42 @@ func buildFamilyMap(gatewayRouters []*meridio2v1alpha1.GatewayRouter) map[string
 	return familyMap
 }
 
+// patchGateCondition(ctx, conditionType, status) error — patches Pod status
+func (cgm *ConnectivityGateManager) patchGateCondition(ctx context.Context, conditionType string, status bool) error {
+	pod := &corev1.Pod{}
+	if err := cgm.client.Get(ctx, types.NamespacedName{Name: cgm.podName, Namespace: cgm.podNamespace}, pod); err != nil {
+		return fmt.Errorf("error fetching pod for patching: %w", err)
+	}
+
+	newStatus := corev1.ConditionFalse
+	if status {
+		newStatus = corev1.ConditionTrue
+	}
+
+	// Find or create the condition
+	found := false
+	for i := range pod.Status.Conditions {
+		if string(pod.Status.Conditions[i].Type) == conditionType {
+			if pod.Status.Conditions[i].Status == newStatus {
+				return nil // No change needed
+			}
+			pod.Status.Conditions[i].Status = newStatus
+			pod.Status.Conditions[i].LastTransitionTime = metav1.Now()
+			found = true
+			break
+		}
+	}
+	if !found {
+		pod.Status.Conditions = append(pod.Status.Conditions, corev1.PodCondition{
+			Type:               corev1.PodConditionType(conditionType),
+			Status:             newStatus,
+			LastTransitionTime: metav1.Now(),
+		})
+	}
+
+	return cgm.client.Status().Update(ctx, pod)
+}
+
 // TODO
 // - OnStatusUpdate(ipv4Connected, ipv6Connected bool) — called on each monitor tick, handles damping and patches
 // - SetAllGatesFalse(ctx) error — called on startup (defense-in-depth)
-// - patchGateCondition(ctx, conditionType, status) error — patches Pod status

--- a/internal/controller/router/connectivity.go
+++ b/internal/controller/router/connectivity.go
@@ -42,6 +42,9 @@ type ConnectivityGateManager struct {
 	// Current gate states (last written to API)
 	ipv4Gate *bool // nil = not declared, true/false = current value
 	ipv6Gate *bool
+	// Damping: timestamp when connectivity first came up (zero = not up)
+	ipv4UpSince time.Time
+	ipv6UpSince time.Time
 }
 
 // NewConnectivityGateManager creates a new instance of ConnectivityGateManager
@@ -69,9 +72,19 @@ func (cgm *ConnectivityGateManager) DiscoverGates(ctx context.Context) error {
 	for _, gate := range pod.Spec.ReadinessGates {
 		switch gate.ConditionType {
 		case ReadinessGateIPv4:
-			cgm.ipv4Gate = new(bool) // declared but initial value unknown
+			cgm.ipv4Gate = new(bool)
+			for _, c := range pod.Status.Conditions {
+				if string(c.Type) == ReadinessGateIPv4 {
+					*cgm.ipv4Gate = c.Status == corev1.ConditionTrue
+				}
+			}
 		case ReadinessGateIPv6:
 			cgm.ipv6Gate = new(bool)
+			for _, c := range pod.Status.Conditions {
+				if string(c.Type) == ReadinessGateIPv6 {
+					*cgm.ipv6Gate = c.Status == corev1.ConditionTrue
+				}
+			}
 		}
 	}
 	return nil
@@ -90,7 +103,7 @@ func (cgm *ConnectivityGateManager) HasIPv6Gate() bool {
 // classifyConnectivityByFamily determines per-IP-family connectivity from protocol statuses.
 // Returns true for each family if at least one protocol of that family is established.
 // Protocols not in familyMap are ignored.
-func classifyConnectivityByFamily(protocols []bird.ProtocolStatus, familyMap map[string]string) (ipv4Connected, ipv6Connected bool) {
+func ClassifyConnectivityByFamily(protocols []bird.ProtocolStatus, familyMap map[string]string) (ipv4Connected, ipv6Connected bool) {
 	for _, p := range protocols {
 		if !p.IsEstablished() {
 			continue
@@ -106,7 +119,7 @@ func classifyConnectivityByFamily(protocols []bird.ProtocolStatus, familyMap map
 }
 
 // buildFamilyMap creates a mapping from protocol names to IP families based on the provided GatewayRouters.
-func buildFamilyMap(gatewayRouters []*meridio2v1alpha1.GatewayRouter) map[string]string {
+func BuildFamilyMap(gatewayRouters []*meridio2v1alpha1.GatewayRouter) map[string]string {
 	familyMap := make(map[string]string)
 	for _, gr := range gatewayRouters {
 		address := gr.Spec.Address
@@ -156,6 +169,67 @@ func (cgm *ConnectivityGateManager) patchGateCondition(ctx context.Context, cond
 	return cgm.client.Status().Update(ctx, pod)
 }
 
-// TODO
-// - OnStatusUpdate(ipv4Connected, ipv6Connected bool) — called on each monitor tick, handles damping and patches
-// - SetAllGatesFalse(ctx) error — called on startup (defense-in-depth)
+// SetAllGatesFalse(ctx) error — called on startup (defense-in-depth)
+func (cgm *ConnectivityGateManager) SetAllGatesFalse(ctx context.Context) error {
+	if cgm.ipv4Gate != nil {
+		if err := cgm.patchGateCondition(ctx, ReadinessGateIPv4, false); err != nil {
+			return fmt.Errorf("error patching IPv4 gate: %w", err)
+		}
+	}
+	if cgm.ipv6Gate != nil {
+		if err := cgm.patchGateCondition(ctx, ReadinessGateIPv6, false); err != nil {
+			return fmt.Errorf("error patching IPv6 gate: %w", err)
+		}
+	}
+	return nil
+}
+
+// OnStatusUpdate handles per-IP-family connectivity changes with damping.
+// Down transitions are immediate. Up transitions require holdTime to elapse
+// with continuous connectivity before the gate is set to True.
+func (cgm *ConnectivityGateManager) OnStatusUpdate(ctx context.Context, ipv4Connected, ipv6Connected bool) error {
+	if err := cgm.handleGate(ctx, cgm.ipv4Gate, ipv4Connected, &cgm.ipv4UpSince, ReadinessGateIPv4); err != nil {
+		return err
+	}
+	return cgm.handleGate(ctx, cgm.ipv6Gate, ipv6Connected, &cgm.ipv6UpSince, ReadinessGateIPv6)
+}
+
+func (cgm *ConnectivityGateManager) handleGate(ctx context.Context, gate *bool, connected bool, upSince *time.Time, conditionType string) error {
+	if gate == nil {
+		return nil // Gate not declared
+	}
+
+	if !connected {
+		// Down: immediate
+		*upSince = time.Time{} // Reset hold timer
+		if *gate {
+			if err := cgm.patchGateCondition(ctx, conditionType, false); err != nil {
+				return err
+			}
+			*gate = false
+		}
+		return nil
+	}
+
+	// Connected
+	if *gate {
+		return nil // Already True, no-op
+	}
+
+	// Start hold timer if not already started
+	now := time.Now()
+	if upSince.IsZero() {
+		*upSince = now
+		return nil // Wait for hold time
+	}
+
+	// Check if hold time has elapsed
+	if now.Sub(*upSince) >= cgm.holdTime {
+		if err := cgm.patchGateCondition(ctx, conditionType, true); err != nil {
+			return err
+		}
+		*gate = true
+	}
+
+	return nil
+}

--- a/internal/controller/router/connectivity.go
+++ b/internal/controller/router/connectivity.go
@@ -214,6 +214,12 @@ func (cgm *ConnectivityGateManager) handleGate(ctx context.Context, gate *bool, 
 		return nil // Already True, no pending write
 	}
 
+	// Note: if gate is True on API but dirty (failed False write), and connectivity
+	// recovers, the hold timer runs but the gate never went False on the API.
+	// This bypasses damping for one cycle. Acceptable: the LB has connectivity
+	// (it recovered), traffic is safe, and the scenario requires both a failed API
+	// write AND immediate recovery within one tick — extremely narrow window.
+
 	// Start hold timer if not already started
 	now := time.Now()
 	if upSince.IsZero() {

--- a/internal/controller/router/connectivity_test.go
+++ b/internal/controller/router/connectivity_test.go
@@ -101,7 +101,7 @@ func TestClassifyConnectivityByFamily(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ipv4, ipv6 := classifyConnectivityByFamily(tt.protocols, tt.familyMap)
+			ipv4, ipv6 := ClassifyConnectivityByFamily(tt.protocols, tt.familyMap)
 			assert.Equal(t, tt.wantIPv4, ipv4, "IPv4 connectivity")
 			assert.Equal(t, tt.wantIPv6, ipv6, "IPv6 connectivity")
 		})
@@ -157,7 +157,7 @@ func TestBuildFamilyMap(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := buildFamilyMap(tt.routers)
+			result := BuildFamilyMap(tt.routers)
 			assert.Equal(t, tt.expected, result)
 		})
 	}
@@ -337,5 +337,309 @@ func TestPatchGateCondition(t *testing.T) {
 				assert.Equal(t, corev1.ConditionTrue, c.Status)
 			}
 		}
+	})
+}
+
+func TestSetAllGatesFalse(t *testing.T) {
+	t.Run("SetsAllDeclaredGatesToFalse", func(t *testing.T) {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default", UID: "uid-1"},
+			Spec: corev1.PodSpec{
+				ReadinessGates: []corev1.PodReadinessGate{
+					{ConditionType: "meridio-2.nordix.org/ipv4-connectivity"},
+					{ConditionType: "meridio-2.nordix.org/ipv6-connectivity"},
+				},
+			},
+		}
+		fakeClient := fake.NewClientBuilder().
+			WithObjects(pod).
+			WithStatusSubresource(pod).
+			Build()
+
+		mgr := NewConnectivityGateManager(fakeClient, "test-pod", "default", "uid-1", 10*time.Second)
+		err := mgr.DiscoverGates(context.Background())
+		assert.NoError(t, err)
+
+		err = mgr.SetAllGatesFalse(context.Background())
+		assert.NoError(t, err)
+
+		// Verify both conditions are False
+		updated := &corev1.Pod{}
+		err = fakeClient.Get(context.Background(), types.NamespacedName{Name: "test-pod", Namespace: "default"}, updated)
+		assert.NoError(t, err)
+
+		for _, condType := range []string{"meridio-2.nordix.org/ipv4-connectivity", "meridio-2.nordix.org/ipv6-connectivity"} {
+			var found bool
+			for _, c := range updated.Status.Conditions {
+				if string(c.Type) == condType {
+					assert.Equal(t, corev1.ConditionFalse, c.Status)
+					found = true
+				}
+			}
+			assert.True(t, found, "condition %s should be set", condType)
+		}
+	})
+
+	t.Run("IPv4Only_SetsOnlyIPv4Gate", func(t *testing.T) {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default", UID: "uid-1"},
+			Spec: corev1.PodSpec{
+				ReadinessGates: []corev1.PodReadinessGate{
+					{ConditionType: "meridio-2.nordix.org/ipv4-connectivity"},
+				},
+			},
+		}
+		fakeClient := fake.NewClientBuilder().
+			WithObjects(pod).
+			WithStatusSubresource(pod).
+			Build()
+
+		mgr := NewConnectivityGateManager(fakeClient, "test-pod", "default", "uid-1", 10*time.Second)
+		err := mgr.DiscoverGates(context.Background())
+		assert.NoError(t, err)
+
+		err = mgr.SetAllGatesFalse(context.Background())
+		assert.NoError(t, err)
+
+		updated := &corev1.Pod{}
+		err = fakeClient.Get(context.Background(), types.NamespacedName{Name: "test-pod", Namespace: "default"}, updated)
+		assert.NoError(t, err)
+		assert.Len(t, updated.Status.Conditions, 1)
+		assert.Equal(t, corev1.PodConditionType("meridio-2.nordix.org/ipv4-connectivity"), updated.Status.Conditions[0].Type)
+		assert.Equal(t, corev1.ConditionFalse, updated.Status.Conditions[0].Status)
+	})
+
+	t.Run("IPv6Only_SetsOnlyIPv6Gate", func(t *testing.T) {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default", UID: "uid-1"},
+			Spec: corev1.PodSpec{
+				ReadinessGates: []corev1.PodReadinessGate{
+					{ConditionType: "meridio-2.nordix.org/ipv6-connectivity"},
+				},
+			},
+		}
+		fakeClient := fake.NewClientBuilder().
+			WithObjects(pod).
+			WithStatusSubresource(pod).
+			Build()
+
+		mgr := NewConnectivityGateManager(fakeClient, "test-pod", "default", "uid-1", 10*time.Second)
+		err := mgr.DiscoverGates(context.Background())
+		assert.NoError(t, err)
+
+		err = mgr.SetAllGatesFalse(context.Background())
+		assert.NoError(t, err)
+
+		updated := &corev1.Pod{}
+		err = fakeClient.Get(context.Background(), types.NamespacedName{Name: "test-pod", Namespace: "default"}, updated)
+		assert.NoError(t, err)
+		assert.Len(t, updated.Status.Conditions, 1)
+		assert.Equal(t, corev1.PodConditionType("meridio-2.nordix.org/ipv6-connectivity"), updated.Status.Conditions[0].Type)
+		assert.Equal(t, corev1.ConditionFalse, updated.Status.Conditions[0].Status)
+	})
+
+	t.Run("NoGatesDeclared_NoOp", func(t *testing.T) {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default", UID: "uid-1"},
+			Spec:       corev1.PodSpec{},
+		}
+		fakeClient := fake.NewClientBuilder().
+			WithObjects(pod).
+			WithStatusSubresource(pod).
+			Build()
+
+		mgr := NewConnectivityGateManager(fakeClient, "test-pod", "default", "uid-1", 10*time.Second)
+		err := mgr.DiscoverGates(context.Background())
+		assert.NoError(t, err)
+
+		err = mgr.SetAllGatesFalse(context.Background())
+		assert.NoError(t, err)
+
+		// No conditions should be set
+		updated := &corev1.Pod{}
+		err = fakeClient.Get(context.Background(), types.NamespacedName{Name: "test-pod", Namespace: "default"}, updated)
+		assert.NoError(t, err)
+		assert.Empty(t, updated.Status.Conditions)
+	})
+}
+
+func TestDamping(t *testing.T) {
+	t.Run("DownTransition_Immediate", func(t *testing.T) {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default", UID: "uid-1"},
+			Spec: corev1.PodSpec{
+				ReadinessGates: []corev1.PodReadinessGate{
+					{ConditionType: "meridio-2.nordix.org/ipv4-connectivity"},
+				},
+			},
+		}
+		fakeClient := fake.NewClientBuilder().
+			WithObjects(pod).
+			WithStatusSubresource(pod).
+			Build()
+
+		mgr := NewConnectivityGateManager(fakeClient, "test-pod", "default", "uid-1", 100*time.Millisecond)
+		_ = mgr.DiscoverGates(context.Background())
+		_ = mgr.SetAllGatesFalse(context.Background())
+
+		// Bring connectivity up: first tick starts timer, wait holdTime, second tick sets True
+		_ = mgr.OnStatusUpdate(context.Background(), true, false)
+		time.Sleep(150 * time.Millisecond)
+		_ = mgr.OnStatusUpdate(context.Background(), true, false)
+
+		// Verify gate is True
+		updated := &corev1.Pod{}
+		_ = fakeClient.Get(context.Background(), types.NamespacedName{Name: "test-pod", Namespace: "default"}, updated)
+		for _, c := range updated.Status.Conditions {
+			if string(c.Type) == ReadinessGateIPv4 {
+				assert.Equal(t, corev1.ConditionTrue, c.Status, "gate should be True before drop")
+			}
+		}
+
+		// Connectivity drops — gate should be False immediately (no 100ms damping applied)
+		err := mgr.OnStatusUpdate(context.Background(), false, false)
+		assert.NoError(t, err)
+
+		_ = fakeClient.Get(context.Background(), types.NamespacedName{Name: "test-pod", Namespace: "default"}, updated)
+		for _, c := range updated.Status.Conditions {
+			if string(c.Type) == ReadinessGateIPv4 {
+				assert.Equal(t, corev1.ConditionFalse, c.Status, "gate should be False immediately on down (no damping)")
+			}
+		}
+	})
+
+	t.Run("UpTransition_Damped", func(t *testing.T) {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default", UID: "uid-1"},
+			Spec: corev1.PodSpec{
+				ReadinessGates: []corev1.PodReadinessGate{
+					{ConditionType: "meridio-2.nordix.org/ipv4-connectivity"},
+				},
+			},
+		}
+		fakeClient := fake.NewClientBuilder().
+			WithObjects(pod).
+			WithStatusSubresource(pod).
+			Build()
+
+		mgr := NewConnectivityGateManager(fakeClient, "test-pod", "default", "uid-1", 100*time.Millisecond)
+		_ = mgr.DiscoverGates(context.Background())
+		_ = mgr.SetAllGatesFalse(context.Background())
+
+		// Connectivity comes up — gate should NOT be True yet (hold time not elapsed)
+		err := mgr.OnStatusUpdate(context.Background(), true, false)
+		assert.NoError(t, err)
+
+		updated := &corev1.Pod{}
+		_ = fakeClient.Get(context.Background(), types.NamespacedName{Name: "test-pod", Namespace: "default"}, updated)
+		for _, c := range updated.Status.Conditions {
+			if string(c.Type) == ReadinessGateIPv4 {
+				assert.Equal(t, corev1.ConditionFalse, c.Status, "gate should still be False during hold time")
+			}
+		}
+
+		// Wait for hold time to elapse
+		time.Sleep(150 * time.Millisecond)
+
+		// Call again — now it should be True
+		err = mgr.OnStatusUpdate(context.Background(), true, false)
+		assert.NoError(t, err)
+
+		_ = fakeClient.Get(context.Background(), types.NamespacedName{Name: "test-pod", Namespace: "default"}, updated)
+		for _, c := range updated.Status.Conditions {
+			if string(c.Type) == ReadinessGateIPv4 {
+				assert.Equal(t, corev1.ConditionTrue, c.Status, "gate should be True after hold time")
+			}
+		}
+	})
+
+	t.Run("UpTransition_FlapDuringHold_ResetsTimer", func(t *testing.T) {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default", UID: "uid-1"},
+			Spec: corev1.PodSpec{
+				ReadinessGates: []corev1.PodReadinessGate{
+					{ConditionType: "meridio-2.nordix.org/ipv4-connectivity"},
+				},
+			},
+		}
+		fakeClient := fake.NewClientBuilder().
+			WithObjects(pod).
+			WithStatusSubresource(pod).
+			Build()
+
+		mgr := NewConnectivityGateManager(fakeClient, "test-pod", "default", "uid-1", 100*time.Millisecond)
+		_ = mgr.DiscoverGates(context.Background())
+		_ = mgr.SetAllGatesFalse(context.Background())
+
+		// Connectivity up
+		_ = mgr.OnStatusUpdate(context.Background(), true, false)
+
+		// Flap down during hold — should reset timer and set False
+		time.Sleep(50 * time.Millisecond)
+		_ = mgr.OnStatusUpdate(context.Background(), false, false)
+
+		// Wait past original hold time
+		time.Sleep(80 * time.Millisecond)
+
+		// Gate should still be False (timer was reset by the flap)
+		updated := &corev1.Pod{}
+		_ = fakeClient.Get(context.Background(), types.NamespacedName{Name: "test-pod", Namespace: "default"}, updated)
+		for _, c := range updated.Status.Conditions {
+			if string(c.Type) == ReadinessGateIPv4 {
+				assert.Equal(t, corev1.ConditionFalse, c.Status, "gate should remain False after flap")
+			}
+		}
+	})
+
+	t.Run("NoChange_NoPatch", func(t *testing.T) {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default", UID: "uid-1"},
+			Spec: corev1.PodSpec{
+				ReadinessGates: []corev1.PodReadinessGate{
+					{ConditionType: "meridio-2.nordix.org/ipv4-connectivity"},
+				},
+			},
+		}
+		fakeClient := fake.NewClientBuilder().
+			WithObjects(pod).
+			WithStatusSubresource(pod).
+			Build()
+
+		mgr := NewConnectivityGateManager(fakeClient, "test-pod", "default", "uid-1", 100*time.Millisecond)
+		_ = mgr.DiscoverGates(context.Background())
+		_ = mgr.SetAllGatesFalse(context.Background())
+
+		// Connectivity still down — no change, should be no-op
+		err := mgr.OnStatusUpdate(context.Background(), false, false)
+		assert.NoError(t, err)
+	})
+
+	t.Run("GateNotDeclared_Ignored", func(t *testing.T) {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default", UID: "uid-1"},
+			Spec: corev1.PodSpec{
+				ReadinessGates: []corev1.PodReadinessGate{
+					{ConditionType: "meridio-2.nordix.org/ipv4-connectivity"},
+				},
+			},
+		}
+		fakeClient := fake.NewClientBuilder().
+			WithObjects(pod).
+			WithStatusSubresource(pod).
+			Build()
+
+		mgr := NewConnectivityGateManager(fakeClient, "test-pod", "default", "uid-1", 100*time.Millisecond)
+		_ = mgr.DiscoverGates(context.Background())
+		_ = mgr.SetAllGatesFalse(context.Background())
+
+		// IPv6 connectivity changes but IPv6 gate not declared — should be ignored
+		err := mgr.OnStatusUpdate(context.Background(), false, true)
+		assert.NoError(t, err)
+
+		// Only IPv4 condition should exist (set to False by SetAllGatesFalse)
+		updated := &corev1.Pod{}
+		_ = fakeClient.Get(context.Background(), types.NamespacedName{Name: "test-pod", Namespace: "default"}, updated)
+		assert.Len(t, updated.Status.Conditions, 1)
+		assert.Equal(t, corev1.PodConditionType(ReadinessGateIPv4), updated.Status.Conditions[0].Type)
 	})
 }

--- a/internal/controller/router/connectivity_test.go
+++ b/internal/controller/router/connectivity_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -233,4 +234,108 @@ func TestDiscoverGates(t *testing.T) {
 			assert.Equal(t, tt.wantIPv6Gate, mgr.HasIPv6Gate())
 		})
 	}
+}
+
+func TestPatchGateCondition(t *testing.T) {
+	t.Run("SetsConditionTrue", func(t *testing.T) {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default", UID: "uid-1"},
+			Spec: corev1.PodSpec{
+				ReadinessGates: []corev1.PodReadinessGate{
+					{ConditionType: "meridio-2.nordix.org/ipv4-connectivity"},
+				},
+			},
+		}
+		fakeClient := fake.NewClientBuilder().
+			WithObjects(pod).
+			WithStatusSubresource(pod).
+			Build()
+
+		mgr := NewConnectivityGateManager(fakeClient, "test-pod", "default", "uid-1", 10*time.Second)
+		err := mgr.patchGateCondition(context.Background(), ReadinessGateIPv4, true)
+		assert.NoError(t, err)
+
+		// Verify condition was set
+		updated := &corev1.Pod{}
+		err = fakeClient.Get(context.Background(), types.NamespacedName{Name: "test-pod", Namespace: "default"}, updated)
+		assert.NoError(t, err)
+
+		var found bool
+		for _, c := range updated.Status.Conditions {
+			if c.Type == corev1.PodConditionType(ReadinessGateIPv4) {
+				assert.Equal(t, corev1.ConditionTrue, c.Status)
+				found = true
+			}
+		}
+		assert.True(t, found, "condition should be set")
+	})
+
+	t.Run("SetsConditionFalse", func(t *testing.T) {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default", UID: "uid-1"},
+			Spec: corev1.PodSpec{
+				ReadinessGates: []corev1.PodReadinessGate{
+					{ConditionType: "meridio-2.nordix.org/ipv6-connectivity"},
+				},
+			},
+		}
+		fakeClient := fake.NewClientBuilder().
+			WithObjects(pod).
+			WithStatusSubresource(pod).
+			Build()
+
+		mgr := NewConnectivityGateManager(fakeClient, "test-pod", "default", "uid-1", 10*time.Second)
+		err := mgr.patchGateCondition(context.Background(), ReadinessGateIPv6, false)
+		assert.NoError(t, err)
+
+		updated := &corev1.Pod{}
+		err = fakeClient.Get(context.Background(), types.NamespacedName{Name: "test-pod", Namespace: "default"}, updated)
+		assert.NoError(t, err)
+
+		var found bool
+		for _, c := range updated.Status.Conditions {
+			if c.Type == corev1.PodConditionType(ReadinessGateIPv6) {
+				assert.Equal(t, corev1.ConditionFalse, c.Status)
+				found = true
+			}
+		}
+		assert.True(t, found, "condition should be set")
+	})
+
+	t.Run("UpdatesExistingCondition", func(t *testing.T) {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default", UID: "uid-1"},
+			Spec: corev1.PodSpec{
+				ReadinessGates: []corev1.PodReadinessGate{
+					{ConditionType: "meridio-2.nordix.org/ipv4-connectivity"},
+				},
+			},
+			Status: corev1.PodStatus{
+				Conditions: []corev1.PodCondition{
+					{
+						Type:   corev1.PodConditionType(ReadinessGateIPv4),
+						Status: corev1.ConditionFalse,
+					},
+				},
+			},
+		}
+		fakeClient := fake.NewClientBuilder().
+			WithObjects(pod).
+			WithStatusSubresource(pod).
+			Build()
+
+		mgr := NewConnectivityGateManager(fakeClient, "test-pod", "default", "uid-1", 10*time.Second)
+		err := mgr.patchGateCondition(context.Background(), ReadinessGateIPv4, true)
+		assert.NoError(t, err)
+
+		updated := &corev1.Pod{}
+		err = fakeClient.Get(context.Background(), types.NamespacedName{Name: "test-pod", Namespace: "default"}, updated)
+		assert.NoError(t, err)
+
+		for _, c := range updated.Status.Conditions {
+			if c.Type == corev1.PodConditionType(ReadinessGateIPv4) {
+				assert.Equal(t, corev1.ConditionTrue, c.Status)
+			}
+		}
+	})
 }

--- a/internal/controller/router/connectivity_test.go
+++ b/internal/controller/router/connectivity_test.go
@@ -1,0 +1,236 @@
+/*
+Copyright (c) 2026 OpenInfra Foundation Europe. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package router
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	meridio2v1alpha1 "github.com/nordix/meridio-2/api/v1alpha1"
+	"github.com/nordix/meridio-2/internal/bird"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestClassifyConnectivityByFamily(t *testing.T) {
+	tests := []struct {
+		name      string
+		protocols []bird.ProtocolStatus
+		familyMap map[string]string // protocolName → "IPv4"/"IPv6"
+		wantIPv4  bool
+		wantIPv6  bool
+	}{
+		{
+			name: "dual-stack both established",
+			protocols: []bird.ProtocolStatus{
+				{Name: "NBR-gw-v4", State: bird.ProtocolStateUp, Info: "Established"},
+				{Name: "NBR-gw-v6", State: bird.ProtocolStateUp, Info: "Established"},
+			},
+			familyMap: map[string]string{"NBR-gw-v4": "IPv4", "NBR-gw-v6": "IPv6"},
+			wantIPv4:  true, wantIPv6: true,
+		},
+		{
+			name: "IPv4 up, IPv6 down",
+			protocols: []bird.ProtocolStatus{
+				{Name: "NBR-gw-v4", State: bird.ProtocolStateUp, Info: "Established"},
+				{Name: "NBR-gw-v6", State: bird.ProtocolStateDown, Info: "Connection closed"},
+			},
+			familyMap: map[string]string{"NBR-gw-v4": "IPv4", "NBR-gw-v6": "IPv6"},
+			wantIPv4:  true, wantIPv6: false,
+		},
+		{
+			name: "IPv6 up, IPv4 down",
+			protocols: []bird.ProtocolStatus{
+				{Name: "NBR-gw-v4", State: bird.ProtocolStateDown, Info: "Connection closed"},
+				{Name: "NBR-gw-v6", State: bird.ProtocolStateUp, Info: "Established"},
+			},
+			familyMap: map[string]string{"NBR-gw-v4": "IPv4", "NBR-gw-v6": "IPv6"},
+			wantIPv4:  false, wantIPv6: true,
+		},
+		{
+			name: "both down",
+			protocols: []bird.ProtocolStatus{
+				{Name: "NBR-gw-v4", State: bird.ProtocolStateDown, Info: "Connection closed"},
+				{Name: "NBR-gw-v6", State: bird.ProtocolStateDown, Info: "Connection closed"},
+			},
+			familyMap: map[string]string{"NBR-gw-v4": "IPv4", "NBR-gw-v6": "IPv6"},
+			wantIPv4:  false, wantIPv6: false,
+		},
+		{
+			name: "unknown protocol ignored",
+			protocols: []bird.ProtocolStatus{
+				{Name: "NBR-unknown", State: bird.ProtocolStateUp, Info: "Established"},
+			},
+			familyMap: map[string]string{},
+			wantIPv4:  false, wantIPv6: false,
+		},
+		{
+			name: "multiple IPv4 peers, one established suffices",
+			protocols: []bird.ProtocolStatus{
+				{Name: "NBR-gw1", State: bird.ProtocolStateDown, Info: "Connection closed"},
+				{Name: "NBR-gw2", State: bird.ProtocolStateUp, Info: "Established"},
+			},
+			familyMap: map[string]string{"NBR-gw1": "IPv4", "NBR-gw2": "IPv4"},
+			wantIPv4:  true, wantIPv6: false,
+		},
+		{
+			name:      "empty protocols",
+			protocols: []bird.ProtocolStatus{},
+			familyMap: map[string]string{},
+			wantIPv4:  false, wantIPv6: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ipv4, ipv6 := classifyConnectivityByFamily(tt.protocols, tt.familyMap)
+			assert.Equal(t, tt.wantIPv4, ipv4, "IPv4 connectivity")
+			assert.Equal(t, tt.wantIPv6, ipv6, "IPv6 connectivity")
+		})
+	}
+}
+
+func TestBuildFamilyMap(t *testing.T) {
+	tests := []struct {
+		name     string
+		routers  []*meridio2v1alpha1.GatewayRouter
+		expected map[string]string
+	}{
+		{
+			name: "IPv4 router",
+			routers: []*meridio2v1alpha1.GatewayRouter{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "gw-v4"},
+					Spec:       meridio2v1alpha1.GatewayRouterSpec{Address: "169.254.100.150"},
+				},
+			},
+			expected: map[string]string{"NBR-gw-v4": "IPv4"},
+		},
+		{
+			name: "IPv6 router",
+			routers: []*meridio2v1alpha1.GatewayRouter{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "gw-v6"},
+					Spec:       meridio2v1alpha1.GatewayRouterSpec{Address: "100:100::150"},
+				},
+			},
+			expected: map[string]string{"NBR-gw-v6": "IPv6"},
+		},
+		{
+			name: "dual-stack two routers",
+			routers: []*meridio2v1alpha1.GatewayRouter{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "gw-v4"},
+					Spec:       meridio2v1alpha1.GatewayRouterSpec{Address: "169.254.100.150"},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "gw-v6"},
+					Spec:       meridio2v1alpha1.GatewayRouterSpec{Address: "100:100::150"},
+				},
+			},
+			expected: map[string]string{"NBR-gw-v4": "IPv4", "NBR-gw-v6": "IPv6"},
+		},
+		{
+			name:     "empty routers",
+			routers:  []*meridio2v1alpha1.GatewayRouter{},
+			expected: map[string]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := buildFamilyMap(tt.routers)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestDiscoverGates(t *testing.T) {
+	tests := []struct {
+		name         string
+		pod          *corev1.Pod
+		wantIPv4Gate bool
+		wantIPv6Gate bool
+	}{
+		{
+			name: "both gates declared",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+				Spec: corev1.PodSpec{
+					ReadinessGates: []corev1.PodReadinessGate{
+						{ConditionType: "meridio-2.nordix.org/ipv4-connectivity"},
+						{ConditionType: "meridio-2.nordix.org/ipv6-connectivity"},
+					},
+				},
+			},
+			wantIPv4Gate: true,
+			wantIPv6Gate: true,
+		},
+		{
+			name: "only IPv4 declared",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+				Spec: corev1.PodSpec{
+					ReadinessGates: []corev1.PodReadinessGate{
+						{ConditionType: "meridio-2.nordix.org/ipv4-connectivity"},
+					},
+				},
+			},
+			wantIPv4Gate: true,
+			wantIPv6Gate: false,
+		},
+		{
+			name: "only IPv6 declared",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+				Spec: corev1.PodSpec{
+					ReadinessGates: []corev1.PodReadinessGate{
+						{ConditionType: "meridio-2.nordix.org/ipv6-connectivity"},
+					},
+				},
+			},
+			wantIPv4Gate: false,
+			wantIPv6Gate: true,
+		},
+		{
+			name: "no gates declared",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+				Spec:       corev1.PodSpec{},
+			},
+			wantIPv4Gate: false,
+			wantIPv6Gate: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeClient := fake.NewClientBuilder().
+				WithObjects(tt.pod).
+				Build()
+
+			mgr := NewConnectivityGateManager(fakeClient, tt.pod.Name, tt.pod.Namespace, tt.pod.UID, 10*time.Second)
+			err := mgr.DiscoverGates(context.Background())
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantIPv4Gate, mgr.HasIPv4Gate())
+			assert.Equal(t, tt.wantIPv6Gate, mgr.HasIPv6Gate())
+		})
+	}
+}

--- a/internal/controller/router/constants.go
+++ b/internal/controller/router/constants.go
@@ -1,0 +1,6 @@
+package router
+
+const (
+	ReadinessGateIPv4 = "meridio-2.nordix.org/ipv4-connectivity"
+	ReadinessGateIPv6 = "meridio-2.nordix.org/ipv6-connectivity"
+)

--- a/test/e2e/e2e_suite_readiness_gates_test.go
+++ b/test/e2e/e2e_suite_readiness_gates_test.go
@@ -1,0 +1,255 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright (c) 2026 OpenInfra Foundation Europe. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"os/exec"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+const (
+	rgNamespace      = "e2e-common-appnet"
+	rgGatewayName    = "gw-b1"
+	rgGateIPv4       = "meridio-2.nordix.org/ipv4-connectivity"
+	rgGateIPv6       = "meridio-2.nordix.org/ipv6-connectivity"
+	rgGatewayLabel   = "gateway.networking.k8s.io/gateway-name"
+)
+
+var _ = Describe("Readiness Gates", Serial, Ordered, func() {
+	var (
+		clientset *kubernetes.Clientset
+		lbPods    []corev1.Pod
+	)
+
+	BeforeAll(func() {
+		config, err := clientcmd.BuildConfigFromFlags("", clientcmd.RecommendedHomeFile)
+		Expect(err).NotTo(HaveOccurred())
+		clientset, err = kubernetes.NewForConfig(config)
+		Expect(err).NotTo(HaveOccurred())
+
+		pods, err := clientset.CoreV1().Pods(rgNamespace).List(context.Background(), metav1.ListOptions{
+			LabelSelector: rgGatewayLabel + "=" + rgGatewayName,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(pods.Items).NotTo(BeEmpty(), "No LB Pods found for gateway %s", rgGatewayName)
+		lbPods = pods.Items
+	})
+
+	It("LB Pods should have readiness gates declared in spec", func() {
+		for _, pod := range lbPods {
+			var hasIPv4Gate bool
+			for _, gate := range pod.Spec.ReadinessGates {
+				if string(gate.ConditionType) == rgGateIPv4 {
+					hasIPv4Gate = true
+				}
+			}
+			Expect(hasIPv4Gate).To(BeTrue(),
+				"Pod %s missing readiness gate %s", pod.Name, rgGateIPv4)
+		}
+	})
+
+	It("LB Pods should have ipv4-connectivity condition True after BGP establishes", func() {
+		// The gate should already be True by this point — deployment succeeded which
+		// requires Pod readiness (including gates). Eventually is used defensively for
+		// CI timing edge cases, but typically passes on first poll.
+		for _, pod := range lbPods {
+			Eventually(func() corev1.ConditionStatus {
+				p, err := clientset.CoreV1().Pods(rgNamespace).Get(context.Background(), pod.Name, metav1.GetOptions{})
+				if err != nil {
+					return corev1.ConditionFalse
+				}
+				for _, c := range p.Status.Conditions {
+					if string(c.Type) == rgGateIPv4 {
+						return c.Status
+					}
+				}
+				return corev1.ConditionFalse
+			}).WithTimeout(30 * time.Second).WithPolling(1 * time.Second).
+				Should(Equal(corev1.ConditionTrue),
+					"Pod %s gate %s should be True", pod.Name, rgGateIPv4)
+		}
+	})
+
+	It("ENC next-hops should include all healthy LB Pod IPs", func() {
+		// Get LB Pod IPs on the internal subnet (from network-status annotation)
+		lbIPs := getLBPodNetworkIPs(rgNamespace, rgGatewayName)
+		Expect(lbIPs).NotTo(BeEmpty(), "No LB Pod IPs found")
+
+		// Get a target Pod's ENC and extract next-hops for this Gateway
+		targetPods, err := clientset.CoreV1().Pods(rgNamespace).List(context.Background(), metav1.ListOptions{
+			LabelSelector: "app=target-b",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(targetPods.Items).NotTo(BeEmpty())
+		targetPod := targetPods.Items[0].Name
+
+		Eventually(func() []string {
+			return getENCNextHops(rgNamespace, targetPod, rgGatewayName)
+		}).WithTimeout(30 * time.Second).WithPolling(2 * time.Second).
+			Should(ContainElements(lbIPs),
+				"ENC next-hops should contain all LB Pod IPs")
+	})
+
+	It("should exclude LB Pod from next-hops when BGP drops", func() {
+		disruptedPod := lbPods[0].Name
+
+		// Get the IP of the disrupted Pod on the internal network
+		podIP := getSinglePodNetworkIP(rgNamespace, disruptedPod, "net-b")
+		Expect(podIP).NotTo(BeEmpty())
+
+		// Disable BGP on the disrupted Pod
+		cmd := exec.Command("kubectl", "exec", "-n", rgNamespace, disruptedPod,
+			"-c", "router", "--", "birdc", "-s", "/var/run/bird/bird.ctl", "disable", "all")
+		out, err := cmd.CombinedOutput()
+		Expect(err).NotTo(HaveOccurred(), "birdc disable failed: %s", string(out))
+
+		// Get a target Pod for ENC lookup
+		targetPods, err := clientset.CoreV1().Pods(rgNamespace).List(context.Background(), metav1.ListOptions{
+			LabelSelector: "app=target-b",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		targetPod := targetPods.Items[0].Name
+
+		// Verify disrupted Pod IP is excluded from ENC next-hops
+		Eventually(func() []string {
+			return getENCNextHops(rgNamespace, targetPod, rgGatewayName)
+		}).WithTimeout(30 * time.Second).WithPolling(2 * time.Second).
+			ShouldNot(ContainElement(podIP),
+				"Disrupted Pod IP should be excluded from next-hops")
+
+		// Re-enable BGP to restore state
+		cmd = exec.Command("kubectl", "exec", "-n", rgNamespace, disruptedPod,
+			"-c", "router", "--", "birdc", "-s", "/var/run/bird/bird.ctl", "enable", "all")
+		_, _ = cmd.CombinedOutput()
+
+		// Wait for gate to recover (BGP + hold time)
+		Eventually(func() []string {
+			return getENCNextHops(rgNamespace, targetPod, rgGatewayName)
+		}).WithTimeout(30 * time.Second).WithPolling(2 * time.Second).
+			Should(ContainElement(podIP),
+				"Pod IP should be re-included after BGP recovery")
+	})
+})
+
+// getLBPodNetworkIPs returns the internal network IPs of LB Pods for a gateway.
+func getLBPodNetworkIPs(namespace, gatewayName string) []string {
+	// Get pod names first, then fetch network-status per pod
+	cmd := exec.Command("kubectl", "get", "pods", "-n", namespace,
+		"-l", rgGatewayLabel+"="+gatewayName,
+		"-o", "jsonpath={.items[*].metadata.name}")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil
+	}
+
+	var ips []string
+	for _, podName := range strings.Fields(string(out)) {
+		netCmd := exec.Command("kubectl", "get", "pod", podName, "-n", namespace,
+			"-o", `jsonpath={.metadata.annotations.k8s\.v1\.cni\.cncf\.io/network-status}`)
+		netOut, err := netCmd.CombinedOutput()
+		if err != nil {
+			continue
+		}
+		var networks []struct {
+			Interface string   `json:"interface"`
+			IPs       []string `json:"ips"`
+		}
+		if err := json.Unmarshal(netOut, &networks); err != nil {
+			continue
+		}
+		for _, net := range networks {
+			if net.Interface == "net-b" {
+				ips = append(ips, net.IPs...)
+			}
+		}
+	}
+	return ips
+}
+
+
+// getSinglePodNetworkIP returns the IP of a specific Pod on a given interface.
+func getSinglePodNetworkIP(namespace, podName, iface string) string {
+	cmd := exec.Command("kubectl", "get", "pod", podName, "-n", namespace,
+		"-o", `jsonpath={.metadata.annotations.k8s\.v1\.cni\.cncf\.io/network-status}`)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return ""
+	}
+	var networks []struct {
+		Interface string   `json:"interface"`
+		IPs       []string `json:"ips"`
+	}
+	if err := json.Unmarshal(out, &networks); err != nil {
+		return ""
+	}
+	for _, net := range networks {
+		if net.Interface == iface && len(net.IPs) > 0 {
+			return net.IPs[0]
+		}
+	}
+	return ""
+}
+// getENCNextHops returns the next-hops from an ENC for a specific gateway.
+func getENCNextHops(namespace, encName, gatewayName string) []string {
+	cmd := exec.Command("kubectl", "get", "endpointnetworkconfigurations.meridio-2.nordix.org",
+		encName, "-n", namespace, "-o", "json")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil
+	}
+
+	var enc struct {
+		Spec struct {
+			Gateways []struct {
+				Name    string `json:"name"`
+				Domains []struct {
+					NextHops []string `json:"nextHops"`
+				} `json:"domains"`
+			} `json:"gateways"`
+		} `json:"spec"`
+	}
+	if err := json.Unmarshal(out, &enc); err != nil {
+		return nil
+	}
+
+	var hops []string
+	for _, gw := range enc.Spec.Gateways {
+		if gw.Name == gatewayName {
+			for _, domain := range gw.Domains {
+				hops = append(hops, domain.NextHops...)
+			}
+		}
+	}
+	return hops
+}
+
+
+


### PR DESCRIPTION
Closes follow-up issue of #174 relates to Readiness Gates issue: #99

### Objective

Verify end-to-end that the three-step readiness gate feature works:

1. Gateway controller declares gates on LB Pods
2. Router sets gate conditions based on BGP state
3. ENC controller filters next-hops by gate conditions

Reuse: common-appnetwork suite (2 Gateways, 2 replicas each, BGP hold time 24s)

### CI Integration

The tests use Serial + Ordered (same as resiliency tests) and live in e2e_suite_readiness_gates_test.go. They run after traffic tests.

Run with: --focus='Readiness Gates'

### Test Cases

1. Gates declared in spec
2. Gates True after BGP
3. ENC next-hops include all healthy LB IPs
4. BGP drop excludes Pod + recovery re-includes it
5. LB Pod Deletion → Immediate Exclusion

## Timeouts

| Event | Expected duration |
|-------|-------------------|
| BGP drop detection | < 1s (BFD enabled, 300ms intervals, multiplier 3) |
| Gate → False after drop | < 2s (immediate + 1 tick) |
| BGP re-establishment | ~3-5s (connect + hold handshake) |
| Gate → True after recovery | BGP time + 3s hold + 1 tick ≈ 8s |
| ENC reconcile after gate change | < 5s (watch trigger) |
| **Total test timeout per scenario** | 60s (generous for CI) |

## Local Execution

```bash
# Build images with readiness gate code
make controller-manager stateless-load-balancer router network-sidecar example-target

# Deploy common-appnetwork
make -C test/e2e deploy-common-appnetwork

# Run only readiness gate tests
cd test/e2e && go run github.com/onsi/ginkgo/v2/ginkgo -v --tags=e2e --focus="Readiness Gates"
```
