### PR TITLE
Consolidate labelGatewayName to internal/common/constants

### DIFF
--- a/internal/common/constants/constants.go
+++ b/internal/common/constants/constants.go
@@ -6,4 +6,7 @@ const (
 	ReadinessGateIPv4 = "meridio-2.nordix.org/ipv4-connectivity"
 	// ReadinessGateIPv6 is the Pod readiness gate condition type for IPv6 external connectivity.
 	ReadinessGateIPv6 = "meridio-2.nordix.org/ipv6-connectivity"
+
+	// LabelGatewayName is the Gateway API standard label identifying which Gateway a resource belongs to.
+	LabelGatewayName = "gateway.networking.k8s.io/gateway-name"
 )

--- a/internal/controller/endpointnetworkconfiguration/controller.go
+++ b/internal/controller/endpointnetworkconfiguration/controller.go
@@ -22,6 +22,7 @@ import (
 	"hash/fnv"
 
 	meridio2v1alpha1 "github.com/nordix/meridio-2/api/v1alpha1"
+	"github.com/nordix/meridio-2/internal/common/constants"
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -112,7 +113,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&corev1.Pod{}, builder.WithPredicates(predicate.NewPredicateFuncs(func(obj client.Object) bool {
 			// ENC reconciliation targets application Pods only; LB Pods are excluded.
-			_, isLBPod := obj.GetLabels()[labelGatewayName]
+			_, isLBPod := obj.GetLabels()[constants.LabelGatewayName]
 			return !isLBPod
 		}))).
 		Owns(&meridio2v1alpha1.EndpointNetworkConfiguration{}).
@@ -129,7 +130,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&corev1.Pod{},
 			handler.EnqueueRequestsFromMapFunc(r.mapSLLBRPodToPods),
 			builder.WithPredicates(predicate.NewPredicateFuncs(func(obj client.Object) bool {
-				_, ok := obj.GetLabels()[labelGatewayName]
+				_, ok := obj.GetLabels()[constants.LabelGatewayName]
 				return ok
 			}))).
 		Named("endpointnetworkconfiguration").

--- a/internal/controller/endpointnetworkconfiguration/mappers.go
+++ b/internal/controller/endpointnetworkconfiguration/mappers.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	meridio2v1alpha1 "github.com/nordix/meridio-2/api/v1alpha1"
+	"github.com/nordix/meridio-2/internal/common/constants"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -112,7 +113,7 @@ func (r *Reconciler) mapSLLBRPodToPods(ctx context.Context, obj client.Object) [
 	if !ok {
 		return nil
 	}
-	gwName, exists := pod.Labels[labelGatewayName]
+	gwName, exists := pod.Labels[constants.LabelGatewayName]
 	if !exists {
 		return nil
 	}

--- a/internal/controller/endpointnetworkconfiguration/mappers_test.go
+++ b/internal/controller/endpointnetworkconfiguration/mappers_test.go
@@ -29,6 +29,7 @@ import (
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	meridio2v1alpha1 "github.com/nordix/meridio-2/api/v1alpha1"
+	"github.com/nordix/meridio-2/internal/common/constants"
 )
 
 func mapperScheme() *runtime.Scheme {
@@ -211,7 +212,7 @@ func TestMapSLLBRPodToPods(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "sllbr-pod-1",
 			Namespace: "default",
-			Labels:    map[string]string{labelGatewayName: "gw-1"},
+			Labels:    map[string]string{constants.LabelGatewayName: "gw-1"},
 		},
 	}
 

--- a/internal/controller/endpointnetworkconfiguration/resolve.go
+++ b/internal/controller/endpointnetworkconfiguration/resolve.go
@@ -40,7 +40,6 @@ const (
 	kindGateway              = "Gateway"
 	kindGatewayConfiguration = "GatewayConfiguration"
 	kindDistributionGroup    = "DistributionGroup"
-	labelGatewayName         = "gateway.networking.k8s.io/gateway-name"
 	attachmentTypeNAD        = "NAD"
 )
 
@@ -260,7 +259,7 @@ func (r *Reconciler) getSLLBRNextHops(ctx context.Context, gw *gatewayv1.Gateway
 	var podList corev1.PodList
 	if err := r.List(ctx, &podList,
 		client.InNamespace(gw.Namespace),
-		client.MatchingLabels{labelGatewayName: gw.Name},
+		client.MatchingLabels{constants.LabelGatewayName: gw.Name},
 	); err != nil {
 		return nil, nil, err
 	}

--- a/internal/controller/endpointnetworkconfiguration/resolve_test.go
+++ b/internal/controller/endpointnetworkconfiguration/resolve_test.go
@@ -32,6 +32,7 @@ import (
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	meridio2v1alpha1 "github.com/nordix/meridio-2/api/v1alpha1"
+	"github.com/nordix/meridio-2/internal/common/constants"
 )
 
 const (
@@ -271,7 +272,7 @@ func TestBuildGatewayConnection_VIPsSorted(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "sllb-sllb-a-abc",
 			Namespace: testNamespace,
-			Labels:    map[string]string{labelGatewayName: "sllb-a"},
+			Labels:    map[string]string{constants.LabelGatewayName: "sllb-a"},
 		},
 		Status: corev1.PodStatus{Phase: corev1.PodRunning},
 	}
@@ -369,7 +370,7 @@ func TestGetSLLBRNextHops(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "sllbr-sllb-a-abc",
 			Namespace: testNamespace,
-			Labels:    map[string]string{labelGatewayName: "sllb-a"},
+			Labels:    map[string]string{constants.LabelGatewayName: "sllb-a"},
 		},
 		Status: corev1.PodStatus{Phase: corev1.PodRunning, ContainerStatuses: []corev1.ContainerStatus{{Name: "loadbalancer", Ready: true}, {Name: "router", Ready: true}}},
 	}
@@ -393,7 +394,7 @@ func TestGetSLLBRNextHops_DeterministicOrdering(t *testing.T) {
 	pod1 := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "sllb-sllb-a-111", Namespace: testNamespace,
-			Labels: map[string]string{labelGatewayName: "sllb-a"},
+			Labels: map[string]string{constants.LabelGatewayName: "sllb-a"},
 		},
 		Status: corev1.PodStatus{
 			Phase:             corev1.PodRunning,
@@ -403,7 +404,7 @@ func TestGetSLLBRNextHops_DeterministicOrdering(t *testing.T) {
 	pod2 := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "sllb-sllb-a-222", Namespace: testNamespace,
-			Labels: map[string]string{labelGatewayName: "sllb-a"},
+			Labels: map[string]string{constants.LabelGatewayName: "sllb-a"},
 		},
 		Status: corev1.PodStatus{
 			Phase:             corev1.PodRunning,
@@ -450,7 +451,7 @@ func TestBuildGatewayConnection_SkipsDomainWithNoInterface(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "sllbr-sllb-a-abc",
 			Namespace: testNamespace,
-			Labels:    map[string]string{labelGatewayName: "sllb-a"},
+			Labels:    map[string]string{constants.LabelGatewayName: "sllb-a"},
 		},
 		Status: corev1.PodStatus{Phase: corev1.PodRunning, ContainerStatuses: []corev1.ContainerStatus{{Name: "loadbalancer", Ready: true}, {Name: "router", Ready: true}}},
 	}
@@ -491,7 +492,7 @@ func TestBuildGatewayConnection_NamingConvention(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "sllbr-sllb-a-abc",
 			Namespace: testNamespace,
-			Labels:    map[string]string{labelGatewayName: "sllb-a"},
+			Labels:    map[string]string{constants.LabelGatewayName: "sllb-a"},
 		},
 		Status: corev1.PodStatus{Phase: corev1.PodRunning, ContainerStatuses: []corev1.ContainerStatus{{Name: "loadbalancer", Ready: true}, {Name: "router", Ready: true}}},
 	}
@@ -560,7 +561,7 @@ func TestResolveGatewayConnections_FullChain(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "sllbr-sllb-a-abc",
 			Namespace: testNamespace,
-			Labels:    map[string]string{labelGatewayName: "sllb-a"},
+			Labels:    map[string]string{constants.LabelGatewayName: "sllb-a"},
 		},
 		Status: corev1.PodStatus{Phase: corev1.PodRunning, ContainerStatuses: []corev1.ContainerStatus{{Name: "loadbalancer", Ready: true}, {Name: "router", Ready: true}}},
 	}
@@ -728,7 +729,7 @@ func TestSidecarContract_DualStack(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "sllbr-sllb-a-abc",
 			Namespace: testNamespace,
-			Labels:    map[string]string{labelGatewayName: "sllb-a"},
+			Labels:    map[string]string{constants.LabelGatewayName: "sllb-a"},
 		},
 		Status: corev1.PodStatus{Phase: corev1.PodRunning, ContainerStatuses: []corev1.ContainerStatus{{Name: "loadbalancer", Ready: true}, {Name: "router", Ready: true}}},
 	}
@@ -1031,7 +1032,7 @@ func TestGetSLLBRNextHops_TwoLevelFiltering(t *testing.T) {
 			objects := make([]client.Object, 0, len(tt.pods))
 			for i := range tt.pods {
 				tt.pods[i].Namespace = "default"
-				tt.pods[i].Labels = map[string]string{labelGatewayName: "test-gw"}
+				tt.pods[i].Labels = map[string]string{constants.LabelGatewayName: "test-gw"}
 				objects = append(objects, &tt.pods[i])
 			}
 

--- a/internal/controller/gateway/const.go
+++ b/internal/controller/gateway/const.go
@@ -39,7 +39,6 @@ const (
 	LBDeploymentTemplateFile = "lb-deployment.yaml"
 
 	// Labels
-	labelGatewayName = "gateway.networking.k8s.io/gateway-name"
-	labelManagedBy   = "app.kubernetes.io/managed-by"
-	managedByValue   = "gateway-controller.meridio-2.nordix.org"
+	labelManagedBy = "app.kubernetes.io/managed-by"
+	managedByValue = "gateway-controller.meridio-2.nordix.org"
 )

--- a/internal/controller/gateway/deployment.go
+++ b/internal/controller/gateway/deployment.go
@@ -210,7 +210,7 @@ func setControllerLabels(meta *metav1.ObjectMeta, deploymentName, gatewayName st
 		meta.Labels = make(map[string]string)
 	}
 	meta.Labels["app"] = deploymentName
-	meta.Labels[labelGatewayName] = gatewayName
+	meta.Labels[constants.LabelGatewayName] = gatewayName
 	meta.Labels[labelManagedBy] = managedByValue
 }
 

--- a/internal/controller/gateway/deployment_test.go
+++ b/internal/controller/gateway/deployment_test.go
@@ -51,7 +51,7 @@ func TestSetControllerLabels(t *testing.T) {
 		setControllerLabels(meta, "sllbr-test", "test-gw")
 
 		assert.Equal(t, "sllbr-test", meta.Labels["app"])
-		assert.Equal(t, "test-gw", meta.Labels[labelGatewayName])
+		assert.Equal(t, "test-gw", meta.Labels[constants.LabelGatewayName])
 		assert.Equal(t, managedByValue, meta.Labels[labelManagedBy])
 	})
 
@@ -254,7 +254,7 @@ func TestReconcileLBDeployment(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, lbDeploymentPrefix+gw.Name, deployment.Name)
 		assert.Equal(t, "template-value", deployment.Labels["template-label"])
-		assert.Equal(t, gw.Name, deployment.Labels[labelGatewayName])
+		assert.Equal(t, gw.Name, deployment.Labels[constants.LabelGatewayName])
 	})
 
 	t.Run("UpdatesExistingDeployment", func(t *testing.T) {
@@ -271,9 +271,9 @@ func TestReconcileLBDeployment(t *testing.T) {
 				Name:      lbDeploymentPrefix + gw.Name,
 				Namespace: gw.Namespace,
 				Labels: map[string]string{
-					"template-label": "old-value",
-					labelGatewayName: gw.Name,
-					"external-label": "preserved",
+					"template-label":           "old-value",
+					constants.LabelGatewayName: gw.Name,
+					"external-label":           "preserved",
 				},
 				OwnerReferences: []metav1.OwnerReference{
 					{


### PR DESCRIPTION
Move the duplicated 'gateway.networking.k8s.io/gateway-name' label constant from gateway/const.go and endpointnetworkconfiguration/resolve.go to the shared constants package. All consumers now import from internal/common/constants.

Fixes: gh-169