### PR TITLE
Rename LB deployment prefix from sllb- to sllbr-

### DIFF
--- a/docs/controllers/gateway.md
+++ b/docs/controllers/gateway.md
@@ -14,7 +14,7 @@ The Gateway controller manages the lifecycle of Gateway API Gateway resources, c
 
 **GatewayConfiguration**: Implementation-specific parameters (replicas, resources, network attachments) referenced via `Gateway.spec.infrastructure.parametersRef`.
 
-**LB Deployment**: A Kubernetes Deployment running load balancer and router containers. Named `sllb-<gateway-name>` and owned by the Gateway via ownerReference.
+**LB Deployment**: A Kubernetes Deployment running load balancer and router containers. Named `sllbr-<gateway-name>` and owned by the Gateway via ownerReference.
 
 ### Design Principles
 
@@ -129,11 +129,11 @@ LB Deployment (owned by Gateway)
 ### 6. Reconcile LB Deployment
 - Use pre-fetched template and GatewayConfiguration from step 3
 - Customize for this Gateway:
-  - Name: `sllb-<gateway-name>`
+  - Name: `sllbr-<gateway-name>`
   - Namespace: same as Gateway
-  - Labels: `app=sllb-<gateway-name>`, `gateway.networking.k8s.io/gateway-name=<gateway-name>`
+  - Labels: `app=sllbr-<gateway-name>`, `gateway.networking.k8s.io/gateway-name=<gateway-name>`
   - ServiceAccount: from `--lb-service-account` flag (injected by Kustomize)
-  - Selector: `app=sllb-<gateway-name>` (immutable)
+  - Selector: `app=sllbr-<gateway-name>` (immutable)
   - Anti-affinity: updated to match deployment-specific labels
   - Gateway name injection: `MERIDIO_GATEWAY_NAME` env var in containers
 - Merge `spec.infrastructure.labels` and `spec.infrastructure.annotations`
@@ -182,7 +182,7 @@ The controller injects Gateway identity into LB pod containers via environment v
 The controller applies labels/annotations in three layers with specific precedence:
 
 1. **Controller-managed labels** (always enforced, highest priority):
-   - `app: sllb-<gateway-name>` - Used for selector (immutable) and pod anti-affinity
+   - `app: sllbr-<gateway-name>` - Used for selector (immutable) and pod anti-affinity
    - `gateway.networking.k8s.io/gateway-name: <gateway-name>` - Gateway API standard label
 
 2. **Gateway infrastructure labels/annotations** (user-controlled, middle priority):
@@ -449,7 +449,7 @@ networkAttachments:
 - User must resolve conflict (rename/delete conflicting Deployment or Gateway)
 
 **Naming enforcement:**
-- Controller uses strict name-based lookup: `sllb-<gateway-name>`
+- Controller uses strict name-based lookup: `sllbr-<gateway-name>`
 - No label-based fallback (ensures consistent naming for external tools like HPA)
 - If Deployment is manually renamed, controller creates new Deployment with correct name
 - Old Deployment remains orphaned (manual cleanup required)
@@ -732,12 +732,12 @@ kubectl -n meridio-2 get gateway test-gateway -o jsonpath='{.status.conditions[?
 # Expected: status=True, reason=Programmed
 
 # Deployment exists with ownerReference
-kubectl -n meridio-2 get deployment sllb-test-gateway \
+kubectl -n meridio-2 get deployment sllbr-test-gateway \
   -o jsonpath='{.metadata.ownerReferences[0].kind}/{.metadata.ownerReferences[0].name}'
 # Expected: Gateway/test-gateway
 
 # ServiceAccount from controller flag
-kubectl -n meridio-2 get deployment sllb-test-gateway -o jsonpath='{.spec.template.spec.serviceAccountName}'
+kubectl -n meridio-2 get deployment sllbr-test-gateway -o jsonpath='{.spec.template.spec.serviceAccountName}'
 # Expected: stateless-load-balancer (or whatever --lb-service-account is set to)
 ```
 
@@ -745,23 +745,23 @@ kubectl -n meridio-2 get deployment sllb-test-gateway -o jsonpath='{.spec.templa
 
 ```bash
 # NAD annotation present on pod template with both interfaces
-kubectl -n meridio-2 get deployment sllb-test-gateway \
+kubectl -n meridio-2 get deployment sllbr-test-gateway \
   -o jsonpath='{.spec.template.metadata.annotations.k8s\.v1\.cni\.cncf\.io/networks}'
 # Expected: JSON array containing vlan-100 (interface: ext1) and macvlan-net1 (interface: net1)
 
 # Capture current pod names before NAD change
-PODS_BEFORE=$(kubectl -n meridio-2 get pods -l app=sllb-test-gateway -o jsonpath='{.items[*].metadata.name}')
+PODS_BEFORE=$(kubectl -n meridio-2 get pods -l app=sllbr-test-gateway -o jsonpath='{.items[*].metadata.name}')
 
 # Remove one NAD from GatewayConfiguration
 kubectl -n meridio-2 patch gatewayconfiguration test-gwconfig --type=json \
   -p '[{"op":"replace","path":"/spec/networkAttachments","value":[{"type":"NAD","nad":{"name":"vlan-100","namespace":"meridio-2","interface":"ext1"}}]}]'
 sleep 10
-kubectl -n meridio-2 get deployment sllb-test-gateway \
+kubectl -n meridio-2 get deployment sllbr-test-gateway \
   -o jsonpath='{.spec.template.metadata.annotations.k8s\.v1\.cni\.cncf\.io/networks}'
 # Expected: JSON array containing only vlan-100 (macvlan-net1 removed)
 
 # Verify pods were recreated (NAD change modifies pod template → rolling update)
-PODS_AFTER=$(kubectl -n meridio-2 get pods -l app=sllb-test-gateway -o jsonpath='{.items[*].metadata.name}')
+PODS_AFTER=$(kubectl -n meridio-2 get pods -l app=sllbr-test-gateway -o jsonpath='{.items[*].metadata.name}')
 [ "$PODS_BEFORE" != "$PODS_AFTER" ] && echo "PASS: pods recreated" || echo "FAIL: pods unchanged"
 
 # Restore both NADs
@@ -773,13 +773,13 @@ kubectl -n meridio-2 patch gatewayconfiguration test-gwconfig --type=json \
 
 ```bash
 # Replicas match GatewayConfiguration
-kubectl -n meridio-2 get deployment sllb-test-gateway -o jsonpath='{.spec.replicas}'
+kubectl -n meridio-2 get deployment sllbr-test-gateway -o jsonpath='{.spec.replicas}'
 # Expected: 2
 
 # Manually scale - controller should revert
-kubectl -n meridio-2 scale deployment sllb-test-gateway --replicas=5
+kubectl -n meridio-2 scale deployment sllbr-test-gateway --replicas=5
 sleep 3
-kubectl -n meridio-2 get deployment sllb-test-gateway -o jsonpath='{.spec.replicas}'
+kubectl -n meridio-2 get deployment sllbr-test-gateway -o jsonpath='{.spec.replicas}'
 # Expected: 2 (controller enforces)
 ```
 
@@ -792,9 +792,9 @@ kubectl -n meridio-2 patch gatewayconfiguration test-gwconfig --type=merge \
 sleep 3
 
 # Manually scale - controller should NOT revert
-kubectl -n meridio-2 scale deployment sllb-test-gateway --replicas=5
+kubectl -n meridio-2 scale deployment sllbr-test-gateway --replicas=5
 sleep 3
-kubectl -n meridio-2 get deployment sllb-test-gateway -o jsonpath='{.spec.replicas}'
+kubectl -n meridio-2 get deployment sllbr-test-gateway -o jsonpath='{.spec.replicas}'
 # Expected: 5 (controller defers to external scaler)
 
 # Restore enforcing mode
@@ -806,12 +806,12 @@ kubectl -n meridio-2 patch gatewayconfiguration test-gwconfig --type=merge \
 
 ```bash
 # Loadbalancer container resources match GatewayConfiguration
-kubectl -n meridio-2 get deployment sllb-test-gateway \
+kubectl -n meridio-2 get deployment sllbr-test-gateway \
   -o jsonpath='{.spec.template.spec.containers[?(@.name=="loadbalancer")].resources}'
 # Expected: requests.cpu=200m, requests.memory=256Mi, limits.cpu=1, limits.memory=1Gi
 
 # Router container keeps template defaults (not in verticalScaling)
-kubectl -n meridio-2 get deployment sllb-test-gateway \
+kubectl -n meridio-2 get deployment sllbr-test-gateway \
   -o jsonpath='{.spec.template.spec.containers[?(@.name=="router")].resources}'
 # Expected: template defaults (requests.cpu=100m, requests.memory=128Mi, etc.)
 
@@ -819,7 +819,7 @@ kubectl -n meridio-2 get deployment sllb-test-gateway \
 kubectl -n meridio-2 patch gatewayconfiguration test-gwconfig --type=json \
   -p '[{"op":"replace","path":"/spec/verticalScaling/containers","value":[{"name":"loadbalancer","enforceResources":true,"resources":{"requests":{"cpu":"500m","memory":"512Mi"},"limits":{"cpu":"2","memory":"2Gi"}}}]}]'
 sleep 3
-kubectl -n meridio-2 get deployment sllb-test-gateway \
+kubectl -n meridio-2 get deployment sllbr-test-gateway \
   -o jsonpath='{.spec.template.spec.containers[?(@.name=="loadbalancer")].resources.requests.cpu}'
 # Expected: 500m
 ```
@@ -833,7 +833,7 @@ kubectl -n meridio-2 patch gatewayconfiguration test-gwconfig --type=json \
 sleep 3
 
 # Resources should remain at previous values (controller defers)
-kubectl -n meridio-2 get deployment sllb-test-gateway \
+kubectl -n meridio-2 get deployment sllbr-test-gateway \
   -o jsonpath='{.spec.template.spec.containers[?(@.name=="loadbalancer")].resources.requests.cpu}'
 # Expected: 500m (unchanged, controller does not enforce)
 ```
@@ -990,7 +990,7 @@ kubectl -n meridio-2 get gateway test-gateway 2>&1 | grep "NotFound"
 # Expected: deleted immediately (no Terminating state)
 
 sleep 5
-kubectl -n meridio-2 get deployment sllb-test-gateway 2>&1 | grep "NotFound"
+kubectl -n meridio-2 get deployment sllbr-test-gateway 2>&1 | grep "NotFound"
 # Expected: Deployment auto-deleted via ownerReference
 ```
 
@@ -1054,7 +1054,7 @@ kubectl delete net-attach-def vlan-100 macvlan-net1 -n meridio-2 --ignore-not-fo
 metadata:
   labels:
     gateway.networking.k8s.io/gateway-name: <gateway-name>  # Gateway API standard
-    app: sllb-<gateway-name>                                # Deployment selector
+    app: sllbr-<gateway-name>                                # Deployment selector
     app.kubernetes.io/managed-by: gateway-controller.meridio-2.nordix.org  # Operator identity
 ```
 
@@ -1074,7 +1074,7 @@ metadata:
   labels:
     # Existing (implemented)
     gateway.networking.k8s.io/gateway-name: <gateway-name>
-    app: sllb-<gateway-name>
+    app: sllbr-<gateway-name>
     app.kubernetes.io/managed-by: gateway-controller.meridio-2.nordix.org
     
     # Add for better compliance

--- a/docs/controllers/sidecar.md
+++ b/docs/controllers/sidecar.md
@@ -673,7 +673,7 @@ kubectl -n meridio-2 get gateway test-gateway \
   -o jsonpath='{.status.conditions[?(@.type=="Accepted")].status}'
 # Expected: True
 
-kubectl -n meridio-2 get deployment sllb-test-gateway
+kubectl -n meridio-2 get deployment sllbr-test-gateway
 ```
 
 #### Test 2: Verify EndpointSlices
@@ -708,7 +708,7 @@ TARGET_POD_UID=$(kubectl get pod -n meridio-2 "$TARGET_POD" \
 # Collect LB pod net1 IPs for ECMP next-hops
 LB_NET1_IPv4=()
 LB_NET1_IPv6=()
-for LB_POD in $(kubectl get pods -n meridio-2 -l app=sllb-test-gateway \
+for LB_POD in $(kubectl get pods -n meridio-2 -l app=sllbr-test-gateway \
   -o jsonpath='{.items[*].metadata.name}'); do
   NET_STATUS=$(kubectl get pod -n meridio-2 "$LB_POD" \
     -o jsonpath='{.metadata.annotations.k8s\.v1\.cni\.cncf\.io/network-status}')

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -60,7 +60,7 @@ kubectl get pods -n <namespace>
 
 Expected Pods:
 - **controller-manager** — 1 Pod, 1/1 Ready
-- **sllb-\<gateway-name\>** — LB Pods (2 containers each: `loadbalancer` + `router`), count matches `GatewayConfiguration.spec.horizontalScaling.replicas` (default: 2) unless HPA is managing the Deployment (`enforceReplicas: false`)
+- **sllbr-\<gateway-name\>** — LB Pods (2 containers each: `loadbalancer` + `router`), count matches `GatewayConfiguration.spec.horizontalScaling.replicas` (default: 2) unless HPA is managing the Deployment (`enforceReplicas: false`)
 - **Application Pods** — with network-sidecar container if using EndpointNetworkConfiguration
 
 All Pods should be Running with all containers ready. Check for restarts.
@@ -102,10 +102,10 @@ Both containers drop all capabilities and add only what's needed:
 
 Verify file capabilities on the binaries:
 ```bash
-kubectl exec -n <ns> <sllb-pod> -c loadbalancer -- getcap /app/stateless-load-balancer
+kubectl exec -n <ns> <sllbr-pod> -c loadbalancer -- getcap /app/stateless-load-balancer
 # Expected: /app/stateless-load-balancer cap_net_admin,cap_ipc_lock,cap_ipc_owner=ep
 
-kubectl exec -n <ns> <sllb-pod> -c router -- getcap /app/router
+kubectl exec -n <ns> <sllbr-pod> -c router -- getcap /app/router
 # Expected: /app/router cap_net_admin,cap_net_bind_service,cap_net_raw=ep
 ```
 
@@ -126,7 +126,7 @@ Both containers run with `readOnlyRootFilesystem: true` and require emptyDir vol
 
 Verify mounts:
 ```bash
-kubectl get pod -n <ns> <sllb-pod> -o jsonpath='{.spec.containers[*].volumeMounts}' | jq .
+kubectl get pod -n <ns> <sllbr-pod> -o jsonpath='{.spec.containers[*].volumeMounts}' | jq .
 ```
 
 ## Logs
@@ -137,15 +137,15 @@ Check logs with:
 kubectl logs -n <ns> <controller-manager-pod>
 
 # LB Pod containers
-kubectl logs -n <ns> <sllb-pod> -c loadbalancer
-kubectl logs -n <ns> <sllb-pod> -c router
+kubectl logs -n <ns> <sllbr-pod> -c loadbalancer
+kubectl logs -n <ns> <sllbr-pod> -c router
 ```
 
 Meridio-2 uses structured JSON logging via controller-runtime's zap logger.
 
 BIRD logs are not sent to stdout — they are written to a file inside the router container. To view BIRD logs:
 ```bash
-kubectl exec -n <ns> <sllb-pod> -c router -- cat /var/log/bird/bird.log
+kubectl exec -n <ns> <sllbr-pod> -c router -- cat /var/log/bird/bird.log
 ```
 The log file path and size limit are configurable via `MERIDIO_BIRD_LOG_FILE` and `MERIDIO_BIRD_LOG_FILE_SIZE`.
 
@@ -240,7 +240,7 @@ The router container runs BIRD 3.x for BGP session management.
 ### Check BIRD is running
 
 ```bash
-kubectl exec -n <ns> <sllb-pod> -c router -- birdc -s /var/run/bird/bird.ctl show status
+kubectl exec -n <ns> <sllbr-pod> -c router -- birdc -s /var/run/bird/bird.ctl show status
 ```
 
 If BIRD is not running, `birdc` will fail with `Cannot connect to BIRD control socket`. Check the router container logs for startup errors. See also limitation about BIRD error propagation missing — the router controller does not crash if BIRD fails.
@@ -248,7 +248,7 @@ If BIRD is not running, `birdc` will fail with `Cannot connect to BIRD control s
 ### Check BGP session status
 
 ```bash
-kubectl exec -n <ns> <sllb-pod> -c router -- birdc -s /var/run/bird/bird.ctl show protocols
+kubectl exec -n <ns> <sllbr-pod> -c router -- birdc -s /var/run/bird/bird.ctl show protocols
 ```
 
 Expected output shows BGP sessions in `Established` state:
@@ -273,8 +273,8 @@ If sessions are `DOWN` or `Active`, check:
 ### Check advertised VIP routes
 
 ```bash
-kubectl exec -n <ns> <sllb-pod> -c router -- birdc -s /var/run/bird/bird.ctl show route protocol VIP4
-kubectl exec -n <ns> <sllb-pod> -c router -- birdc -s /var/run/bird/bird.ctl show route protocol VIP6
+kubectl exec -n <ns> <sllbr-pod> -c router -- birdc -s /var/run/bird/bird.ctl show route protocol VIP4
+kubectl exec -n <ns> <sllbr-pod> -c router -- birdc -s /var/run/bird/bird.ctl show route protocol VIP6
 ```
 
 VIPs should appear as static routes on `lo` exported to BGP peers.
@@ -282,19 +282,19 @@ VIPs should appear as static routes on `lo` exported to BGP peers.
 ### Check routes learned from BGP peers
 
 ```bash
-kubectl exec -n <ns> <sllb-pod> -c router -- birdc -s /var/run/bird/bird.ctl show protocols
+kubectl exec -n <ns> <sllbr-pod> -c router -- birdc -s /var/run/bird/bird.ctl show protocols
 ```
 
 Use the BGP protocol names from the output (e.g., `NBR-gateway-router-v4`) to check learned routes:
 ```bash
-kubectl exec -n <ns> <sllb-pod> -c router -- birdc -s /var/run/bird/bird.ctl 'show route where proto = "NBR-gateway-router-v4"'
+kubectl exec -n <ns> <sllbr-pod> -c router -- birdc -s /var/run/bird/bird.ctl 'show route where proto = "NBR-gateway-router-v4"'
 ```
 
 ### Check kernel routing table
 
 BGP-learned routes (default routes from external gateways) should appear in kernel table 4096:
 ```bash
-kubectl exec -n <ns> <sllb-pod> -c router -- ip route show table 4096
+kubectl exec -n <ns> <sllbr-pod> -c router -- ip route show table 4096
 # Expected: default via <gateway-ip> dev <ext-interface> proto bird
 ```
 
@@ -303,7 +303,7 @@ If routes are missing or delayed (up to 60 seconds), this may be the BIRD 3.x sc
 ### Check policy routing rules
 
 ```bash
-kubectl exec -n <ns> <sllb-pod> -c router -- ip rule
+kubectl exec -n <ns> <sllbr-pod> -c router -- ip rule
 ```
 
 Expected rules for VIP source-based routing:
@@ -321,7 +321,7 @@ Expected rules for VIP source-based routing:
 
 IP forwarding must be enabled in the LB Pod's network namespace for traffic to be forwarded to/from targets:
 ```bash
-kubectl exec -n <ns> <sllb-pod> -c loadbalancer -- sysctl net.ipv4.conf.all.forwarding net.ipv6.conf.all.forwarding
+kubectl exec -n <ns> <sllbr-pod> -c loadbalancer -- sysctl net.ipv4.conf.all.forwarding net.ipv6.conf.all.forwarding
 # Expected: net.ipv4.conf.all.forwarding = 1
 #           net.ipv6.conf.all.forwarding = 1
 ```
@@ -329,7 +329,7 @@ kubectl exec -n <ns> <sllb-pod> -c loadbalancer -- sysctl net.ipv4.conf.all.forw
 ### Check nftables
 
 ```bash
-kubectl exec -n <ns> <sllb-pod> -c loadbalancer -- nft list ruleset
+kubectl exec -n <ns> <sllbr-pod> -c loadbalancer -- nft list ruleset
 ```
 
 Example output:
@@ -385,7 +385,7 @@ Note: `nft` requires `NET_ADMIN` and `allowPrivilegeEscalation: true` as explain
 
 Verify that NFQLB is listening on the expected queues:
 ```bash
-kubectl exec -n <ns> <sllb-pod> -c loadbalancer -- cat /proc/net/netfilter/nfnetlink_queue
+kubectl exec -n <ns> <sllbr-pod> -c loadbalancer -- cat /proc/net/netfilter/nfnetlink_queue
 ```
 
 Example output:
@@ -401,7 +401,7 @@ The first column is the queue number (0-3 matching the nftables `queue to 0-3` r
 ### Check NFQLB shared memory instances
 
 ```bash
-kubectl exec -n <ns> <sllb-pod> -c loadbalancer -- nfqlb show --shm=tshm-<dg-name>
+kubectl exec -n <ns> <sllbr-pod> -c loadbalancer -- nfqlb show --shm=tshm-<dg-name>
 ```
 
 Example output:
@@ -428,7 +428,7 @@ Shm: tshm-test-backend-indirect
 ### Check NFQLB flows
 
 ```bash
-kubectl exec -n <ns> <sllb-pod> -c loadbalancer -- nfqlb flow-list
+kubectl exec -n <ns> <sllbr-pod> -c loadbalancer -- nfqlb flow-list
 ```
 
 Example output:
@@ -464,8 +464,8 @@ Each flow corresponds to an L34Route. The `name` is `tshm-<dg-name>-<route-name>
 ### Check fwmark routing to targets
 
 ```bash
-kubectl exec -n <ns> <sllb-pod> -c loadbalancer -- ip rule
-kubectl exec -n <ns> <sllb-pod> -c loadbalancer -- ip route show table <fwmark>
+kubectl exec -n <ns> <sllbr-pod> -c loadbalancer -- ip rule
+kubectl exec -n <ns> <sllbr-pod> -c loadbalancer -- ip route show table <fwmark>
 ```
 
 Each active target per DistributionGroup should have:
@@ -474,7 +474,7 @@ Each active target per DistributionGroup should have:
 
 Verify target IPs are reachable:
 ```bash
-kubectl exec -n <ns> <sllb-pod> -c loadbalancer -- ping -c1 -W1 <target-ip>
+kubectl exec -n <ns> <sllbr-pod> -c loadbalancer -- ping -c1 -W1 <target-ip>
 ```
 Note: `ping` requires `NET_RAW` and `allowPrivilegeEscalation: true` as explained. Alternatively, use nsenter instead.
 

--- a/hack/vpn-gateway/Dockerfile
+++ b/hack/vpn-gateway/Dockerfile
@@ -9,12 +9,17 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libreadline-dev \
     wget \
     ca-certificates \
+    autoconf \
+    automake \
+    libtool \
+    m4 \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /tmp
-RUN wget https://bird.network.cz/download/bird-3.1.2.tar.gz \
-    && tar -xzf bird-3.1.2.tar.gz \
-    && cd bird-3.1.2 \
+RUN wget https://gitlab.nic.cz/labs/bird/-/archive/v3.1.2/bird-v3.1.2.tar.gz \
+    && tar -xzf bird-v3.1.2.tar.gz \
+    && cd bird-v3.1.2 \
+    && autoreconf -i \
     && ./configure \
     && make -j$(nproc) \
     && make install

--- a/internal/controller/endpointnetworkconfiguration/resolve_test.go
+++ b/internal/controller/endpointnetworkconfiguration/resolve_test.go
@@ -285,7 +285,7 @@ func TestGetSLLBRNextHops(t *testing.T) {
 	gw := acceptedGateway("sllb-a", testControllerName)
 	sllbrPod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "sllb-sllb-a-abc",
+			Name:      "sllbr-sllb-a-abc",
 			Namespace: testNamespace,
 			Labels:    map[string]string{labelGatewayName: "sllb-a"},
 		},
@@ -294,7 +294,7 @@ func TestGetSLLBRNextHops(t *testing.T) {
 
 	r, _ := setupReconciler(gw, sllbrPod)
 	r.IPScraper = func(pod *corev1.Pod, cidr, attachmentType string) string {
-		if pod.Name == "sllb-sllb-a-abc" && cidr == testSubnetV4 {
+		if pod.Name == "sllbr-sllb-a-abc" && cidr == testSubnetV4 {
 			return testNextHopV4
 		}
 		return ""
@@ -314,7 +314,7 @@ func TestBuildGatewayConnection_SkipsDomainWithNoInterface(t *testing.T) {
 	gc := newGatewayConfig([]string{testSubnetV4, "fd00:100::/64"})
 	sllbrPod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "sllb-sllb-a-abc",
+			Name:      "sllbr-sllb-a-abc",
 			Namespace: testNamespace,
 			Labels:    map[string]string{labelGatewayName: "sllb-a"},
 		},
@@ -355,7 +355,7 @@ func TestBuildGatewayConnection_NamingConvention(t *testing.T) {
 	gc := newGatewayConfig([]string{testSubnetV4, "fd00:100::/64"})
 	sllbrPod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "sllb-sllb-a-abc",
+			Name:      "sllbr-sllb-a-abc",
 			Namespace: testNamespace,
 			Labels:    map[string]string{labelGatewayName: "sllb-a"},
 		},
@@ -424,7 +424,7 @@ func TestResolveGatewayConnections_FullChain(t *testing.T) {
 	dg := newDG("dg-1", map[string]string{"app": "web"}, "sllb-a")
 	sllbrPod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "sllb-sllb-a-abc",
+			Name:      "sllbr-sllb-a-abc",
 			Namespace: testNamespace,
 			Labels:    map[string]string{labelGatewayName: "sllb-a"},
 		},
@@ -529,7 +529,7 @@ func TestSidecarContract_DualStack(t *testing.T) {
 	dg := newDG("dg-1", map[string]string{"app": "web"}, "sllb-a")
 	sllbrPod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "sllb-sllb-a-abc",
+			Name:      "sllbr-sllb-a-abc",
 			Namespace: testNamespace,
 			Labels:    map[string]string{labelGatewayName: "sllb-a"},
 		},

--- a/internal/controller/gateway/const.go
+++ b/internal/controller/gateway/const.go
@@ -34,7 +34,7 @@ const (
 	yamlDecoderBufferSize = 4096
 
 	// LB Deployment naming
-	lbDeploymentPrefix = "sllb-"
+	lbDeploymentPrefix = "sllbr-"
 	// LBDeploymentTemplateFile is the filename for the LB Deployment template
 	LBDeploymentTemplateFile = "lb-deployment.yaml"
 

--- a/internal/controller/gateway/deployment_test.go
+++ b/internal/controller/gateway/deployment_test.go
@@ -40,16 +40,16 @@ func TestLbDeploymentName(t *testing.T) {
 
 	name := lbDeploymentName(gw)
 
-	assert.Equal(t, "sllb-my-gateway", name)
+	assert.Equal(t, "sllbr-my-gateway", name)
 }
 
 func TestSetControllerLabels(t *testing.T) {
 	t.Run("SetsRequiredLabels", func(t *testing.T) {
 		meta := &metav1.ObjectMeta{}
 
-		setControllerLabels(meta, "sllb-test", "test-gw")
+		setControllerLabels(meta, "sllbr-test", "test-gw")
 
-		assert.Equal(t, "sllb-test", meta.Labels["app"])
+		assert.Equal(t, "sllbr-test", meta.Labels["app"])
 		assert.Equal(t, "test-gw", meta.Labels[labelGatewayName])
 		assert.Equal(t, managedByValue, meta.Labels[labelManagedBy])
 	})
@@ -57,7 +57,7 @@ func TestSetControllerLabels(t *testing.T) {
 	t.Run("InitializesLabelsMapIfNil", func(t *testing.T) {
 		meta := &metav1.ObjectMeta{Labels: nil}
 
-		setControllerLabels(meta, "sllb-test", "test-gw")
+		setControllerLabels(meta, "sllbr-test", "test-gw")
 
 		assert.NotNil(t, meta.Labels)
 		assert.Len(t, meta.Labels, 3)
@@ -68,7 +68,7 @@ func TestSetControllerLabels(t *testing.T) {
 			Labels: map[string]string{"existing": "label"},
 		}
 
-		setControllerLabels(meta, "sllb-test", "test-gw")
+		setControllerLabels(meta, "sllbr-test", "test-gw")
 
 		assert.Equal(t, "label", meta.Labels["existing"])
 		assert.Len(t, meta.Labels, 4)
@@ -248,10 +248,10 @@ func TestReconcileLBDeployment(t *testing.T) {
 		var deployment appsv1.Deployment
 		err = fakeClient.Get(context.Background(), client.ObjectKey{
 			Namespace: gw.Namespace,
-			Name:      "sllb-" + gw.Name,
+			Name:      lbDeploymentPrefix + gw.Name,
 		}, &deployment)
 		assert.NoError(t, err)
-		assert.Equal(t, "sllb-"+gw.Name, deployment.Name)
+		assert.Equal(t, lbDeploymentPrefix+gw.Name, deployment.Name)
 		assert.Equal(t, "template-value", deployment.Labels["template-label"])
 		assert.Equal(t, gw.Name, deployment.Labels[labelGatewayName])
 	})
@@ -267,7 +267,7 @@ func TestReconcileLBDeployment(t *testing.T) {
 
 		existing := &appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "sllb-" + gw.Name,
+				Name:      lbDeploymentPrefix + gw.Name,
 				Namespace: gw.Namespace,
 				Labels: map[string]string{
 					"template-label": "old-value",
@@ -288,7 +288,7 @@ func TestReconcileLBDeployment(t *testing.T) {
 			Spec: appsv1.DeploymentSpec{
 				Replicas: ptr(int32(1)),
 				Selector: &metav1.LabelSelector{
-					MatchLabels: map[string]string{"app": "sllb-" + gw.Name},
+					MatchLabels: map[string]string{"app": lbDeploymentPrefix + gw.Name},
 				},
 			},
 		}
@@ -301,7 +301,7 @@ func TestReconcileLBDeployment(t *testing.T) {
 		var deployment appsv1.Deployment
 		err = fakeClient.Get(context.Background(), client.ObjectKey{
 			Namespace: gw.Namespace,
-			Name:      "sllb-" + gw.Name,
+			Name:      lbDeploymentPrefix + gw.Name,
 		}, &deployment)
 		assert.NoError(t, err)
 		assert.Equal(t, "new-value", deployment.Labels["template-label"])
@@ -363,7 +363,7 @@ func TestReconcileLBDeployment(t *testing.T) {
 
 		var deployment appsv1.Deployment
 		err = fakeClient.Get(context.Background(), client.ObjectKey{
-			Namespace: gw.Namespace, Name: "sllb-" + gw.Name,
+			Namespace: gw.Namespace, Name: lbDeploymentPrefix + gw.Name,
 		}, &deployment)
 		assert.NoError(t, err)
 		assert.Equal(t, []corev1.PodReadinessGate{
@@ -387,7 +387,7 @@ func TestReconcileLBDeployment(t *testing.T) {
 
 		var deployment appsv1.Deployment
 		err = fakeClient.Get(context.Background(), client.ObjectKey{
-			Namespace: gw.Namespace, Name: "sllb-" + gw.Name,
+			Namespace: gw.Namespace, Name: lbDeploymentPrefix + gw.Name,
 		}, &deployment)
 		assert.NoError(t, err)
 		assert.Equal(t, []corev1.PodReadinessGate{
@@ -413,7 +413,7 @@ func TestReconcileLBDeployment(t *testing.T) {
 
 		var deployment appsv1.Deployment
 		err = fakeClient.Get(context.Background(), client.ObjectKey{
-			Namespace: gw.Namespace, Name: "sllb-" + gw.Name,
+			Namespace: gw.Namespace, Name: lbDeploymentPrefix + gw.Name,
 		}, &deployment)
 		assert.NoError(t, err)
 

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -133,7 +133,7 @@ cluster-cleanup: ## Cleanup cluster dependencies.
 ################################################################################
 
 # deploy-suite: Deploy a test suite
-# Args: $(1)=namespace, $(2)=suite-dir, $(3)=suite-label, $(4)=sllb-deployments
+# Args: $(1)=namespace, $(2)=suite-dir, $(3)=suite-label, $(4)=sllbr-deployments
 define deploy-suite
 	@NS=$(1); \
 	SUITE_DIR=$(2); \
@@ -193,7 +193,7 @@ common-appnetwork: deploy-common-appnetwork test-common-appnetwork ## Deploy and
 
 .PHONY: deploy-common-appnetwork
 deploy-common-appnetwork: cluster ## Deploy common-appnetwork topology.
-	$(call deploy-suite,e2e-common-appnet,$(shell pwd)/suites/common-appnetwork,common-appnet,sllb-gw-b1 sllb-gw-b2)
+	$(call deploy-suite,e2e-common-appnet,$(shell pwd)/suites/common-appnetwork,common-appnet,sllbr-gw-b1 sllbr-gw-b2)
 
 .PHONY: test-common-appnetwork
 test-common-appnetwork: ## Run e2e tests for common-appnetwork suite.
@@ -214,7 +214,7 @@ separate-appnetwork: deploy-separate-appnetwork test-separate-appnetwork ## Depl
 
 .PHONY: deploy-separate-appnetwork
 deploy-separate-appnetwork: cluster ## Deploy separate-appnetwork topology.
-	$(call deploy-suite,e2e-separate-appnet,$(shell pwd)/suites/separate-appnetwork,separate-appnet,sllb-gw-a1 sllb-gw-a2)
+	$(call deploy-suite,e2e-separate-appnet,$(shell pwd)/suites/separate-appnetwork,separate-appnet,sllbr-gw-a1 sllbr-gw-a2)
 
 .PHONY: test-separate-appnetwork
 test-separate-appnetwork: ## Run e2e tests for separate-appnetwork suite.
@@ -235,7 +235,7 @@ sctp-multihoming: deploy-sctp-multihoming test-sctp-multihoming ## Deploy and te
 
 .PHONY: deploy-sctp-multihoming
 deploy-sctp-multihoming: cluster ## Deploy sctp-multihoming topology.
-	$(call deploy-suite,e2e-sctp-multihoming,$(shell pwd)/suites/sctp-multihoming,sctp-multihoming,sllb-sctp-gw1 sllb-sctp-gw2)
+	$(call deploy-suite,e2e-sctp-multihoming,$(shell pwd)/suites/sctp-multihoming,sctp-multihoming,sllbr-sctp-gw1 sllbr-sctp-gw2)
 
 .PHONY: test-sctp-multihoming
 test-sctp-multihoming: ## Run e2e tests for sctp-multihoming suite.
@@ -256,7 +256,7 @@ low-mtu: deploy-low-mtu test-low-mtu ## Deploy and test low-mtu suite.
 
 .PHONY: deploy-low-mtu
 deploy-low-mtu: cluster ## Deploy low-mtu topology.
-	$(call deploy-suite,e2e-low-mtu,$(shell pwd)/suites/low-mtu,low-mtu,sllb-gw-m1)
+	$(call deploy-suite,e2e-low-mtu,$(shell pwd)/suites/low-mtu,low-mtu,sllbr-gw-m1)
 
 .PHONY: test-low-mtu
 test-low-mtu: ## Run e2e tests for low-mtu suite.


### PR DESCRIPTION
## Description

Renames the LB deployment prefix from sllb- to sllbr- to reflect that pods contain both the Stateless Load Balancer and the Router components.

SLLBR = Stateless Load Balancer + Router

## Issue
#166

## Changes

### Core Implementation
- Updated lbDeploymentPrefix constant: "sllb-" → "sllbr-"
- Deployment names now follow pattern: sllbr-<gateway-name>
- Pod names: sllbr-<gateway-name>-<hash>
- Labels automatically updated via dynamic construction: app: sllbr-<gateway-name>

### Testing
- Gateway controller tests updated
- ENC controller tests updated (LB pod references)
- E2E test Makefile updated (all suite deployment names)
- All tests passing

### Documentation
- Updated troubleshooting guide
- Updated gateway controller docs
- Updated sidecar controller docs
- Updated review documents