### PR TITLE
Pod cache label filtering (controller-manager)

### DIFF
--- a/cmd/controller-manager/cmd/run.go
+++ b/cmd/controller-manager/cmd/run.go
@@ -21,10 +21,12 @@ import (
 	"crypto/tls"
 	goflag "flag"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -87,6 +89,13 @@ func NewRunCmd() *cobra.Command {
 
 			if cfg.CertWaitTimeout > time.Minute {
 				return fmt.Errorf("--cert-wait-timeout cannot exceed 1 minute (got %s)", cfg.CertWaitTimeout)
+			}
+
+			if cfg.PodCacheLabel != "" {
+				k, v, ok := strings.Cut(cfg.PodCacheLabel, "=")
+				if !ok || k == "" || v == "" || strings.Contains(v, "=") {
+					return fmt.Errorf("--pod-cache-label must be in key=value format, got %q", cfg.PodCacheLabel)
+				}
 			}
 
 			return nil
@@ -183,6 +192,18 @@ func runManager(cfg *config.ManagerConfig) error {
 		}
 	}
 
+	// Parse pod cache label once (already validated in PreRunE)
+	var podCacheLabelKey, podCacheLabelValue string
+	if cfg.PodCacheLabel != "" {
+		podCacheLabelKey, podCacheLabelValue, _ = strings.Cut(cfg.PodCacheLabel, "=")
+		if cacheOptions.ByObject == nil {
+			cacheOptions.ByObject = map[client.Object]cache.ByObject{}
+		}
+		cacheOptions.ByObject[&corev1.Pod{}] = cache.ByObject{
+			Label: labels.SelectorFromSet(labels.Set{podCacheLabelKey: podCacheLabelValue}),
+		}
+	}
+
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                        scheme,
 		Cache:                         cacheOptions,
@@ -209,12 +230,14 @@ func runManager(cfg *config.ManagerConfig) error {
 	}
 
 	if err = (&gateway.GatewayReconciler{
-		Client:           mgr.GetClient(),
-		Scheme:           mgr.GetScheme(),
-		ControllerName:   cfg.ControllerName,
-		Namespace:        cfg.Namespace,
-		TemplatePath:     cfg.TemplatePath,
-		LBServiceAccount: cfg.LBServiceAccount,
+		Client:             mgr.GetClient(),
+		Scheme:             mgr.GetScheme(),
+		ControllerName:     cfg.ControllerName,
+		Namespace:          cfg.Namespace,
+		TemplatePath:       cfg.TemplatePath,
+		LBServiceAccount:   cfg.LBServiceAccount,
+		PodCacheLabelKey:   podCacheLabelKey,
+		PodCacheLabelValue: podCacheLabelValue,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Gateway")
 		return err

--- a/docs/operations/pod-cache-filtering.md
+++ b/docs/operations/pod-cache-filtering.md
@@ -1,0 +1,81 @@
+# Pod Cache Filtering
+
+## Overview
+
+The controller-manager can be configured to only cache Pods that carry a specific label. This reduces memory usage and event processing overhead in namespaces with many unrelated Pods.
+
+When enabled, only Pods with the configured label are visible to the controller-manager's informer cache. All controllers (DG, ENC, Gateway) operate exclusively on labeled Pods. Unlabeled Pods are invisible — no events, no List/Get results.
+
+## Configuration
+
+| Flag | Env Var | Default | Description |
+|---|---|---|---|
+| `--pod-cache-label` | `MERIDIO_POD_CACHE_LABEL` | _(empty, disabled)_ | Label `key=value` for Pod cache filtering. Empty disables filtering (all Pods cached). |
+
+Example:
+```bash
+--pod-cache-label=meridio-2.nordix.org/managed=true
+```
+
+When set, the controller-manager:
+1. Configures the informer cache with the label selector for Pods
+2. Adds the label to LB Deployment pod templates (LB Pods inherit it automatically via rolling update)
+
+## Requirements
+
+- **Application Pods** must have the label in their pod template. The label is a documented requirement alongside existing DG selector labels.
+- **LB Pods** receive the label automatically via the Deployment template (managed by the Gateway controller).
+
+## Upgrade Procedure
+
+When enabling pod cache filtering on an existing deployment:
+
+1. **Pre-label all relevant Pods** before upgrading the controller-manager:
+   ```bash
+   # Label application Pods
+   kubectl label pods -l <app-selector> -n <namespace> meridio-2.nordix.org/managed=true
+
+   # Label existing LB Pods (avoids transient invisibility during rollout)
+   kubectl label pods -l gateway.networking.k8s.io/gateway-name -n <namespace> meridio-2.nordix.org/managed=true
+   ```
+   Direct Pod labeling does not trigger Deployment rollouts.
+
+2. **Upgrade the controller-manager** with `--pod-cache-label` set.
+
+3. **LB Pods** rolling update proceeds — the controller-manager updates the Deployment template with the label. Pre-labeled old Pods remain visible throughout; new Pods inherit the label from the template.
+
+If pre-labeling is skipped:
+- Application Pods without the label will not have ENCs created/updated. Existing ENCs become stale (ownerReference GC won't fire because the Pod still exists).
+- LB Pods without the label are invisible during rollout (not included in ENC next-hop lists), causing brief degradation until replaced by new labeled Pods.
+- The DG controller incidentally removes unlabeled application Pods from EndpointSlices during the LB rollout (new LB Pods trigger the DG Pod mapper → reconciliation lists only labeled Pods).
+
+## Disabling the Feature
+
+Setting `--pod-cache-label` to empty (or removing it) restores the default behavior: all Pods in the namespace are cached.
+
+Note: the label applied to the LB Deployment template is additive. The controller-manager does not remove previously-configured labels from the template when the feature is disabled, since both key and value are user-defined and the controller has no record of what was previously set. The lingering label is harmless but can be removed manually from the LB Deployment template if desired.
+
+## Operational Constraints
+
+The cache label is a **hard contract**:
+
+- Do not remove the label from running application Pods. If removed:
+  - The DG controller removes the Pod from EndpointSlices (triggered by the synthetic Delete event from the filtered watch)
+  - The ENC becomes orphaned (stale content, not garbage-collected because the Pod still exists)
+
+- If runtime label removal is intentional, follow this order:
+  1. Remove the DG selector label(s) first (while the Pod is still visible). This triggers proper ENC cleanup.
+  2. Then remove the cache label.
+
+- If the DG label removal was missed, delete the stale ENC manually:
+  ```bash
+  kubectl delete enc <pod-name> -n <namespace>
+  ```
+
+## When to Use
+
+The optimization is beneficial when:
+- The namespace has many Pods unrelated to Meridio (e.g., 500 Pods, only 10 managed by Meridio)
+- Pod churn is high in the namespace (frequent creates/deletes of unrelated Pods)
+
+When most Pods in the namespace are Meridio-managed, the benefit is minimal and the operational overhead of labeling may not be justified.

--- a/examples/target/deployment/helm/templates/target.yaml
+++ b/examples/target/deployment/helm/templates/target.yaml
@@ -74,7 +74,7 @@ spec:
               screen -d -m bash -c "./ctraffic -server -address [::]:5002" ;
               screen -d -m bash -c "./ctraffic -server -udp -address [::]:5100" ;
               screen -d -m bash -c "./ctraffic -server -udp -address [::]:5101" ;
-              tail -f /dev/null
+              trap 'exit 0' TERM; sleep infinity & wait
           securityContext:
             runAsNonRoot: true
             capabilities:

--- a/hack/vpn-gateway/bird-gw.conf
+++ b/hack/vpn-gateway/bird-gw.conf
@@ -104,3 +104,14 @@ protocol bgp GW4_M1 from LINK {
 		export filter bgp_announce;
 	};
 }
+
+# pod-cache-label gw-pcl peers on VLAN 800 (ASN 64519)
+protocol bgp GW4_PCL from LINK {
+	local 169.254.103.150 port 10179 as 4200000000;
+	neighbor range 0.0.0.0/0 port 10179 as 64519;
+	dynamic name "GW4_PCL_";
+	ipv4 {
+		import all;
+		export filter bgp_announce;
+	};
+}

--- a/hack/vpn-gateway/init.sh
+++ b/hack/vpn-gateway/init.sh
@@ -47,6 +47,11 @@ ip addr add 200.50.0.100/32 dev vlan7
 
 ethtool -K eth0 tx off
 
-echo "VPN Gateway ready on VLAN 100, 200, 300, 400, 500, 600, 700"
+# VLAN 800 — pod-cache-label gw-pcl
+ip link add link eth0 name vlan8 type vlan id 800
+ip link set vlan8 up
+ip addr add 169.254.103.150/24 dev vlan8
+
+echo "VPN Gateway ready on VLAN 100, 200, 300, 400, 500, 600, 700, 800"
 
 /usr/sbin/bird -d -c /etc/bird/bird-gw.conf

--- a/internal/bird/bird.go
+++ b/internal/bird/bird.go
@@ -17,6 +17,7 @@ limitations under the License.
 package bird
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
@@ -172,13 +173,7 @@ func (b *Bird) generateConfig(vips []string, routers []*meridio2v1alpha1.Gateway
 	}
 
 	slices.SortFunc(routers, func(a, b *meridio2v1alpha1.GatewayRouter) int {
-		if a.Name < b.Name {
-			return -1
-		}
-		if a.Name > b.Name {
-			return 1
-		}
-		return 0
+		return cmp.Compare(a.Name, b.Name)
 	})
 
 	ifset := make(map[string]bool)

--- a/internal/common/config/manager.go
+++ b/internal/common/config/manager.go
@@ -45,6 +45,9 @@ type ManagerConfig struct {
 	// Features
 	EnableTopologyHints bool
 
+	// Filtering
+	PodCacheLabel string
+
 	// Templates
 	TemplatePath string
 
@@ -90,6 +93,9 @@ func (c *ManagerConfig) AddFlags(fs *pflag.FlagSet) {
 		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
 	fs.BoolVar(&c.EnableTopologyHints, "enable-topology-hints", false,
 		"Enable Node watching for topology-aware endpoint hints. Requires RBAC permissions for nodes.")
+	fs.StringVar(&c.PodCacheLabel, "pod-cache-label", "",
+		"Label key=value to filter Pods in the informer cache (e.g., meridio-2.nordix.org/managed=true). "+
+			"When set, only Pods with this label are cached. Empty means all Pods are cached.")
 	fs.StringVar(&c.TemplatePath, "template-path", "/templates",
 		"Path to template directory containing deployment templates.")
 	fs.StringVar(&c.LBServiceAccount, "lb-service-account", "stateless-load-balancer",
@@ -129,6 +135,7 @@ func (c *ManagerConfig) BindEnv(fs *pflag.FlagSet) {
 	bindBool(fs, "metrics-secure", "MERIDIO_METRICS_SECURE", &c.SecureMetrics)
 	bindBool(fs, "enable-http2", "MERIDIO_ENABLE_HTTP2", &c.EnableHTTP2)
 	bindBool(fs, "enable-topology-hints", "MERIDIO_ENABLE_TOPOLOGY_HINTS", &c.EnableTopologyHints)
+	bindString(fs, "pod-cache-label", "MERIDIO_POD_CACHE_LABEL", &c.PodCacheLabel)
 	bindString(fs, "template-path", "MERIDIO_TEMPLATE_PATH", &c.TemplatePath)
 	bindString(fs, "lb-service-account", "MERIDIO_LB_SERVICE_ACCOUNT", &c.LBServiceAccount)
 	bindInt(fs, "webhook-port", "MERIDIO_WEBHOOK_PORT", &c.WebhookPort)

--- a/internal/controller/distributiongroup/controller.go
+++ b/internal/controller/distributiongroup/controller.go
@@ -99,7 +99,7 @@ func (r *DistributionGroupReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		log.Error(err, "failed to list matching pods")
 		return ctrl.Result{}, err
 	}
-	log.Info("found matching pods", "count", len(pods))
+	log.Info("matching pods", "count", len(pods))
 
 	// 4. If no Pods, delete all owned EndpointSlices and update status
 	if len(pods) == 0 {

--- a/internal/controller/endpointnetworkconfiguration/controller.go
+++ b/internal/controller/endpointnetworkconfiguration/controller.go
@@ -19,6 +19,7 @@ package endpointnetworkconfiguration
 import (
 	"context"
 	"fmt"
+	"hash/fnv"
 
 	meridio2v1alpha1 "github.com/nordix/meridio-2/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
@@ -64,7 +65,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	var pod corev1.Pod
 	if err := r.Get(ctx, req.NamespacedName, &pod); err != nil {
 		if apierrors.IsNotFound(err) {
-			// Pod deleted → ENC garbage-collected via ownerReference
+			// Pod deleted → ENC garbage-collected via ownerReference.
+			// Note: if pod-cache-label filtering is enabled and the label is removed
+			// at runtime, the Pod is evicted from cache (triggering this path) but
+			// still exists — GC won't fire. Calling deleteENCIfExists here instead
+			// of returning nil would handle that edge case.
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, err
@@ -81,7 +86,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, fmt.Errorf("failed to resolve gateway connections: %w", err)
 	}
 
-	log.V(1).Info("resolved gateway connections", "pod", pod.Name, "gateways", len(gatewayConnections))
+	log.V(1).Info("resolved gateway connections", "pod", pod.Name, "gateways", len(gatewayConnections), "hash", hashConnections(gatewayConnections))
+	log.V(2).Info("gateway connection details", "pod", pod.Name, "connections", gatewayConnections)
 
 	// 4. If no gateway connections, delete ENC if it exists
 	if len(gatewayConnections) == 0 {
@@ -89,13 +95,26 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 
 	// 5. Create or update ENC
-	return ctrl.Result{}, r.reconcileENC(ctx, &pod, gatewayConnections)
+	if err := r.reconcileENC(ctx, &pod, gatewayConnections); err != nil {
+		if apierrors.IsConflict(err) {
+			// Requeue immediately instead of returning error (which triggers exponential backoff).
+			// Conflicts are expected from stale cache reads or concurrent status writers;
+			// fast retry avoids prolonging stale next-hop configuration.
+			return ctrl.Result{Requeue: true}, nil
+		}
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&corev1.Pod{}).
+		For(&corev1.Pod{}, builder.WithPredicates(predicate.NewPredicateFuncs(func(obj client.Object) bool {
+			// ENC reconciliation targets application Pods only; LB Pods are excluded.
+			_, isLBPod := obj.GetLabels()[labelGatewayName]
+			return !isLBPod
+		}))).
 		Owns(&meridio2v1alpha1.EndpointNetworkConfiguration{}).
 		Watches(&meridio2v1alpha1.DistributionGroup{},
 			handler.EnqueueRequestsFromMapFunc(r.mapDGToPods)).
@@ -156,4 +175,15 @@ func (r *Reconciler) deleteENCIfExists(ctx context.Context, key client.ObjectKey
 		return client.IgnoreNotFound(err)
 	}
 	return r.Delete(ctx, &enc)
+}
+
+func hashConnections(connections []meridio2v1alpha1.GatewayConnection) string {
+	if len(connections) == 0 {
+		// Note: FNV-32a can theoretically produce 0 for a non-empty input,
+		// but it's merely a log hint and no logic depends on it.
+		return "0"
+	}
+	h := fnv.New32a()
+	_, _ = fmt.Fprint(h, connections)
+	return fmt.Sprintf("%08x", h.Sum32())
 }

--- a/internal/controller/endpointnetworkconfiguration/resolve.go
+++ b/internal/controller/endpointnetworkconfiguration/resolve.go
@@ -17,10 +17,12 @@ limitations under the License.
 package endpointnetworkconfiguration
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"fmt"
 	"net"
+	"slices"
 	"strings"
 
 	netdefv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
@@ -79,6 +81,11 @@ func (r *Reconciler) resolveGatewayConnections(ctx context.Context, pod *corev1.
 			connections = append(connections, *conn)
 		}
 	}
+	// Sort connections by Gateway name: map iteration order is non-deterministic,
+	// and ordering differences would trigger unnecessary ENC updates.
+	slices.SortFunc(connections, func(a, b meridio2v1alpha1.GatewayConnection) int {
+		return cmp.Compare(a.Name, b.Name)
+	})
 
 	return connections, nil
 }
@@ -142,6 +149,11 @@ func (r *Reconciler) buildGatewayConnection(ctx context.Context, pod *corev1.Pod
 	if len(domains) == 0 {
 		return nil, nil
 	}
+
+	// Sort domains by name: subnetToType map iteration order is non-deterministic.
+	slices.SortFunc(domains, func(a, b meridio2v1alpha1.NetworkDomain) int {
+		return cmp.Compare(a.Name, b.Name)
+	})
 
 	return &meridio2v1alpha1.GatewayConnection{
 		Name:    gw.Name,
@@ -252,6 +264,10 @@ func (r *Reconciler) getSLLBRNextHops(ctx context.Context, gw *gatewayv1.Gateway
 			}
 		}
 	}
+	// Sort for deterministic output: Pod list order from cache is not guaranteed,
+	// and non-deterministic ordering causes unnecessary ENC updates.
+	slices.Sort(ipv4)
+	slices.Sort(ipv6)
 	return ipv4, ipv6, nil
 }
 

--- a/internal/controller/endpointnetworkconfiguration/resolve_test.go
+++ b/internal/controller/endpointnetworkconfiguration/resolve_test.go
@@ -306,6 +306,52 @@ func TestGetSLLBRNextHops(t *testing.T) {
 	assert.Nil(t, ipv6)
 }
 
+func TestGetSLLBRNextHops_DeterministicOrdering(t *testing.T) {
+	gw := acceptedGateway("sllb-a", testControllerName)
+	pod1 := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "sllb-sllb-a-111", Namespace: testNamespace,
+			Labels: map[string]string{labelGatewayName: "sllb-a"},
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+	pod2 := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "sllb-sllb-a-222", Namespace: testNamespace,
+			Labels: map[string]string{labelGatewayName: "sllb-a"},
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+
+	scraper := func(pod *corev1.Pod, cidr, attachmentType string) string {
+		switch pod.Name {
+		case "sllb-sllb-a-111":
+			return "192.168.100.11"
+		case "sllb-sllb-a-222":
+			return "192.168.100.22"
+		}
+		return ""
+	}
+	subnetToType := map[string]string{testSubnetV4: "NAD"}
+
+	// pod1 before pod2
+	r1, _ := setupReconciler(gw, pod1, pod2)
+	r1.IPScraper = scraper
+	ipv4a, _, err := r1.getSLLBRNextHops(context.Background(), gw, subnetToType)
+	require.NoError(t, err)
+
+	// pod2 before pod1 (reversed insertion order)
+	r2, _ := setupReconciler(gw, pod2, pod1)
+	r2.IPScraper = scraper
+	ipv4b, _, err := r2.getSLLBRNextHops(context.Background(), gw, subnetToType)
+	require.NoError(t, err)
+
+	// Both must produce the same sorted result
+	expected := []string{"192.168.100.11", "192.168.100.22"}
+	assert.Equal(t, expected, ipv4a)
+	assert.Equal(t, expected, ipv4b)
+}
+
 // --- buildGatewayConnection tests ---
 
 func TestBuildGatewayConnection_SkipsDomainWithNoInterface(t *testing.T) {
@@ -450,6 +496,69 @@ func TestResolveGatewayConnections_FullChain(t *testing.T) {
 	assert.Equal(t, "net1", connections[0].Domains[0].Network.InterfaceHint)
 	assert.Equal(t, []string{"20.0.0.1"}, connections[0].Domains[0].VIPs)
 	assert.Equal(t, []string{testNextHopV4}, connections[0].Domains[0].NextHops)
+}
+
+func TestResolveGatewayConnections_DeterministicOrdering(t *testing.T) {
+	pod := newPod("app-1", corev1.PodRunning, map[string]string{"app": "web"})
+	pod.Annotations = map[string]string{
+		"k8s.v1.cni.cncf.io/network-status": `[
+			{"name":"default","interface":"eth0","ips":["10.244.0.5"],"default":true},
+			{"name":"nad-1","interface":"net1","ips":["169.111.100.10","fd00::100:10"]}
+		]`,
+	}
+
+	names := []string{"gw-d", "gw-b", "gw-c", "gw-a"}
+	ipv4VIPs := []string{"40.0.0.1", "20.0.0.1", "30.0.0.1", "10.0.0.1"}
+	ipv6VIPs := []string{"2001:db8::4", "2001:db8::2", "2001:db8::3", "2001:db8::1"}
+
+	buildObjects := func(order []int) []client.Object {
+		var objs []client.Object
+		objs = append(objs, pod)
+		for _, i := range order {
+			gw := acceptedGateway(names[i], testControllerName, ipv4VIPs[i], ipv6VIPs[i])
+			gc := newGatewayConfig([]string{testSubnetV4, testSubnetV6})
+			gc.Name = names[i] + "-config"
+			dg := newDG("dg-"+names[i], map[string]string{"app": "web"}, names[i])
+			objs = append(objs, gw, gc, dg)
+		}
+		return objs
+	}
+
+	scraper := func(_ *corev1.Pod, cidr, _ string) string {
+		switch cidr {
+		case testSubnetV4:
+			return testNextHopV4
+		case testSubnetV6:
+			return testNextHopV6
+		}
+		return ""
+	}
+
+	// Two runs with different insertion orders
+	r1, _ := setupReconciler(buildObjects([]int{3, 2, 1, 0})...)
+	r1.IPScraper = scraper
+	conn1, err := r1.resolveGatewayConnections(context.Background(), pod)
+	require.NoError(t, err)
+
+	r2, _ := setupReconciler(buildObjects([]int{1, 3, 0, 2})...)
+	r2.IPScraper = scraper
+	conn2, err := r2.resolveGatewayConnections(context.Background(), pod)
+	require.NoError(t, err)
+
+	// Both must produce same sorted order
+	require.Len(t, conn1, 4)
+	require.Len(t, conn2, 4)
+	expectedGW := []string{"gw-a", "gw-b", "gw-c", "gw-d"}
+	for i, name := range expectedGW {
+		assert.Equal(t, name, conn1[i].Name, "conn1[%d]", i)
+		assert.Equal(t, name, conn2[i].Name, "conn2[%d]", i)
+		// Verify domain ordering (sorted by name within each connection)
+		require.Len(t, conn1[i].Domains, 2, "conn1[%d] domains", i)
+		require.Len(t, conn2[i].Domains, 2, "conn2[%d] domains", i)
+		assert.Equal(t, conn1[i].Domains[0].Name, conn2[i].Domains[0].Name)
+		assert.True(t, conn1[i].Domains[0].Name < conn1[i].Domains[1].Name,
+			"domains should be sorted: %s, %s", conn1[i].Domains[0].Name, conn1[i].Domains[1].Name)
+	}
 }
 
 // --- helper tests ---

--- a/internal/controller/gateway/controller.go
+++ b/internal/controller/gateway/controller.go
@@ -36,11 +36,13 @@ import (
 // GatewayReconciler reconciles a Gateway object
 type GatewayReconciler struct {
 	client.Client
-	Scheme           *runtime.Scheme
-	ControllerName   string
-	Namespace        string // Namespace to watch (empty = all namespaces)
-	TemplatePath     string // Path to template directory (defaults to /templates)
-	LBServiceAccount string // ServiceAccount name for LB Deployment pods
+	Scheme             *runtime.Scheme
+	ControllerName     string
+	Namespace          string // Namespace to watch (empty = all namespaces)
+	TemplatePath       string // Path to template directory (defaults to /templates)
+	LBServiceAccount   string // ServiceAccount name for LB Deployment pods
+	PodCacheLabelKey   string // Optional label key for Pod cache filtering (added to LB Pod template)
+	PodCacheLabelValue string // Corresponding label value
 }
 
 // RBAC: See config/rbac/manager-role.yaml and manager-clusterrole.yaml for required permissions.

--- a/internal/controller/gateway/deployment.go
+++ b/internal/controller/gateway/deployment.go
@@ -75,7 +75,7 @@ func (r *GatewayReconciler) reconcileLBDeployment(ctx context.Context, gw *gatew
 		base = &existing
 	}
 
-	desired := reconcileDeploymentSpec(base, template, gw, gwConfig, deploymentName, r.LBServiceAccount)
+	desired := r.reconcileDeploymentSpec(base, template, gw, gwConfig, deploymentName)
 	if !found {
 		if err := ctrl.SetControllerReference(gw, desired, r.Scheme); err != nil {
 			return fmt.Errorf("failed to set owner reference: %w", err)
@@ -102,20 +102,10 @@ func (r *GatewayReconciler) reconcileLBDeployment(ctx context.Context, gw *gatew
 	return nil
 }
 
-// getControllerOwner returns the controller owner of a Deployment as "Kind/Name"
-func getControllerOwner(deployment *appsv1.Deployment) string {
-	for _, ref := range deployment.OwnerReferences {
-		if ref.Controller != nil && *ref.Controller {
-			return fmt.Sprintf("%s/%s", ref.Kind, ref.Name)
-		}
-	}
-	return "unknown"
-}
-
 // reconcileDeploymentSpec builds desired deployment state (works for both create and update)
 // If base is nil, template is used as starting point (create scenario)
 // If base is provided, it's used as starting point and template fields are merged (update scenario)
-func reconcileDeploymentSpec(base, template *appsv1.Deployment, gw *gatewayv1.Gateway, gwConfig *meridio2v1alpha1.GatewayConfiguration, deploymentName, serviceAccount string) *appsv1.Deployment {
+func (r *GatewayReconciler) reconcileDeploymentSpec(base, template *appsv1.Deployment, gw *gatewayv1.Gateway, gwConfig *meridio2v1alpha1.GatewayConfiguration, deploymentName string) *appsv1.Deployment {
 	var desired *appsv1.Deployment
 
 	if base == nil {
@@ -150,11 +140,12 @@ func reconcileDeploymentSpec(base, template *appsv1.Deployment, gw *gatewayv1.Ga
 	// Set deployment-specific values (always enforced)
 	desired.Name = deploymentName
 	desired.Namespace = gw.Namespace
-	desired.Spec.Template.Spec.ServiceAccountName = serviceAccount
+	desired.Spec.Template.Spec.ServiceAccountName = r.LBServiceAccount
 
 	// Set controller-managed labels
 	setControllerLabels(&desired.ObjectMeta, deploymentName, gw.Name)
 	setControllerLabels(&desired.Spec.Template.ObjectMeta, deploymentName, gw.Name)
+	setPodCacheLabel(&desired.Spec.Template.ObjectMeta, r.PodCacheLabelKey, r.PodCacheLabelValue)
 
 	// Set selector (immutable, but safe to set on every reconcile)
 	desired.Spec.Selector = &metav1.LabelSelector{
@@ -180,6 +171,16 @@ func reconcileDeploymentSpec(base, template *appsv1.Deployment, gw *gatewayv1.Ga
 	injectRouterPodIdentityEnvVars(desired)
 
 	return desired
+}
+
+// getControllerOwner returns the controller owner of a Deployment as "Kind/Name"
+func getControllerOwner(deployment *appsv1.Deployment) string {
+	for _, ref := range deployment.OwnerReferences {
+		if ref.Controller != nil && *ref.Controller {
+			return fmt.Sprintf("%s/%s", ref.Kind, ref.Name)
+		}
+	}
+	return "unknown"
 }
 
 // deploymentNeedsUpdate checks if Deployment needs update using semantic equality
@@ -210,6 +211,17 @@ func setControllerLabels(meta *metav1.ObjectMeta, deploymentName, gatewayName st
 	meta.Labels["app"] = deploymentName
 	meta.Labels[labelGatewayName] = gatewayName
 	meta.Labels[labelManagedBy] = managedByValue
+}
+
+// setPodCacheLabel adds the pod cache filter label to the metadata (if configured).
+func setPodCacheLabel(meta *metav1.ObjectMeta, key, value string) {
+	if key == "" {
+		return
+	}
+	if meta.Labels == nil {
+		meta.Labels = make(map[string]string)
+	}
+	meta.Labels[key] = value
 }
 
 // mergeInfrastructureMetadata merges Gateway.spec.infrastructure labels/annotations

--- a/internal/controller/gateway/deployment_test.go
+++ b/internal/controller/gateway/deployment_test.go
@@ -435,6 +435,45 @@ func TestReconcileLBDeployment(t *testing.T) {
 		assert.Equal(t, "metadata.namespace", envMap["POD_NAMESPACE"].ValueFrom.FieldRef.FieldPath)
 		assert.Equal(t, "metadata.uid", envMap["POD_UID"].ValueFrom.FieldRef.FieldPath)
 	})
+
+	t.Run("SetsPodCacheLabel", func(t *testing.T) {
+		gwClass := newGatewayClass(testControllerName)
+		gw := newGateway(gwClass.Name)
+		gwConfig := newGatewayConfiguration()
+		attachGatewayConfiguration(gw, gwConfig)
+		reconciler, fakeClient := setupReconciler(gwClass, gw, gwConfig)
+		reconciler.PodCacheLabelKey = "meridio-2.nordix.org/managed"
+		reconciler.PodCacheLabelValue = "true"
+
+		err := reconciler.reconcileLBDeployment(context.Background(), gw, gwConfig, template)
+		assert.NoError(t, err)
+
+		var deployment appsv1.Deployment
+		err = fakeClient.Get(context.Background(), client.ObjectKey{
+			Namespace: gw.Namespace, Name: "sllbr-" + gw.Name,
+		}, &deployment)
+		assert.NoError(t, err)
+		assert.Equal(t, "true", deployment.Spec.Template.Labels["meridio-2.nordix.org/managed"])
+	})
+
+	t.Run("NoPodCacheLabel_WhenNotConfigured", func(t *testing.T) {
+		gwClass := newGatewayClass(testControllerName)
+		gw := newGateway(gwClass.Name)
+		gwConfig := newGatewayConfiguration()
+		attachGatewayConfiguration(gw, gwConfig)
+		reconciler, fakeClient := setupReconciler(gwClass, gw, gwConfig)
+
+		err := reconciler.reconcileLBDeployment(context.Background(), gw, gwConfig, template)
+		assert.NoError(t, err)
+
+		var deployment appsv1.Deployment
+		err = fakeClient.Get(context.Background(), client.ObjectKey{
+			Namespace: gw.Namespace, Name: "sllbr-" + gw.Name,
+		}, &deployment)
+		assert.NoError(t, err)
+		_, exists := deployment.Spec.Template.Labels["meridio-2.nordix.org/managed"]
+		assert.False(t, exists)
+	})
 }
 
 func TestInjectGatewayEnvVars(t *testing.T) {

--- a/internal/controller/loadbalancer/targets.go
+++ b/internal/controller/loadbalancer/targets.go
@@ -17,6 +17,7 @@ limitations under the License.
 package loadbalancer
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"slices"
@@ -56,13 +57,7 @@ func (c *Controller) reconcileTargets(ctx context.Context, distGroup *meridio2v1
 	// preventing flapping during transients when the same identifier appears in multiple
 	// slices of the same IP family (e.g., Pod replacement with >100 endpoints).
 	slices.SortFunc(endpointSliceList.Items, func(a, b discoveryv1.EndpointSlice) int {
-		if a.Name < b.Name {
-			return -1
-		}
-		if a.Name > b.Name {
-			return 1
-		}
-		return 0
+		return cmp.Compare(a.Name, b.Name)
 	})
 
 	// Get current targets

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -269,6 +269,27 @@ undeploy-low-mtu: ## Undeploy low-mtu topology.
 	$(KUBECTL) delete namespace $$NS --ignore-not-found=true
 
 ################################################################################
+##@ Pod Cache Label suite
+################################################################################
+
+.PHONY: pod-cache-label
+pod-cache-label: deploy-pod-cache-label test-pod-cache-label ## Deploy and test pod-cache-label suite.
+
+.PHONY: deploy-pod-cache-label
+deploy-pod-cache-label: cluster ## Deploy pod-cache-label topology.
+	$(call deploy-suite,e2e-pod-cache-label,$(shell pwd)/suites/pod-cache-label,pod-cache-label,sllbr-gw-pcl)
+
+.PHONY: test-pod-cache-label
+test-pod-cache-label: ## Run e2e tests for pod-cache-label suite.
+	cd $(PROJECT_ROOT)/test/e2e && go run github.com/onsi/ginkgo/v2/ginkgo -v --tags=e2e --focus="Pod Cache Label" $(GINKGO_FLAGS)
+
+.PHONY: undeploy-pod-cache-label
+undeploy-pod-cache-label: ## Undeploy pod-cache-label topology.
+	@NS=e2e-pod-cache-label; \
+	$(KUBECTL) delete validatingwebhookconfiguration meridio-2-validating-webhook-configuration-pod-cache-label --ignore-not-found=true; \
+	$(KUBECTL) delete namespace $$NS --ignore-not-found=true
+
+################################################################################
 ##@ All suites
 ################################################################################
 

--- a/test/e2e/e2e_suite_podcachelabel_test.go
+++ b/test/e2e/e2e_suite_podcachelabel_test.go
@@ -1,0 +1,196 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright (c) 2026 OpenInfra Foundation Europe. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	meridio2v1alpha1 "github.com/nordix/meridio-2/api/v1alpha1"
+	e2eutils "github.com/nordix/meridio-2/test/e2e/utils"
+	"github.com/nordix/meridio-2/test/utils"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("Pod Cache Label", func() {
+	const (
+		namespace   = "e2e-pod-cache-label"
+		gatewayName = "gw-pcl"
+		vip         = "60.0.0.1"
+		cacheLabel  = "meridio-2.nordix.org/managed"
+		cacheLabelV = "true"
+	)
+
+	SetDefaultEventuallyTimeout(2 * time.Minute)
+	SetDefaultEventuallyPollingInterval(2 * time.Second)
+
+	var (
+		k8sClient      client.Client
+		clientset      *kubernetes.Clientset
+		labeledPodName string
+	)
+
+	BeforeEach(func() {
+		config, err := clientcmd.BuildConfigFromFlags("", clientcmd.RecommendedHomeFile)
+		Expect(err).NotTo(HaveOccurred())
+
+		scheme := runtime.NewScheme()
+		Expect(meridio2v1alpha1.AddToScheme(scheme)).To(Succeed())
+		Expect(corev1.AddToScheme(scheme)).To(Succeed())
+		Expect(appsv1.AddToScheme(scheme)).To(Succeed())
+
+		k8sClient, err = client.New(config, client.Options{Scheme: scheme})
+		Expect(err).NotTo(HaveOccurred())
+
+		clientset, err = kubernetes.NewForConfig(config)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("Gateway should be Accepted", func() {
+		Eventually(func(g Gomega) {
+			cmd := exec.Command("kubectl", "get", "gateway", gatewayName, "-n", namespace,
+				"-o", "jsonpath={.status.conditions[?(@.type=='Accepted')].status}")
+			out, err := utils.Run(cmd)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(out).To(Equal("True"))
+		}).Should(Succeed())
+	})
+
+	It("Gateway should be Programmed", func() {
+		Eventually(func(g Gomega) {
+			cmd := exec.Command("kubectl", "get", "gateway", gatewayName, "-n", namespace,
+				"-o", "jsonpath={.status.conditions[?(@.type=='Programmed')].status}")
+			out, err := utils.Run(cmd)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(out).To(Equal("True"))
+		}).Should(Succeed())
+	})
+
+	It("LB Deployment pods have the cache label", func() {
+		ctx := context.Background()
+
+		// Find LB Pods for the gateway
+		Eventually(func() bool {
+			pods, err := clientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+				LabelSelector: fmt.Sprintf("gateway.networking.k8s.io/gateway-name=%s", gatewayName),
+			})
+			if err != nil || len(pods.Items) == 0 {
+				return false
+			}
+			for _, pod := range pods.Items {
+				if pod.Labels[cacheLabel] != cacheLabelV {
+					return false
+				}
+			}
+			return pods.Items[0].Status.Phase == corev1.PodRunning
+		}).Should(BeTrue(),
+			"LB Pods should be Running and have the cache label")
+	})
+
+	It("creates ENC for labeled app Pod with non-empty next-hops", func() {
+		ctx := context.Background()
+
+		// Wait for labeled Pod to be Running
+		Eventually(func() bool {
+			pods, err := clientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+				LabelSelector: "variant=labeled",
+			})
+			if err != nil || len(pods.Items) == 0 {
+				return false
+			}
+			labeledPodName = pods.Items[0].Name
+			return pods.Items[0].Status.Phase == corev1.PodRunning
+		}).Should(BeTrue(),
+			"Labeled app Pod should be Running")
+
+		// Verify ENC exists with non-empty next-hops (proves LB Pod is visible)
+		Eventually(func() bool {
+			enc := &meridio2v1alpha1.EndpointNetworkConfiguration{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{
+				Name: labeledPodName, Namespace: namespace,
+			}, enc); err != nil {
+				return false
+			}
+			for _, gw := range enc.Spec.Gateways {
+				for _, domain := range gw.Domains {
+					if len(domain.NextHops) > 0 {
+						return true
+					}
+				}
+			}
+			return false
+		}).Should(BeTrue(),
+			"ENC should exist for labeled Pod with non-empty next-hops")
+	})
+
+	It("does NOT create ENC for unlabeled app Pod", func() {
+		ctx := context.Background()
+
+		// Wait for unlabeled Pod to be Running
+		var unlabeledPodName string
+		Eventually(func() bool {
+			pods, err := clientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+				LabelSelector: "variant=unlabeled",
+			})
+			if err != nil || len(pods.Items) == 0 {
+				return false
+			}
+			unlabeledPodName = pods.Items[0].Name
+			return pods.Items[0].Status.Phase == corev1.PodRunning
+		}).Should(BeTrue(),
+			"Unlabeled app Pod should be Running")
+
+		// Verify ENC does NOT exist
+		Consistently(func() error {
+			enc := &meridio2v1alpha1.EndpointNetworkConfiguration{}
+			return k8sClient.Get(ctx, types.NamespacedName{
+				Name: unlabeledPodName, Namespace: namespace,
+			}, enc)
+		}).WithTimeout(10*time.Second).WithPolling(2*time.Second).ShouldNot(Succeed(),
+			"ENC should NOT be created for unlabeled Pod")
+	})
+
+	It("VIP is reachable via ICMP", func() {
+		Eventually(func() error { return e2eutils.Ping(vip) }).
+			Should(Succeed(), "VIP should be reachable from VPN gateway")
+	})
+
+	It("distributes TCP traffic only to labeled target", func() {
+		lastingConn, lostConn, err := e2eutils.SendTraffic(vip, 5000, "tcp", 50)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(lostConn).To(BeZero(), "no connections should be lost")
+		Expect(lastingConn).To(HaveLen(1),
+			"traffic should reach exactly 1 target (labeled only), got: %v", lastingConn)
+		Expect(lastingConn).To(HaveKey(labeledPodName),
+			"traffic should only reach the labeled Pod %q, got: %v", labeledPodName, lastingConn)
+	})
+})

--- a/test/e2e/suites/common-appnetwork/targets.yaml
+++ b/test/e2e/suites/common-appnetwork/targets.yaml
@@ -32,7 +32,7 @@ spec:
         - |
           screen -d -m bash -c "./ctraffic -server -address [::]:5000" ;
           screen -d -m bash -c "./ctraffic -server -udp -address [::]:5001" ;
-          tail -f /dev/null
+          trap 'exit 0' TERM; sleep infinity & wait
         securityContext:
           runAsNonRoot: true
           capabilities:

--- a/test/e2e/suites/low-mtu/targets.yaml
+++ b/test/e2e/suites/low-mtu/targets.yaml
@@ -30,7 +30,7 @@ spec:
         - |
           screen -d -m bash -c "./ctraffic -server -address [::]:5000" ;
           screen -d -m bash -c "./ctraffic -server -udp -address [::]:5001" ;
-          tail -f /dev/null
+          trap 'exit 0' TERM; sleep infinity & wait
         securityContext:
           runAsNonRoot: true
           capabilities:

--- a/test/e2e/suites/pod-cache-label/dg.yaml
+++ b/test/e2e/suites/pod-cache-label/dg.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: meridio-2.nordix.org/v1alpha1
+kind: DistributionGroup
+metadata:
+  name: dg-pcl
+spec:
+  type: Maglev
+  maglev:
+    maxEndpoints: 8
+  selector:
+    matchLabels:
+      app: target-pcl
+  parentRefs:
+  - name: gw-pcl

--- a/test/e2e/suites/pod-cache-label/gateway.yaml
+++ b/test/e2e/suites/pod-cache-label/gateway.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gw-pcl
+spec:
+  gatewayClassName: meridio
+  infrastructure:
+    parametersRef:
+      group: meridio-2.nordix.org
+      kind: GatewayConfiguration
+      name: gwconfig-pcl
+  listeners:
+  - name: all
+    protocol: ALL
+    port: 1
+---
+apiVersion: meridio-2.nordix.org/v1alpha1
+kind: GatewayConfiguration
+metadata:
+  name: gwconfig-pcl
+spec:
+  networkAttachments:
+  - type: NAD
+    nad:
+      name: sysctl-tuning
+      namespace: e2e-pod-cache-label
+      interface: dummy
+  - type: NAD
+    nad:
+      name: vlan-800
+      namespace: e2e-pod-cache-label
+      interface: vlan-800
+  - type: NAD
+    nad:
+      name: app-net
+      namespace: e2e-pod-cache-label
+      interface: net1
+  internalSubnets:
+  - attachmentType: NAD
+    cidr: "169.111.103.0/24"
+  horizontalScaling:
+    replicas: 1

--- a/test/e2e/suites/pod-cache-label/kustomization.yaml
+++ b/test/e2e/suites/pod-cache-label/kustomization.yaml
@@ -1,0 +1,73 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: e2e-pod-cache-label
+
+resources:
+- ../../../../config/default
+
+images:
+- name: controller-manager
+  newName: registry.nordix.org/cloud-native/meridio-2/controller-manager
+  newTag: latest
+
+nameSuffix: -pod-cache-label
+
+labels:
+- pairs:
+    e2e-suite: pod-cache-label
+
+patches:
+- patch: |-
+    apiVersion: admissionregistration.k8s.io/v1
+    kind: ValidatingWebhookConfiguration
+    metadata:
+      name: not-important
+      annotations:
+        cert-manager.io/inject-ca-from: e2e-pod-cache-label/meridio-2-serving-cert-pod-cache-label
+    webhooks:
+    - name: vl34route-v1alpha1.kb.io
+      namespaceSelector:
+        matchLabels:
+          e2e-suite: pod-cache-label
+      clientConfig:
+        service:
+          name: meridio-2-webhook-service-pod-cache-label
+          namespace: e2e-pod-cache-label
+  target:
+    kind: ValidatingWebhookConfiguration
+- patch: |-
+    - op: replace
+      path: /spec/dnsNames
+      value:
+      - meridio-2-webhook-service-pod-cache-label.e2e-pod-cache-label.svc
+      - meridio-2-webhook-service-pod-cache-label.e2e-pod-cache-label.svc.cluster.local
+    - op: replace
+      path: /spec/secretName
+      value: webhook-server-cert-pod-cache-label
+  target:
+    group: cert-manager.io
+    kind: Certificate
+    name: serving-cert
+- patch: |-
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: not-important
+    spec:
+      template:
+        spec:
+          containers:
+          - name: manager
+            env:
+            - name: MERIDIO_LB_SERVICE_ACCOUNT
+              value: meridio-2-stateless-load-balancer-pod-cache-label
+            - name: MERIDIO_POD_CACHE_LABEL
+              value: "meridio-2.nordix.org/managed=true"
+          volumes:
+          - name: webhook-certs
+            secret:
+              secretName: webhook-server-cert-pod-cache-label
+  target:
+    kind: Deployment
+    labelSelector: control-plane=controller-manager

--- a/test/e2e/suites/pod-cache-label/nad.yaml
+++ b/test/e2e/suites/pod-cache-label/nad.yaml
@@ -1,0 +1,73 @@
+---
+# Sysctl tuning NAD
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: sysctl-tuning
+spec:
+  config: '{
+      "cniVersion": "0.4.0",
+      "name": "sysctl-tuning",
+      "plugins": [
+        {
+          "type": "tuning",
+          "prevResult": {},
+          "sysctl": {
+            "net.ipv4.conf.all.forwarding": "1",
+            "net.ipv6.conf.all.forwarding": "1",
+            "net.ipv4.fib_multipath_hash_policy": "1",
+            "net.ipv6.fib_multipath_hash_policy": "1",
+            "net.ipv4.conf.all.rp_filter": "2",
+            "net.ipv4.conf.default.rp_filter": "2",
+            "net.ipv4.fwmark_reflect": "1",
+            "net.ipv6.fwmark_reflect": "1",
+            "net.ipv4.ip_local_port_range": "49152 65535"
+          }
+        }
+      ]
+  }'
+---
+# VLAN 800 NAD for BGP peering
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: vlan-800
+spec:
+  config: |
+    {
+      "cniVersion": "0.3.1",
+      "type": "vlan",
+      "master": "eth0",
+      "vlanId": 800,
+      "ipam": {
+        "type": "whereabouts",
+        "ipRanges": [
+          { "range": "169.254.103.0/24", "exclude": ["169.254.103.150/32"] }
+        ]
+      }
+    }
+---
+# App network (macvlan on eth0)
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: app-net
+spec:
+  config: |
+    {
+      "cniVersion": "1.0.0",
+      "name": "app-net-pcl",
+      "plugins": [
+        {
+          "type": "macvlan",
+          "master": "eth0",
+          "mode": "bridge",
+          "ipam": {
+            "type": "whereabouts",
+            "ipRanges": [
+              { "range": "169.111.103.0/24" }
+            ]
+          }
+        }
+      ]
+    }

--- a/test/e2e/suites/pod-cache-label/rbac.yaml
+++ b/test/e2e/suites/pod-cache-label/rbac.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: meridio-2-network-sidecar
+  namespace: e2e-pod-cache-label
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: meridio-2-network-sidecar
+  namespace: e2e-pod-cache-label
+rules:
+- apiGroups: ["meridio-2.nordix.org"]
+  resources: ["endpointnetworkconfigurations"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["meridio-2.nordix.org"]
+  resources: ["endpointnetworkconfigurations/status"]
+  verbs: ["get", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: meridio-2-network-sidecar
+  namespace: e2e-pod-cache-label
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: meridio-2-network-sidecar
+subjects:
+- kind: ServiceAccount
+  name: meridio-2-network-sidecar
+  namespace: e2e-pod-cache-label

--- a/test/e2e/suites/pod-cache-label/routing.yaml
+++ b/test/e2e/suites/pod-cache-label/routing.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: meridio-2.nordix.org/v1alpha1
+kind: GatewayRouter
+metadata:
+  name: gw-router-pcl
+spec:
+  gatewayRef:
+    name: gw-pcl
+  interface: "vlan-800"
+  address: "169.254.103.150"
+  bgp:
+    remoteASN: 4200000000
+    localASN: 64519
+    holdTime: "24s"
+    remotePort: 10179
+    localPort: 10179
+    bfd:
+      switch: true
+      minTx: 300ms
+      minRx: 300ms
+      multiplier: 3
+---
+apiVersion: meridio-2.nordix.org/v1alpha1
+kind: L34Route
+metadata:
+  name: route-pcl
+spec:
+  parentRefs:
+  - name: gw-pcl
+  backendRefs:
+  - name: dg-pcl
+    group: meridio-2.nordix.org
+    kind: DistributionGroup
+  destinationCIDRs:
+  - "60.0.0.1/32"
+  protocols:
+  - TCP
+  priority: 1

--- a/test/e2e/suites/pod-cache-label/targets.yaml
+++ b/test/e2e/suites/pod-cache-label/targets.yaml
@@ -1,0 +1,124 @@
+---
+# Target WITH the cache label — should get an ENC
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: target-labeled
+  labels:
+    app: target-pcl
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: target-pcl
+      variant: labeled
+  template:
+    metadata:
+      labels:
+        app: target-pcl
+        variant: labeled
+        meridio-2.nordix.org/managed: "true"
+      annotations:
+        k8s.v1.cni.cncf.io/networks: app-net
+    spec:
+      serviceAccountName: meridio-2-network-sidecar
+      containers:
+      - name: example-target
+        image: registry.nordix.org/cloud-native/meridio-2/example-target:latest
+        imagePullPolicy: IfNotPresent
+        command: ["/bin/bash", "-c"]
+        args:
+        - |
+          screen -d -m bash -c "./ctraffic -server -address [::]:5000" ;
+          trap 'exit 0' TERM; sleep infinity & wait
+        securityContext:
+          runAsNonRoot: true
+          capabilities:
+            drop: ["ALL"]
+            add: ["DAC_OVERRIDE", "NET_RAW", "SYS_PTRACE"]
+      - name: network-sidecar
+        image: registry.nordix.org/cloud-native/meridio-2/network-sidecar:latest
+        imagePullPolicy: IfNotPresent
+        args:
+        - --pod-name=$(POD_NAME)
+        - --pod-namespace=$(POD_NAMESPACE)
+        - --pod-uid=$(POD_UID)
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
+        securityContext:
+          runAsNonRoot: true
+          capabilities:
+            drop: ["ALL"]
+            add: ["NET_ADMIN"]
+---
+# Target WITHOUT the cache label — should NOT get an ENC
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: target-unlabeled
+  labels:
+    app: target-pcl
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: target-pcl
+      variant: unlabeled
+  template:
+    metadata:
+      labels:
+        app: target-pcl
+        variant: unlabeled
+        # NOTE: intentionally missing meridio-2.nordix.org/managed label
+      annotations:
+        k8s.v1.cni.cncf.io/networks: app-net
+    spec:
+      serviceAccountName: meridio-2-network-sidecar
+      containers:
+      - name: example-target
+        image: registry.nordix.org/cloud-native/meridio-2/example-target:latest
+        imagePullPolicy: IfNotPresent
+        command: ["/bin/bash", "-c"]
+        args:
+        - trap 'exit 0' TERM; sleep infinity & wait
+        securityContext:
+          runAsNonRoot: true
+          capabilities:
+            drop: ["ALL"]
+            add: ["DAC_OVERRIDE", "NET_RAW", "SYS_PTRACE"]
+      - name: network-sidecar
+        image: registry.nordix.org/cloud-native/meridio-2/network-sidecar:latest
+        imagePullPolicy: IfNotPresent
+        args:
+        - --pod-name=$(POD_NAME)
+        - --pod-namespace=$(POD_NAMESPACE)
+        - --pod-uid=$(POD_UID)
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
+        securityContext:
+          runAsNonRoot: true
+          capabilities:
+            drop: ["ALL"]
+            add: ["NET_ADMIN"]

--- a/test/e2e/suites/separate-appnetwork/targets.yaml
+++ b/test/e2e/suites/separate-appnetwork/targets.yaml
@@ -32,7 +32,7 @@ spec:
         - |
           screen -d -m bash -c "./ctraffic -server -address [::]:5000" ;
           screen -d -m bash -c "./ctraffic -server -udp -address [::]:5001" ;
-          tail -f /dev/null
+          trap 'exit 0' TERM; sleep infinity & wait
         securityContext:
           runAsNonRoot: true
           capabilities:


### PR DESCRIPTION
Fixes #93

## Background

Cache-level filtering was chosen over predicate-based filtering because:
- Both approaches require the same operational prerequisite (pre-labeling application Pods before enabling)
- Cache filtering provides strictly superior runtime performance: events for non-matching Pods never enter the informer, never allocate memory, never trigger any processing
- Predicate filtering still receives, deserializes, and evaluates every Pod event before dropping it
- The OR problem (DG and ENC controllers watching different Pod subsets) is resolved by using a single common label for both application and LB Pods
- When applied consistently, both approaches produce identical reconciliation and data-plane outcomes — cache filtering simply does so with less overhead

See #93 for the full analysis including per-controller impact, upgrade concerns, and runtime label-removal consequences.

## Changes

Pod cache label filtering (controller-manager):
- Add --pod-cache-label flag (MERIDIO_POD_CACHE_LABEL env) to scope the informer cache to Pods with a specified key=value label
- When set, only labeled Pods are visible to all controllers (DG, ENC, Gateway)
- Gateway controller stamps the label on LB Deployment pod templates automatically
- Feature is opt-in: empty value = disabled (all Pods cached, default behavior unchanged)
- Flag format validated in PreRunE (rejects malformed input)
- The LB and router controllers (running inside LB Pods) are not affected by the pod cache label — they do not watch Pod objects. The cache filtering only applies to the controller-manager, which hosts the DG and ENC controllers.

ENC controller improvements (discovered during testing):
- Fix non-deterministic ordering of GatewayConnections, NetworkDomains, and nextHops (caused update storms from map iteration order flapping)
- Handle 409 Conflict errors with immediate requeue instead of exponential backoff (faster convergence)
- Exclude LB Pods from .For(Pod) watch via predicate (avoids unnecessary reconciliation)
- Add FNV-32 hash at V(1) log level for compact change detection; full details at V(2)
- Refactor sort comparators to use cmp.Compare (also applied to bird and LB controller)

Example targets:
- Fix slow container termination: replace tail -f /dev/null with signal-aware trap pattern

E2E test suite (pod-cache-label):
- Verifies Gateway Accepted/Programmed status
- LB Pods inherit the cache label
- ENC created for labeled app Pod with non-empty next-hops
- ENC not created for unlabeled app Pod
- VIP ICMP reachability
- TCP traffic reaches only the labeled target

Documentation:
- docs/operations/pod-cache-filtering.md — configuration, requirements, upgrade procedure, operational constraints

## Refactoring

- `reconcileDeploymentSpec` converted to a method on GatewayReconciler (eliminates growing parameter list)
- `setPodCacheLabel` helper for label application with nil-safe map handling