### PR TITLE
RBAC: add pods list/watch and pods/status to LB ServiceAccount

### DIFF
--- a/config/rbac/lb-serviceaccount.yaml
+++ b/config/rbac/lb-serviceaccount.yaml
@@ -51,13 +51,16 @@ rules:
   - get
   - list
   - watch
-# Router controller patches its own Pod status (readiness gates)
+# Router controller needs to read its own Pod (readiness gates) and
+# uses controller-runtime cache which requires list+watch.
 - apiGroups:
   - ""
   resources:
   - pods
   verbs:
   - get
+  - list
+  - watch
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
The router controller uses controller-runtime cache to read its own Pod for readiness gate management. The cache requires list+watch permissions in addition to get. Also adds pods/status update+patch for setting readiness gate conditions.

Without this, all e2e tests fail because the router cannot start its informer cache (forbidden error on pod list).

Fixes: gh-122