### PR TITLE
Add static bfd monitor, plus tests

### DIFF
--- a/api/v1alpha1/gatewayrouter_types.go
+++ b/api/v1alpha1/gatewayrouter_types.go
@@ -39,7 +39,6 @@ type GatewayRouterSpec struct {
 
 	// protocol selects the routing protocol for this peering.
 	// +kubebuilder:validation:Enum=BGP;Static
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="protocol is immutable"
 	Protocol RoutingProtocol `json:"protocol"`
 
 	// bgp defines BGP session parameters. Required when protocol is BGP.
@@ -47,21 +46,35 @@ type GatewayRouterSpec struct {
 	// If the Protocol is bgp, the minimal parameters to be defined in bgp properties
 	// are RemoteASN and LocalASN
 	// +optional
-	// +kubebuilder:validation:XValidation:rule="!oldSelf.hasValue() || self == oldSelf.value()",message="bgp is immutable once set",optionalOldSelf=true
 	BGP *BgpSpec `json:"bgp,omitempty"`
 
 	// static defines static routing with BFD supervision. Required when protocol is Static.
 	// +optional
-	// +kubebuilder:validation:XValidation:rule="!oldSelf.hasValue() || self == oldSelf.value()",message="static is immutable once set",optionalOldSelf=true
 	Static *StaticSpec `json:"static,omitempty"`
 }
 
 type BgpSpec struct {
 	// The ASN number of the Gateway Router
+	//
+	// Note: Format="" suppresses the default int32 format that kubebuilder generates
+	// for uint32 fields. Without it, 4-byte ASNs (> 2147483647) would be rejected
+	// by the CRD schema validation. The explicit Maximum/Minimum enforce the full
+	// uint32 range at the API level.
+	// +kubebuilder:validation:Format=""
+	// +kubebuilder:validation:Maximum=4294967295
+	// +kubebuilder:validation:Minimum=0
 	// +required
 	RemoteASN uint32 `json:"remoteASN"`
 
 	// The ASN number of the system where the Attractor FrontEnds locates
+	//
+	// Note: Format="" suppresses the default int32 format that kubebuilder generates
+	// for uint32 fields. Without it, 4-byte ASNs (> 2147483647) would be rejected
+	// by the CRD schema validation. The explicit Maximum/Minimum enforce the full
+	// uint32 range at the API level.
+	// +kubebuilder:validation:Format=""
+	// +kubebuilder:validation:Maximum=4294967295
+	// +kubebuilder:validation:Minimum=0
 	// +required
 	LocalASN uint32 `json:"localASN"`
 

--- a/api/v1alpha1/gatewayrouter_validation_test.go
+++ b/api/v1alpha1/gatewayrouter_validation_test.go
@@ -123,6 +123,14 @@ func TestGatewayRouterCRDValidation(t *testing.T) {
 		assert.NoError(t, k8sClient.Create(ctx, r))
 	})
 
+	t.Run("Static router with empty static field accepted", func(t *testing.T) {
+		r := baseRouter("static-empty")
+		r.Spec.Protocol = meridio2v1alpha1.RoutingProtocolStatic
+		r.Spec.Static = &meridio2v1alpha1.StaticSpec{}
+
+		assert.NoError(t, k8sClient.Create(ctx, r))
+	})
+
 	t.Run("BGP router without bgp field rejected", func(t *testing.T) {
 		r := baseRouter("bgp-no-spec")
 		r.Spec.Protocol = meridio2v1alpha1.RoutingProtocolBGP
@@ -192,40 +200,6 @@ func TestGatewayRouterCRDValidation(t *testing.T) {
 		assert.Contains(t, err.Error(), "Must be an ip address")
 	})
 
-	t.Run("BGP immutable once set", func(t *testing.T) {
-		r := baseRouter("immutable-bgp")
-		r.Spec.Protocol = meridio2v1alpha1.RoutingProtocolBGP
-		r.Spec.BGP = &meridio2v1alpha1.BgpSpec{RemoteASN: 65000, LocalASN: 65001}
-		require.NoError(t, k8sClient.Create(ctx, r))
-
-		fetched := &meridio2v1alpha1.GatewayRouter{}
-		require.NoError(t, k8sClient.Get(ctx, client.ObjectKeyFromObject(r), fetched))
-
-		fetched.Spec.BGP.RemoteASN = 99999
-		err := k8sClient.Update(ctx, fetched)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "bgp is immutable once set")
-	})
-
-	t.Run("Static immutable once set", func(t *testing.T) {
-		r := baseRouter("immutable-static")
-		r.Spec.Protocol = meridio2v1alpha1.RoutingProtocolStatic
-		r.Spec.Static = &meridio2v1alpha1.StaticSpec{
-			BFD: &meridio2v1alpha1.BfdSpec{
-				MinTx: "300ms", MinRx: "300ms", Multiplier: 3,
-			},
-		}
-		require.NoError(t, k8sClient.Create(ctx, r))
-
-		fetched := &meridio2v1alpha1.GatewayRouter{}
-		require.NoError(t, k8sClient.Get(ctx, client.ObjectKeyFromObject(r), fetched))
-
-		fetched.Spec.Static.BFD.MinTx = "500ms"
-		err := k8sClient.Update(ctx, fetched)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "static is immutable once set")
-	})
-
 	t.Run("missing bfd multiplier rejected", func(t *testing.T) {
 		obj := fromYAML(t, `
 apiVersion: meridio-2.nordix.org/v1alpha1
@@ -270,5 +244,27 @@ spec:
 		err := k8sClient.Create(ctx, obj)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "minTx")
+	})
+
+	t.Run("remoteASN exceeding uint32 max rejected", func(t *testing.T) {
+		obj := fromYAML(t, `
+apiVersion: meridio-2.nordix.org/v1alpha1
+kind: GatewayRouter
+metadata:
+  name: asn-too-large
+  namespace: default
+spec:
+  gatewayRef:
+    name: test-gateway
+  interface: ext-vlan
+  address: "169.254.100.1"
+  protocol: BGP
+  bgp:
+    remoteASN: 5000000000
+    localASN: 65001
+`)
+		err := k8sClient.Create(ctx, obj)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "remoteASN")
 	})
 }

--- a/cmd/router/cmd/run.go
+++ b/cmd/router/cmd/run.go
@@ -21,6 +21,7 @@ import (
 	"crypto/tls"
 	"fmt"
 
+	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -244,33 +245,35 @@ func monitorConnectivity(
 				return fmt.Errorf("monitor channel closed unexpectedly")
 			}
 
+			// Fetch routers from informer cache (local memory read)
+			routers, err := getGatewayRoutersFromCache(ctx, mgr.GetClient(), cfg.GatewayName, cfg.GatewayNamespace)
+			if err != nil {
+				log.Error(err, "failed to get gateway routers from cache")
+				continue
+			}
+
+			// Mutate static protocol states based on BFD session status.
+			// After this, all protocols reflect true connectivity (Info != Established if BFD is down).
+			applyBfdState(status.Protocols, status.BfdSessions, routers, log)
+
 			count := protocolsUp(status.Protocols)
 
 			// Log when protocol up count changes
 			if firstUpdate || count != lastCount {
-				if status.HasConnectivity {
-					log.Info("Gateway connectivity established", "status", status.StatusString())
-				} else {
-					log.Info("Gateway connectivity lost", "status", status.StatusString())
-				}
+				log.Info("Gateway connectivity", "protocols", fmt.Sprintf("%d/%d up", count, len(routers)))
 				lastCount = count
 				firstUpdate = false
 			}
 
 			// Update readiness gates
 			if gateMgr != nil {
-				// Rebuild family map on every tick — reads from informer cache (no API call)
-				// and BuildFamilyMap is a trivial loop. Handles GatewayRouter add/remove/replace.
-				routers, err := getGatewayRoutersFromCache(ctx, mgr.GetClient(), cfg.GatewayName, cfg.GatewayNamespace)
-				if err == nil {
-					var ipv4, ipv6 bool
-					if len(routers) > 0 {
-						ipv4, ipv6 = router.ClassifyConnectivityByFamily(status.Protocols, router.BuildFamilyMap(routers))
-					}
-					// When no routers exist, ipv4/ipv6 stay false — gates set to False
-					if err := gateMgr.OnStatusUpdate(ctx, ipv4, ipv6); err != nil {
-						log.Error(err, "failed to update readiness gates")
-					}
+				var ipv4, ipv6 bool
+				if len(routers) > 0 {
+					ipv4, ipv6 = router.ClassifyConnectivityByFamily(status.Protocols, router.BuildFamilyMap(routers))
+				}
+				// When no routers exist, ipv4/ipv6 stay false — gates set to False
+				if err := gateMgr.OnStatusUpdate(ctx, ipv4, ipv6); err != nil {
+					log.Error(err, "failed to update readiness gates")
 				}
 			}
 		}
@@ -306,4 +309,52 @@ func protocolsUp(protocols []bird.ProtocolStatus) int {
 		}
 	}
 	return count
+}
+
+// applyBfdState mutates static protocol statuses based on BFD session state.
+// Static protocols with state up get Info set to Established if BFD is not
+// configured or BFD session is Up. If BFD is configured and not Up, Info is
+// set to BfdInfoDown.
+func applyBfdState(
+	protocols []bird.ProtocolStatus,
+	bfdSessions []bird.BfdSession,
+	routers []*meridio2v1alpha1.GatewayRouter,
+	log logr.Logger,
+) {
+	routerByName := make(map[string]*meridio2v1alpha1.GatewayRouter, len(routers))
+	for _, gr := range routers {
+		routerByName["NBR-"+gr.Name] = gr
+	}
+
+	type bfdKey struct {
+		ip    string
+		iface string
+	}
+	bfdByKey := make(map[bfdKey]bool, len(bfdSessions))
+	for _, s := range bfdSessions {
+		bfdByKey[bfdKey{s.IP, s.Interface}] = s.IsUp()
+	}
+
+	for i := range protocols {
+		p := &protocols[i]
+		if p.Proto != "Static" || !p.State.IsUp() {
+			continue
+		}
+
+		gr := routerByName[p.Name]
+		if gr == nil {
+			continue
+		}
+
+		if gr.Spec.Static != nil && gr.Spec.Static.BFD != nil {
+			if bfdByKey[bfdKey{gr.Spec.Address, gr.Spec.Interface}] {
+				p.Info = bird.BgpInfoEstablished
+			} else {
+				p.Info = bird.BfdInfoDown
+				log.V(1).Info("BFD session down for static protocol", "protocol", p.Name, "address", gr.Spec.Address)
+			}
+		} else {
+			p.Info = bird.BgpInfoEstablished
+		}
+	}
 }

--- a/cmd/router/cmd/run_test.go
+++ b/cmd/router/cmd/run_test.go
@@ -1,0 +1,232 @@
+/*
+Copyright (c) 2026 OpenInfra Foundation Europe. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	meridio2v1alpha1 "github.com/nordix/meridio-2/api/v1alpha1"
+	"github.com/nordix/meridio-2/internal/bird"
+)
+
+func TestApplyBfdState(t *testing.T) {
+	bfdSpec := &meridio2v1alpha1.BfdSpec{
+		MinTx:      "300ms",
+		MinRx:      "300ms",
+		Multiplier: 3,
+	}
+
+	tests := []struct {
+		name          string
+		protocols     []bird.ProtocolStatus
+		bfdSessions   []bird.BfdSession
+		routers       []*meridio2v1alpha1.GatewayRouter
+		expectedState []bird.ProtocolState
+		expectedInfo  []string
+	}{
+		{
+			name: "static with BFD up - sets Established",
+			protocols: []bird.ProtocolStatus{
+				{Name: "NBR-gw-static-v4", Proto: "Static", State: bird.ProtocolStateUp},
+			},
+			bfdSessions: []bird.BfdSession{
+				{IP: "169.254.12.150", Interface: "vlan-100", State: "Up"},
+			},
+			routers: []*meridio2v1alpha1.GatewayRouter{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "gw-static-v4"},
+					Spec: meridio2v1alpha1.GatewayRouterSpec{
+						Address:   "169.254.12.150",
+						Interface: "vlan-100",
+						Protocol:  meridio2v1alpha1.RoutingProtocolStatic,
+						Static:    &meridio2v1alpha1.StaticSpec{BFD: bfdSpec},
+					},
+				},
+			},
+			expectedState: []bird.ProtocolState{bird.ProtocolStateUp},
+			expectedInfo:  []string{bird.BgpInfoEstablished},
+		},
+		{
+			name: "static with BFD down - Info set to BFD Down",
+			protocols: []bird.ProtocolStatus{
+				{Name: "NBR-gw-static-v4", Proto: "Static", State: bird.ProtocolStateUp},
+			},
+			bfdSessions: []bird.BfdSession{
+				{IP: "169.254.12.150", Interface: "vlan-100", State: "Down"},
+			},
+			routers: []*meridio2v1alpha1.GatewayRouter{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "gw-static-v4"},
+					Spec: meridio2v1alpha1.GatewayRouterSpec{
+						Address:   "169.254.12.150",
+						Interface: "vlan-100",
+						Protocol:  meridio2v1alpha1.RoutingProtocolStatic,
+						Static:    &meridio2v1alpha1.StaticSpec{BFD: bfdSpec},
+					},
+				},
+			},
+			expectedState: []bird.ProtocolState{bird.ProtocolStateUp},
+			expectedInfo:  []string{bird.BfdInfoDown},
+		},
+		{
+			name: "static with BFD - session not found - Info set to BFD Down",
+			protocols: []bird.ProtocolStatus{
+				{Name: "NBR-gw-static-v4", Proto: "Static", State: bird.ProtocolStateUp},
+			},
+			bfdSessions: []bird.BfdSession{},
+			routers: []*meridio2v1alpha1.GatewayRouter{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "gw-static-v4"},
+					Spec: meridio2v1alpha1.GatewayRouterSpec{
+						Address:   "169.254.12.150",
+						Interface: "vlan-100",
+						Protocol:  meridio2v1alpha1.RoutingProtocolStatic,
+						Static:    &meridio2v1alpha1.StaticSpec{BFD: bfdSpec},
+					},
+				},
+			},
+			expectedState: []bird.ProtocolState{bird.ProtocolStateUp},
+			expectedInfo:  []string{bird.BfdInfoDown},
+		},
+		{
+			name: "static without BFD - sets Established",
+			protocols: []bird.ProtocolStatus{
+				{Name: "NBR-gw-static-v4", Proto: "Static", State: bird.ProtocolStateUp},
+			},
+			bfdSessions: []bird.BfdSession{},
+			routers: []*meridio2v1alpha1.GatewayRouter{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "gw-static-v4"},
+					Spec: meridio2v1alpha1.GatewayRouterSpec{
+						Address:   "169.254.12.150",
+						Interface: "vlan-100",
+						Protocol:  meridio2v1alpha1.RoutingProtocolStatic,
+						Static:    &meridio2v1alpha1.StaticSpec{},
+					},
+				},
+			},
+			expectedState: []bird.ProtocolState{bird.ProtocolStateUp},
+			expectedInfo:  []string{bird.BgpInfoEstablished},
+		},
+		{
+			name: "BGP protocol - not touched",
+			protocols: []bird.ProtocolStatus{
+				{Name: "NBR-gw-bgp-v4", Proto: "BGP", State: bird.ProtocolStateUp, Info: "Established"},
+			},
+			bfdSessions: []bird.BfdSession{},
+			routers: []*meridio2v1alpha1.GatewayRouter{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "gw-bgp-v4"},
+					Spec: meridio2v1alpha1.GatewayRouterSpec{
+						Address:  "169.254.12.150",
+						Protocol: meridio2v1alpha1.RoutingProtocolBGP,
+					},
+				},
+			},
+			expectedState: []bird.ProtocolState{bird.ProtocolStateUp},
+			expectedInfo:  []string{"Established"},
+		},
+		{
+			name: "static protocol already down - not touched",
+			protocols: []bird.ProtocolStatus{
+				{Name: "NBR-gw-static-v4", Proto: "Static", State: bird.ProtocolStateDown},
+			},
+			bfdSessions: []bird.BfdSession{
+				{IP: "169.254.12.150", Interface: "vlan-100", State: "Up"},
+			},
+			routers: []*meridio2v1alpha1.GatewayRouter{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "gw-static-v4"},
+					Spec: meridio2v1alpha1.GatewayRouterSpec{
+						Address:   "169.254.12.150",
+						Interface: "vlan-100",
+						Protocol:  meridio2v1alpha1.RoutingProtocolStatic,
+						Static:    &meridio2v1alpha1.StaticSpec{BFD: bfdSpec},
+					},
+				},
+			},
+			expectedState: []bird.ProtocolState{bird.ProtocolStateDown},
+			expectedInfo:  []string{""},
+		},
+		{
+			name: "static protocol with no matching router - not touched",
+			protocols: []bird.ProtocolStatus{
+				{Name: "NBR-unknown-static", Proto: "Static", State: bird.ProtocolStateUp},
+			},
+			bfdSessions:   []bird.BfdSession{},
+			routers:       []*meridio2v1alpha1.GatewayRouter{},
+			expectedState: []bird.ProtocolState{bird.ProtocolStateUp},
+			expectedInfo:  []string{""},
+		},
+		{
+			name: "mixed BGP and static with BFD",
+			protocols: []bird.ProtocolStatus{
+				{Name: "NBR-gw-bgp-v4", Proto: "BGP", State: bird.ProtocolStateUp, Info: "Established"},
+				{Name: "NBR-gw-static-v4", Proto: "Static", State: bird.ProtocolStateUp},
+				{Name: "NBR-gw-static-v6", Proto: "Static", State: bird.ProtocolStateUp},
+			},
+			bfdSessions: []bird.BfdSession{
+				{IP: "169.254.12.150", Interface: "vlan-100", State: "Up"},
+				{IP: "fd00::150", Interface: "vlan-100", State: "Down"},
+			},
+			routers: []*meridio2v1alpha1.GatewayRouter{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "gw-bgp-v4"},
+					Spec: meridio2v1alpha1.GatewayRouterSpec{
+						Address:  "169.254.12.100",
+						Protocol: meridio2v1alpha1.RoutingProtocolBGP,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "gw-static-v4"},
+					Spec: meridio2v1alpha1.GatewayRouterSpec{
+						Address:   "169.254.12.150",
+						Interface: "vlan-100",
+						Protocol:  meridio2v1alpha1.RoutingProtocolStatic,
+						Static:    &meridio2v1alpha1.StaticSpec{BFD: bfdSpec},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "gw-static-v6"},
+					Spec: meridio2v1alpha1.GatewayRouterSpec{
+						Address:   "fd00::150",
+						Interface: "vlan-100",
+						Protocol:  meridio2v1alpha1.RoutingProtocolStatic,
+						Static:    &meridio2v1alpha1.StaticSpec{BFD: bfdSpec},
+					},
+				},
+			},
+			expectedState: []bird.ProtocolState{bird.ProtocolStateUp, bird.ProtocolStateUp, bird.ProtocolStateUp},
+			expectedInfo:  []string{"Established", bird.BgpInfoEstablished, bird.BfdInfoDown},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			applyBfdState(tt.protocols, tt.bfdSessions, tt.routers, ctrl.Log)
+
+			for i, p := range tt.protocols {
+				assert.Equal(t, tt.expectedState[i], p.State, "protocol[%d] %s State", i, p.Name)
+				assert.Equal(t, tt.expectedInfo[i], p.Info, "protocol[%d] %s Info", i, p.Name)
+			}
+		})
+	}
+}

--- a/config/crd/bases/meridio-2.nordix.org_gatewayrouters.yaml
+++ b/config/crd/bases/meridio-2.nordix.org_gatewayrouters.yaml
@@ -89,9 +89,15 @@ spec:
                     - message: Must be at least 3s
                       rule: duration(self) >= duration('3s')
                   localASN:
-                    description: The ASN number of the system where the Attractor
-                      FrontEnds locates
-                    format: int32
+                    description: |-
+                      The ASN number of the system where the Attractor FrontEnds locates
+
+                      Note: Format="" suppresses the default int32 format that kubebuilder generates
+                      for uint32 fields. Without it, 4-byte ASNs (> 2147483647) would be rejected
+                      by the CRD schema validation. The explicit Maximum/Minimum enforce the full
+                      uint32 range at the API level.
+                    maximum: 4294967295
+                    minimum: 0
                     type: integer
                   localPort:
                     default: 179
@@ -100,8 +106,15 @@ spec:
                     minimum: 1
                     type: integer
                   remoteASN:
-                    description: The ASN number of the Gateway Router
-                    format: int32
+                    description: |-
+                      The ASN number of the Gateway Router
+
+                      Note: Format="" suppresses the default int32 format that kubebuilder generates
+                      for uint32 fields. Without it, 4-byte ASNs (> 2147483647) would be rejected
+                      by the CRD schema validation. The explicit Maximum/Minimum enforce the full
+                      uint32 range at the API level.
+                    maximum: 4294967295
+                    minimum: 0
                     type: integer
                   remotePort:
                     default: 179
@@ -113,10 +126,6 @@ spec:
                 - localASN
                 - remoteASN
                 type: object
-                x-kubernetes-validations:
-                - message: bgp is immutable once set
-                  optionalOldSelf: true
-                  rule: '!oldSelf.hasValue() || self == oldSelf.value()'
               gatewayRef:
                 description: gatewayRef references the Gateway this router peers with.
                 properties:
@@ -261,9 +270,6 @@ spec:
                 - BGP
                 - Static
                 type: string
-                x-kubernetes-validations:
-                - message: protocol is immutable
-                  rule: self == oldSelf
               static:
                 description: static defines static routing with BFD supervision. Required
                   when protocol is Static.
@@ -294,10 +300,6 @@ spec:
                     - multiplier
                     type: object
                 type: object
-                x-kubernetes-validations:
-                - message: static is immutable once set
-                  optionalOldSelf: true
-                  rule: '!oldSelf.hasValue() || self == oldSelf.value()'
             required:
             - address
             - gatewayRef

--- a/docs/controllers/router.md
+++ b/docs/controllers/router.md
@@ -124,13 +124,14 @@ Blackhole routes (`0.0.0.0/0` and `::/0`) in table 4097 prevent traffic leaking 
 
 Rules are reconciled idempotently: stale rules removed, missing rules added. Errors are accumulated best-effort (partial progress over rollback); the next reconcile retries any failed operations.
 
-### BGP Monitoring
+### BGP and BFD Monitoring
 
-A separate goroutine polls `birdc show protocols all "NBR-*"` at 1-second intervals:
+A separate goroutine polls `birdc show protocols all "NBR-*"` and `birdc show bfd sessions` at 1-second intervals:
 
 - Parses protocol state (up/down/start/idle) and BGP session info (Established)
-- Tracks connectivity: at least one `NBR-*` protocol in state `up` with info `Established`
-- Currently log-only; status changes logged when protocol up-count changes
+- For static protocols with BFD configured, applies BFD session state: if the BFD session is Up, Info is set to `Established`; if BFD is down or not found, Info is set to `BFD Down`
+- Tracks connectivity per IP version: at least one `NBR-*` protocol with Info containing `Established`
+- Status changes logged when protocol up-count changes
 - Failed birdc queries are logged at V(1) level for debugging
 
 ## LB Readiness Gating
@@ -152,6 +153,10 @@ All flags support environment variable overrides following the precedence: flags
 |---|---|---|---|
 | `--gateway-name` | `MERIDIO_GATEWAY_NAME` | _(required)_ | Name of the Gateway resource to watch |
 | `--gateway-namespace` | `MERIDIO_GATEWAY_NAMESPACE` | `default` | Namespace of the Gateway resource |
+| `--pod-name` | `POD_NAME` | _(required for gates)_ | Pod name (Downward API) |
+| `--pod-namespace` | `POD_NAMESPACE` | _(required for gates)_ | Pod namespace (Downward API) |
+| `--pod-uid` | `POD_UID` | _(required for gates)_ | Pod UID (Downward API) |
+| `--connectivity-hold-time` | `MERIDIO_CONNECTIVITY_HOLD_TIME` | `3s` | Hold time before setting connectivity gate to True after BGP session establishes |
 | `--table-id` | `MERIDIO_TABLE_ID` | `4096` | Kernel routing table ID for BIRD-managed routes. Blackhole table is `table-id + 1`. |
 | `--rule-priority` | `MERIDIO_RULE_PRIORITY` | `100` | Policy routing rule priority. Blackhole priority is `rule-priority + 1`. |
 | `--bird-socket` | `MERIDIO_BIRD_SOCKET` | `/var/run/bird/bird.ctl` | Path to the BIRD control socket |
@@ -170,7 +175,7 @@ All flags support environment variable overrides following the precedence: flags
 
 ### BIRD Process Lifecycle (MVP gaps)
 
-- **No error propagation**: `Bird.Run()` goroutine logs errors but doesn't signal the main process. If BIRD crashes, the controller keeps running with green health probes while doing nothing useful. Fix: use `errCh` pattern to trigger context cancellation on BIRD failure.
+- **No error propagation**: ~~`Bird.Run()` goroutine logs errors but doesn't signal the main process.~~ Resolved: the router controller uses an errgroup to run BIRD and the monitor goroutine. If either fails, the errgroup cancels the context and the router process exits.
 
 - **Startup readiness window**: `running` is set to `true` after `cmd.Start()` (fork), not after BIRD's control socket is ready. A reconcile during this window will attempt `birdc configure` and fail. Self-heals via controller-runtime requeue, but produces noisy error logs at startup.
 
@@ -209,7 +214,7 @@ Meridio v1 exposes per-GatewayRouter metrics and monitors BIRD route counts:
 | Feature | Meridio-1 | This Controller | Notes |
 |---|---|---|---|
 | BGP config generation | ✅ | ✅ | Dual-stack, BFD, custom ports |
-| Static routing protocol | ✅ | ❌ | CRD only has BGP (by design) |
+| Static routing protocol | ✅ | ✅ | Default route with optional BFD supervision |
 | BGP authentication | ✅ | ❌ | Out of MVP scope |
 | BIRD process lifecycle | ✅ | ✅ | Graceful shutdown via SIGTERM, file-based logging |
 | BIRD startup readiness | ✅ | ❌ | Meridio-1 polls `birdc show status`; this controller relies on retry |
@@ -217,7 +222,7 @@ Meridio v1 exposes per-GatewayRouter metrics and monitors BIRD route counts:
 | Policy routing (VIP→table) | ✅ | ✅ | With blackhole fallback |
 | BIRD log monitoring | ✅ | ⚠️ | File-based logging added; no stderr parsing or structured re-emission |
 | Connectivity → health signal | ✅ | ❌ | Meridio-1 signals NSP; this controller only logs |
-| Error propagation | ✅ | ❌ | Meridio-1 uses `errCh` pattern |
+| Error propagation | ✅ | ✅ | errgroup cancels context on BIRD/monitor failure |
 | Metrics | ✅ | ❌ | Meridio-1 has gateway metrics |
 | Config generation method | `fmt.Sprintf` | `text/template` | Migrated for maintainability and future auth support |
 
@@ -226,5 +231,5 @@ Meridio v1 exposes per-GatewayRouter metrics and monitors BIRD route counts:
 ### Unit Tests
 
 - `internal/controller/router/controller_test.go`: Reconciler logic (gateway filtering, GatewayRouter matching, VIP extraction, address type filtering, enqueue mapper, configure error propagation)
-- `internal/bird/bird_test.go`: Config generation (base, VIPs, routers, full reference config comparison)
-- `internal/bird/monitor_test.go`: Protocol output parsing, connectivity detection, status formatting, monitor channel lifecycle
+- `internal/bird/bird_test.go`: Config generation (base, VIPs, routers, full reference config comparison, static routing with/without BFD, BFD interface params first-alphabetically-wins)
+- `internal/bird/monitor_test.go`: Protocol output parsing, BFD session output parsing, connectivity detection, status formatting, monitor channel lifecycle

--- a/hack/vpn-gateway/bird-gw.conf
+++ b/hack/vpn-gateway/bird-gw.conf
@@ -153,3 +153,35 @@ protocol bgp GW4_PCL from LINK {
 		export filter bgp_announce;
 	};
 }
+
+# separate-static-appnetwork: static routes with BFD for LB pod next-hops.
+# We list a generous range of potential LB pod IPs (.1-.10). BFD ensures only
+# routes pointing at live pods are active — non-existent peers stay BFD Down
+# and the route is suppressed. This allows scaling without reconfiguring the gateway.
+protocol static GW_STATIC {
+    ipv4 {
+        export all;
+    };
+    # gw-a1 (VLAN 1100) — VIP 110.0.0.1
+    route 110.0.0.1/32 via 169.254.110.1 bfd;
+    route 110.0.0.1/32 via 169.254.110.2 bfd;
+    route 110.0.0.1/32 via 169.254.110.3 bfd;
+    route 110.0.0.1/32 via 169.254.110.4 bfd;
+    route 110.0.0.1/32 via 169.254.110.5 bfd;
+    route 110.0.0.1/32 via 169.254.110.6 bfd;
+    route 110.0.0.1/32 via 169.254.110.7 bfd;
+    route 110.0.0.1/32 via 169.254.110.8 bfd;
+    route 110.0.0.1/32 via 169.254.110.9 bfd;
+    route 110.0.0.1/32 via 169.254.110.10 bfd;
+    # gw-a2 (VLAN 1200) — VIP 110.0.0.2
+    route 110.0.0.2/32 via 169.254.111.1 bfd;
+    route 110.0.0.2/32 via 169.254.111.2 bfd;
+    route 110.0.0.2/32 via 169.254.111.3 bfd;
+    route 110.0.0.2/32 via 169.254.111.4 bfd;
+    route 110.0.0.2/32 via 169.254.111.5 bfd;
+    route 110.0.0.2/32 via 169.254.111.6 bfd;
+    route 110.0.0.2/32 via 169.254.111.7 bfd;
+    route 110.0.0.2/32 via 169.254.111.8 bfd;
+    route 110.0.0.2/32 via 169.254.111.9 bfd;
+    route 110.0.0.2/32 via 169.254.111.10 bfd;
+}

--- a/hack/vpn-gateway/init.sh
+++ b/hack/vpn-gateway/init.sh
@@ -52,8 +52,18 @@ ip link add link eth0 name vlan8 type vlan id 800
 ip link set vlan8 up
 ip addr add 169.254.50.150/24 dev vlan8
 
+# VLAN 1100 — separate-static-appnetwork gw-a1
+ip link add link eth0 name vlan11 type vlan id 1100
+ip link set vlan11 up
+ip addr add 169.254.110.150/24 dev vlan11
+
+# VLAN 1200 — separate-static-appnetwork gw-a2
+ip link add link eth0 name vlan12 type vlan id 1200
+ip link set vlan12 up
+ip addr add 169.254.111.150/24 dev vlan12
+
 ethtool -K eth0 tx off
 
-echo "VPN Gateway ready on VLAN 100, 200, 300, 400, 500, 600, 700, 800"
+echo "VPN Gateway ready on VLAN 100, 200, 300, 400, 500, 600, 700, 800, 1100, 1200"
 
 /usr/sbin/bird -d -c /etc/bird/bird-gw.conf

--- a/internal/bird/monitor.go
+++ b/internal/bird/monitor.go
@@ -18,7 +18,6 @@ package bird
 
 import (
 	"context"
-	"fmt"
 	"os/exec"
 	"strings"
 	"time"
@@ -34,6 +33,12 @@ const (
 	ProtocolStateIdle  ProtocolState = "idle"
 )
 
+// BgpInfoEstablished is the Info value BIRD reports for an established BGP session.
+const BgpInfoEstablished = "Established"
+
+// BfdInfoDown is the Info value set on static protocols when BFD session is down or missing.
+const BfdInfoDown = "BFD Down"
+
 // IsUp returns true if the protocol is in an operational state
 func (s ProtocolState) IsUp() bool {
 	return s == ProtocolStateUp
@@ -42,21 +47,21 @@ func (s ProtocolState) IsUp() bool {
 // IsEstablished checks if the protocol has an established BGP session
 // For BGP protocols, both State must be "up" AND Info must contain "Established"
 func (p ProtocolStatus) IsEstablished() bool {
-	return p.State.IsUp() && strings.Contains(p.Info, "Established")
+	return p.State.IsUp() && strings.Contains(p.Info, BgpInfoEstablished)
 }
 
 // ProtocolStatus represents the status of a BIRD protocol
 type ProtocolStatus struct {
 	Name  string
-	Proto string // Protocol type (BGP, Static) - TODO: handle static protocols for feature parity with Meridio-1
+	Proto string // Protocol type (BGP, Static)
 	State ProtocolState
 	Info  string
 }
 
 // MonitorStatus represents the overall monitoring status
 type MonitorStatus struct {
-	Protocols       []ProtocolStatus
-	HasConnectivity bool
+	Protocols   []ProtocolStatus
+	BfdSessions []BfdSession
 }
 
 // Monitor periodically checks BGP protocol status by querying birdc.
@@ -90,8 +95,8 @@ func (b *Bird) Monitor(ctx context.Context, interval time.Duration) (<-chan Moni
 // checkStatus queries birdc for protocol status
 func (b *Bird) checkStatus(ctx context.Context) MonitorStatus {
 	status := MonitorStatus{
-		Protocols:       []ProtocolStatus{},
-		HasConnectivity: false,
+		Protocols:   []ProtocolStatus{},
+		BfdSessions: []BfdSession{},
 	}
 
 	b.mu.Lock()
@@ -110,7 +115,14 @@ func (b *Bird) checkStatus(ctx context.Context) MonitorStatus {
 	}
 
 	status.Protocols = parseProtocolOutput(string(out))
-	status.HasConnectivity = hasConnectivity(status.Protocols)
+
+	bfdCmd := exec.CommandContext(ctx, "birdc", "-s", b.SocketPath, "show", "bfd", "sessions")
+	bfdOut, err := bfdCmd.CombinedOutput()
+	if err != nil {
+		log.V(1).Info("birdc bfd query failed", "error", err)
+	} else {
+		status.BfdSessions = parseBfdOutput(string(bfdOut))
+	}
 
 	return status
 }
@@ -147,28 +159,40 @@ func parseProtocolOutput(output string) []ProtocolStatus {
 	return protocols
 }
 
-// hasConnectivity determines if there's at least one established BGP session
-func hasConnectivity(protocols []ProtocolStatus) bool {
-	for _, p := range protocols {
-		if p.IsEstablished() {
-			return true
-		}
-	}
-	return false
+// BfdSession represents the state of a BIRD BFD session.
+type BfdSession struct {
+	IP        string
+	Interface string
+	State     string // "Up", "Down", "Init", etc.
 }
 
-// StatusString returns a human-readable status summary
-func (ms MonitorStatus) StatusString() string {
-	if len(ms.Protocols) == 0 {
-		return "No protocols configured"
-	}
+// IsUp returns true if the BFD session state is "Up".
+func (b BfdSession) IsUp() bool {
+	return b.State == "Up"
+}
 
-	upCount := 0
-	for _, p := range ms.Protocols {
-		if p.IsEstablished() {
-			upCount++
+// parseBfdOutput parses the output of `birdc show bfd sessions`.
+func parseBfdOutput(output string) []BfdSession {
+	sessions := make([]BfdSession, 0, 8)
+
+	for line := range strings.SplitSeq(output, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "BIRD") ||
+			strings.HasPrefix(line, "IP address") {
+			continue
 		}
+
+		fields := strings.Fields(line)
+		if len(fields) < 3 {
+			continue
+		}
+
+		sessions = append(sessions, BfdSession{
+			IP:        fields[0],
+			Interface: fields[1],
+			State:     fields[2],
+		})
 	}
 
-	return fmt.Sprintf("%d/%d protocols up", upCount, len(ms.Protocols))
+	return sessions
 }

--- a/internal/bird/monitor_test.go
+++ b/internal/bird/monitor_test.go
@@ -187,57 +187,12 @@ NBR-gw-ipv6 BGP       ---        up     2026-03-02    Established`,
 	}
 }
 
-func TestHasConnectivity(t *testing.T) {
-	tests := []struct {
-		name      string
-		protocols []ProtocolStatus
-		expected  bool
-	}{
-		{
-			name: "at least one established",
-			protocols: []ProtocolStatus{
-				{Name: "NBR-1", State: ProtocolStateUp, Info: "Established"},
-				{Name: "NBR-2", State: ProtocolStateStart, Info: "Connect"},
-			},
-			expected: true,
-		},
-		{
-			name: "all down",
-			protocols: []ProtocolStatus{
-				{Name: "NBR-1", State: ProtocolStateDown, Info: "Connection closed"},
-				{Name: "NBR-2", State: ProtocolStateStart, Info: "Connect"},
-			},
-			expected: false,
-		},
-		{
-			name:      "no protocols",
-			protocols: []ProtocolStatus{},
-			expected:  false,
-		},
-		{
-			name: "all established",
-			protocols: []ProtocolStatus{
-				{Name: "NBR-1", State: ProtocolStateUp, Info: "Established"},
-				{Name: "NBR-2", State: ProtocolStateUp, Info: "Established"},
-			},
-			expected: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := hasConnectivity(tt.protocols)
-			if result != tt.expected {
-				t.Errorf("hasConnectivity() = %v, want %v", result, tt.expected)
-			}
-		})
-	}
-}
 func TestParseAndFormatStatus(t *testing.T) {
 	tests := []struct {
-		name           string
-		birdcOutput    string
-		expectedStatus string
+		name          string
+		birdcOutput   string
+		expectedUp    int
+		expectedTotal int
 	}{
 		{
 			name: "dual-stack both up",
@@ -245,7 +200,7 @@ func TestParseAndFormatStatus(t *testing.T) {
 Name       Proto      Table      State  Since         Info
 NBR-gatewayrouter-sample BGP        ---        up     10:04:13.527  Established
 NBR-gatewayrouter-sample-v6 BGP        ---        up     10:04:12.499  Established`,
-			expectedStatus: "2/2 protocols up",
+			expectedUp: 2, expectedTotal: 2,
 		},
 		{
 			name: "dual-stack one up",
@@ -253,25 +208,30 @@ NBR-gatewayrouter-sample-v6 BGP        ---        up     10:04:12.499  Establish
 Name       Proto      Table      State  Since         Info
 NBR-gatewayrouter-sample BGP        ---        start  10:04:13.527  Connect
 NBR-gatewayrouter-sample-v6 BGP        ---        up     10:04:12.499  Established`,
-			expectedStatus: "1/2 protocols up",
+			expectedUp: 1, expectedTotal: 2,
 		},
 		{
 			name: "no protocols",
 			birdcOutput: `BIRD 3.1.5 ready.
 Name       Proto      Table      State  Since         Info`,
-			expectedStatus: "No protocols configured",
+			expectedUp: 0, expectedTotal: 0,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			protocols := parseProtocolOutput(tt.birdcOutput)
-			status := MonitorStatus{
-				Protocols: protocols,
+			if len(protocols) != tt.expectedTotal {
+				t.Errorf("protocol count = %d, want %d", len(protocols), tt.expectedTotal)
 			}
-			result := status.StatusString()
-			if result != tt.expectedStatus {
-				t.Errorf("StatusString() = %q, want %q", result, tt.expectedStatus)
+			upCount := 0
+			for _, p := range protocols {
+				if p.IsEstablished() {
+					upCount++
+				}
+			}
+			if upCount != tt.expectedUp {
+				t.Errorf("established count = %d, want %d", upCount, tt.expectedUp)
 			}
 		})
 	}
@@ -279,46 +239,45 @@ Name       Proto      Table      State  Since         Info`,
 
 func TestProtocolUpCountChanges(t *testing.T) {
 	// Simulate the sequence: 0 protocols → 1/1 up → 1/2 up → 2/2 up
-	// This verifies that status string changes at each step
+	// This verifies that up-count changes at each step
 	outputs := []struct {
-		birdcOutput    string
-		expectedStatus string
-		expectedCount  int
+		birdcOutput   string
+		expectedCount int
+		expectedTotal int
 	}{
 		{
 			birdcOutput: `BIRD 3.1.5 ready.
 Name       Proto      Table      State  Since         Info`,
-			expectedStatus: "No protocols configured",
-			expectedCount:  0,
+			expectedCount: 0, expectedTotal: 0,
 		},
 		{
 			birdcOutput: `BIRD 3.1.5 ready.
 Name       Proto      Table      State  Since         Info
 NBR-gatewayrouter-sample-v6 BGP        ---        up     10:04:12.499  Established`,
-			expectedStatus: "1/1 protocols up",
-			expectedCount:  1,
+			expectedCount: 1, expectedTotal: 1,
 		},
 		{
 			birdcOutput: `BIRD 3.1.5 ready.
 Name       Proto      Table      State  Since         Info
 NBR-gatewayrouter-sample BGP        ---        start  10:04:13.527  Connect
 NBR-gatewayrouter-sample-v6 BGP        ---        up     10:04:12.499  Established`,
-			expectedStatus: "1/2 protocols up",
-			expectedCount:  1,
+			expectedCount: 1, expectedTotal: 2,
 		},
 		{
 			birdcOutput: `BIRD 3.1.5 ready.
 Name       Proto      Table      State  Since         Info
 NBR-gatewayrouter-sample BGP        ---        up     10:04:13.527  Established
 NBR-gatewayrouter-sample-v6 BGP        ---        up     10:04:12.499  Established`,
-			expectedStatus: "2/2 protocols up",
-			expectedCount:  2,
+			expectedCount: 2, expectedTotal: 2,
 		},
 	}
 
 	for i, step := range outputs {
 		protocols := parseProtocolOutput(step.birdcOutput)
-		status := MonitorStatus{Protocols: protocols}
+
+		if len(protocols) != step.expectedTotal {
+			t.Errorf("Step %d: protocol count = %d, want %d", i, len(protocols), step.expectedTotal)
+		}
 
 		upCount := 0
 		for _, p := range protocols {
@@ -329,11 +288,6 @@ NBR-gatewayrouter-sample-v6 BGP        ---        up     10:04:12.499  Establish
 
 		if upCount != step.expectedCount {
 			t.Errorf("Step %d: upCount = %d, want %d", i, upCount, step.expectedCount)
-		}
-
-		statusStr := status.StatusString()
-		if statusStr != step.expectedStatus {
-			t.Errorf("Step %d: StatusString() = %q, want %q", i, statusStr, step.expectedStatus)
 		}
 	}
 }
@@ -382,4 +336,72 @@ func TestMonitorEmitsStatus(t *testing.T) {
 	case <-time.After(50 * time.Millisecond):
 		t.Error("did not receive status in time")
 	}
+}
+
+func TestParseBfdOutput(t *testing.T) {
+	t.Run("standard output with multiple sessions", func(t *testing.T) {
+		output := `BIRD 3.2.0 ready.
+IP address                Interface  State      Since         Interval  Timeout
+169.254.110.1             vlan11     Up         14:23:45.100    0.300    0.900
+169.254.111.2             vlan12     Down       14:24:01.200    1.000    0.000`
+
+		sessions := parseBfdOutput(output)
+		if len(sessions) != 2 {
+			t.Fatalf("expected 2 sessions, got %d", len(sessions))
+		}
+		if sessions[0].IP != "169.254.110.1" || sessions[0].Interface != "vlan11" || sessions[0].State != "Up" {
+			t.Errorf("session[0] = %+v", sessions[0])
+		}
+		if sessions[1].IP != "169.254.111.2" || sessions[1].Interface != "vlan12" || sessions[1].State != "Down" {
+			t.Errorf("session[1] = %+v", sessions[1])
+		}
+	})
+
+	t.Run("empty output", func(t *testing.T) {
+		sessions := parseBfdOutput("")
+		if len(sessions) != 0 {
+			t.Errorf("expected 0 sessions, got %d", len(sessions))
+		}
+	})
+
+	t.Run("headers only no sessions", func(t *testing.T) {
+		output := `BIRD 3.2.0 ready.
+IP address                Interface  State      Since         Interval  Timeout`
+
+		sessions := parseBfdOutput(output)
+		if len(sessions) != 0 {
+			t.Errorf("expected 0 sessions, got %d", len(sessions))
+		}
+	})
+
+	t.Run("IPv6 sessions", func(t *testing.T) {
+		output := `BIRD 3.2.0 ready.
+IP address                Interface  State      Since         Interval  Timeout
+fd00:cafe:10::1           vlan11     Up         14:23:45.100    0.300    0.900
+fd00:cafe:10::2           vlan11     Down       14:24:01.200    1.000    0.000`
+
+		sessions := parseBfdOutput(output)
+		if len(sessions) != 2 {
+			t.Fatalf("expected 2 sessions, got %d", len(sessions))
+		}
+		if sessions[0].IP != "fd00:cafe:10::1" || sessions[0].State != "Up" {
+			t.Errorf("session[0] = %+v", sessions[0])
+		}
+		if sessions[1].IP != "fd00:cafe:10::2" || sessions[1].State != "Down" {
+			t.Errorf("session[1] = %+v", sessions[1])
+		}
+	})
+
+	t.Run("malformed lines skipped", func(t *testing.T) {
+		output := `BIRD 3.2.0 ready.
+IP address                Interface  State      Since         Interval  Timeout
+169.254.110.1             vlan11     Up         14:23:45.100    0.300    0.900
+short
+169.254.111.2             vlan12     Down       14:24:01.200    1.000    0.000`
+
+		sessions := parseBfdOutput(output)
+		if len(sessions) != 2 {
+			t.Fatalf("expected 2 sessions (malformed skipped), got %d", len(sessions))
+		}
+	})
 }

--- a/internal/controller/router/connectivity.go
+++ b/internal/controller/router/connectivity.go
@@ -105,7 +105,7 @@ func (cgm *ConnectivityGateManager) HasIPv6Gate() bool {
 	return cgm.ipv6Gate != nil
 }
 
-// classifyConnectivityByFamily determines per-IP-family connectivity from protocol statuses.
+// ClassifyConnectivityByFamily determines per-IP-family connectivity from protocol statuses.
 // Returns true for each family if at least one protocol of that family is established.
 // Protocols not in familyMap are ignored.
 func ClassifyConnectivityByFamily(protocols []bird.ProtocolStatus, familyMap map[string]string) (ipv4Connected, ipv6Connected bool) {

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -28,7 +28,7 @@ MULTUS_VERSION ?= v4.1.2
 WHEREABOUTS_VERSION ?= v0.8.0
 
 # Suites
-SUITES_IPV4 ?= shared-appnetwork separate-appnetwork sctp-multihoming ipv4-simple pod-cache-label
+SUITES_IPV4 ?= shared-appnetwork separate-appnetwork separate-static-appnetwork sctp-multihoming ipv4-simple pod-cache-label
 SUITES_DS ?= dual-stack-simple
 
 # Test flags (e.g., make test GINKGO_FLAGS="--junit-report=report.xml")
@@ -223,6 +223,27 @@ test-separate-appnetwork: ## Run e2e tests for separate-appnetwork suite.
 undeploy-separate-appnetwork: ## Undeploy separate-appnetwork topology.
 	@NS=e2e-separate-appnetwork; \
 	$(KUBECTL) delete validatingwebhookconfiguration meridio-2-validating-webhook-configuration-separate-appnet --ignore-not-found=true; \
+	$(KUBECTL) delete namespace $$NS --ignore-not-found=true
+
+##############################################################################
+##@ Suite: separate-static-appnetwork
+################################################################################
+
+.PHONY: separate-static-appnetwork
+separate-static-appnetwork: deploy-separate-static-appnetwork test-separate-static-appnetwork ## Deploy and test separate-static-appnetwork suite.
+
+.PHONY: deploy-separate-static-appnetwork
+deploy-separate-static-appnetwork: cluster ## Deploy separate-static-appnetwork topology.
+	$(call deploy-suite,e2e-separate-static-appnetwork,$(shell pwd)/suites/separate-static-appnetwork,sep-static-net,sllbr-gw-a1 sllbr-gw-a2)
+
+.PHONY: test-separate-static-appnetwork
+test-separate-static-appnetwork: ## Run e2e tests for separate-static-appnetwork suite.
+	cd $(PROJECT_ROOT)/test/e2e && go run github.com/onsi/ginkgo/v2/ginkgo -v --tags=e2e --focus="Separate Static App Network" $(GINKGO_FLAGS)
+
+.PHONY: undeploy-separate-static-appnetwork
+undeploy-separate-static-appnetwork: ## Undeploy separate-static-appnetwork topology.
+	@NS=e2e-separate-static-appnetwork; \
+	$(KUBECTL) delete validatingwebhookconfiguration meridio-2-validating-webhook-configuration-sep-static-net --ignore-not-found=true; \
 	$(KUBECTL) delete namespace $$NS --ignore-not-found=true
 
 ##############################################################################

--- a/test/e2e/e2e_suite_appnetwork_test.go
+++ b/test/e2e/e2e_suite_appnetwork_test.go
@@ -45,6 +45,16 @@ var testCases = []suiteTestCase{
 		},
 	},
 	{
+		name:           "Separate Static App Network",
+		namespace:      "e2e-separate-static-appnetwork",
+		targetApp:      "target-a",
+		targetReplicas: 2,
+		gateways: []gwTestCase{
+			{name: "gw-a1", vip: "110.0.0.1", targets: 2, dgName: "dg-a1"},
+			{name: "gw-a2", vip: "110.0.0.2", targets: 2, dgName: "dg-a2"},
+		},
+	},
+	{
 		name:           "Shared App Network",
 		namespace:      "e2e-shared-appnetwork",
 		targetApp:      "target-b",
@@ -348,6 +358,8 @@ var _ = Describe("E2E Test Suites", Label("ipv4"), func() {
 							suiteDir = "shared-appnetwork"
 						case "Separate App Network":
 							suiteDir = "separate-appnetwork"
+						case "Separate Static App Network":
+							suiteDir = "separate-static-appnetwork"
 						default:
 							Skip(fmt.Sprintf("Unknown suite: %s", suite.name))
 						}

--- a/test/e2e/suites/README.md
+++ b/test/e2e/suites/README.md
@@ -74,6 +74,8 @@ IPv6 achieves this with `fd00:cafe:{X}::` (external) vs `fd00:cafe:1{X}0::` (int
 | 600 | sctp-multihoming | sctp-gw2 | `169.254.31.0/24` | — | `169.111.30.0/24` | — | `30.0.0.2/32` | 64517 | 4200000000 |
 | 700 | ipv4-simple | gw-m1 | `169.254.40.0/24` | — | `169.111.40.0/24` | — | `40.0.0.1/32` | 64518 | 4200000000 |
 | 800 | pod-cache-label | gw-pcl | `169.254.50.0/24` | — | `169.111.50.0/24` | — | `50.0.0.1/32` | 64519 | 4200000000 |
+| 1100 | separate-static-appnetwork | gw-a1 | `169.254.110.0/24` | — | `169.111.110.0/24` | — | `110.0.0.1/32` | — (static+BFD) | — |
+| 1200 | separate-static-appnetwork | gw-a2 | `169.254.111.0/24` | — | `169.111.110.0/24` | — | `110.0.0.2/32` | — (static+BFD) | — |
 
 **Next available:** VLAN 900, ASN 64520, external `169.254.60.0/24`, internal `169.111.60.0/24`, VIP `60.0.0.1/32`
 
@@ -195,3 +197,4 @@ Update this README whenever you add, remove, or modify a test suite. Specificall
 - BFD is enabled on all sessions with 300ms intervals and multiplier 3 (or 5 for SCTP)
 - The `separate-appnetwork` and `dual-stack` suites share VLAN 100 — they cannot run simultaneously
 - Suites sharing the same VLAN are mutually exclusive (deploy only one at a time)
+- The `separate-static-appnetwork` suite uses static routing with BFD. LB pod IPs are limited to `.1`-`.10` per VLAN (max 10 replicas per gateway) to match the gateway's pre-configured static routes.

--- a/test/e2e/suites/separate-static-appnetwork/dg.yaml
+++ b/test/e2e/suites/separate-static-appnetwork/dg.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: meridio-2.nordix.org/v1alpha1
+kind: DistributionGroup
+metadata:
+  name: dg-a1
+spec:
+  selector:
+    matchLabels:
+      app: target-a
+  maglev:
+    maxEndpoints: 32
+  parentRefs:
+  - name: gw-a1
+---
+apiVersion: meridio-2.nordix.org/v1alpha1
+kind: DistributionGroup
+metadata:
+  name: dg-a2
+spec:
+  selector:
+    matchLabels:
+      app: target-a
+  maglev:
+    maxEndpoints: 32
+  parentRefs:
+  - name: gw-a2

--- a/test/e2e/suites/separate-static-appnetwork/gateway.yaml
+++ b/test/e2e/suites/separate-static-appnetwork/gateway.yaml
@@ -1,0 +1,88 @@
+---
+# Gateway A1 on VLAN 1100 with app-net-a1
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gw-a1
+spec:
+  gatewayClassName: meridio
+  infrastructure:
+    parametersRef:
+      group: meridio-2.nordix.org
+      kind: GatewayConfiguration
+      name: gwconfig-a1
+  listeners:
+  - name: default
+    protocol: TCP
+    port: 80
+---
+apiVersion: meridio-2.nordix.org/v1alpha1
+kind: GatewayConfiguration
+metadata:
+  name: gwconfig-a1
+spec:
+  networkAttachments:
+  - type: NAD
+    nad:
+      name: sysctl-tuning
+      namespace: e2e-separate-static-appnetwork
+      interface: dummy
+  - type: NAD
+    nad:
+      name: vlan-1100
+      namespace: e2e-separate-static-appnetwork
+      interface: vlan-1100
+  - type: NAD
+    nad:
+      name: app-net-a1
+      namespace: e2e-separate-static-appnetwork
+      interface: net-a1
+  internalSubnets:
+  - attachmentType: NAD
+    cidr: "169.111.110.0/24"
+  horizontalScaling:
+    replicas: 2
+---
+# Gateway A2 on VLAN 1200 with app-net-a2
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gw-a2
+spec:
+  gatewayClassName: meridio
+  infrastructure:
+    parametersRef:
+      group: meridio-2.nordix.org
+      kind: GatewayConfiguration
+      name: gwconfig-a2
+  listeners:
+  - name: default
+    protocol: TCP
+    port: 80
+---
+apiVersion: meridio-2.nordix.org/v1alpha1
+kind: GatewayConfiguration
+metadata:
+  name: gwconfig-a2
+spec:
+  networkAttachments:
+  - type: NAD
+    nad:
+      name: sysctl-tuning
+      namespace: e2e-separate-static-appnetwork
+      interface: dummy
+  - type: NAD
+    nad:
+      name: vlan-1200
+      namespace: e2e-separate-static-appnetwork
+      interface: vlan-1200
+  - type: NAD
+    nad:
+      name: app-net-a2
+      namespace: e2e-separate-static-appnetwork
+      interface: net-a2
+  internalSubnets:
+  - attachmentType: NAD
+    cidr: "169.111.110.0/24"
+  horizontalScaling:
+    replicas: 2

--- a/test/e2e/suites/separate-static-appnetwork/kustomization.yaml
+++ b/test/e2e/suites/separate-static-appnetwork/kustomization.yaml
@@ -1,0 +1,71 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: e2e-separate-static-appnetwork
+
+resources:
+- ../../../../config/default
+
+images:
+- name: controller-manager
+  newName: localhost:5001/controller-manager
+  newTag: latest
+
+nameSuffix: -sep-static-net
+
+labels:
+- pairs:
+    e2e-suite: sep-static-net
+
+patches:
+- patch: |-
+    apiVersion: admissionregistration.k8s.io/v1
+    kind: ValidatingWebhookConfiguration
+    metadata:
+      name: not-important
+      annotations:
+        cert-manager.io/inject-ca-from: e2e-separate-static-appnetwork/meridio-2-serving-cert-sep-static-net
+    webhooks:
+    - name: vl34route-v1alpha1.kb.io
+      namespaceSelector:
+        matchLabels:
+          e2e-suite: sep-static-net
+      clientConfig:
+        service:
+          name: meridio-2-webhook-service-sep-static-net
+          namespace: e2e-separate-static-appnetwork
+  target:
+    kind: ValidatingWebhookConfiguration
+- patch: |-
+    - op: replace
+      path: /spec/dnsNames
+      value:
+      - meridio-2-webhook-service-sep-static-net.e2e-separate-static-appnetwork.svc
+      - meridio-2-webhook-service-sep-static-net.e2e-separate-static-appnetwork.svc.cluster.local
+    - op: replace
+      path: /spec/secretName
+      value: webhook-server-cert-sep-static-net
+  target:
+    group: cert-manager.io
+    kind: Certificate
+    name: serving-cert
+- patch: |-
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: not-important
+    spec:
+      template:
+        spec:
+          containers:
+          - name: manager
+            env:
+            - name: MERIDIO_LB_SERVICE_ACCOUNT
+              value: meridio-2-stateless-load-balancer-sep-static-net
+          volumes:
+          - name: webhook-certs
+            secret:
+              secretName: webhook-server-cert-sep-static-net
+  target:
+    kind: Deployment
+    labelSelector: control-plane=controller-manager

--- a/test/e2e/suites/separate-static-appnetwork/nad.yaml
+++ b/test/e2e/suites/separate-static-appnetwork/nad.yaml
@@ -1,0 +1,120 @@
+---
+# Sysctl tuning NAD
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: sysctl-tuning
+spec:
+  config: '{
+      "cniVersion": "0.4.0",
+      "name": "sysctl-tuning",
+      "plugins": [
+        {
+          "type": "tuning",
+          "prevResult": {},
+          "sysctl": {
+            "net.ipv4.conf.all.forwarding": "1",
+            "net.ipv6.conf.all.forwarding": "1",
+            "net.ipv4.fib_multipath_hash_policy": "1",
+            "net.ipv6.fib_multipath_hash_policy": "1",
+            "net.ipv4.conf.all.rp_filter": "2",
+            "net.ipv4.conf.default.rp_filter": "2",
+            "net.ipv4.fwmark_reflect": "1",
+            "net.ipv6.fwmark_reflect": "1",
+            "net.ipv4.ip_local_port_range": "49152 65535"
+          }
+        }
+      ]
+  }'
+---
+# VLAN 1100 NAD for gw-a1 static peering
+# range_start/range_end limits allocation to .1-.10, matching the gateway's
+# static routes. The /24 subnet ensures L2 reachability to the gateway (.150).
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: vlan-1100
+spec:
+  config: |
+    {
+      "cniVersion": "0.3.1",
+      "type": "vlan",
+      "master": "eth0",
+      "vlanId": 1100,
+      "ipam": {
+        "type": "whereabouts",
+        "ipRanges": [
+          { "range": "169.254.110.0/24", "range_start": "169.254.110.1", "range_end": "169.254.110.10", "exclude": ["169.254.110.150/32"] }
+        ]
+      }
+    }
+---
+# VLAN 1200 NAD for gw-a2 static peering
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: vlan-1200
+spec:
+  config: |
+    {
+      "cniVersion": "0.3.1",
+      "type": "vlan",
+      "master": "eth0",
+      "vlanId": 1200,
+      "ipam": {
+        "type": "whereabouts",
+        "ipRanges": [
+          { "range": "169.254.111.0/24", "range_start": "169.254.111.1", "range_end": "169.254.111.10", "exclude": ["169.254.111.150/32"] }
+        ]
+      }
+    }
+---
+# App network for gw-a1 (SLLBR ↔ app Pods)
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: app-net-a1
+spec:
+  config: |
+    {
+      "cniVersion": "1.0.0",
+      "name": "app-net-a1",
+      "plugins": [
+        {
+          "type": "macvlan",
+          "master": "eth0",
+          "mode": "bridge",
+          "ipam": {
+            "type": "whereabouts",
+            "ipRanges": [
+              { "range": "169.111.110.0/24" }
+            ]
+          }
+        }
+      ]
+    }
+---
+# App network for gw-a2 (separate from gw-a1)
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: app-net-a2
+spec:
+  config: |
+    {
+      "cniVersion": "1.0.0",
+      "name": "app-net-a2",
+      "plugins": [
+        {
+          "type": "macvlan",
+          "master": "eth0",
+          "mode": "bridge",
+          "ipam": {
+            "type": "whereabouts",
+            "ipRanges": [
+              { "range": "169.111.110.0/24" }
+            ]
+          }
+        }
+      ]
+    }

--- a/test/e2e/suites/separate-static-appnetwork/rbac.yaml
+++ b/test/e2e/suites/separate-static-appnetwork/rbac.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: meridio-2-network-sidecar
+  namespace: e2e-separate-static-appnetwork
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: meridio-2-network-sidecar
+  namespace: e2e-separate-static-appnetwork
+rules:
+- apiGroups: ["meridio-2.nordix.org"]
+  resources: ["endpointnetworkconfigurations"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["meridio-2.nordix.org"]
+  resources: ["endpointnetworkconfigurations/status"]
+  verbs: ["get", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: meridio-2-network-sidecar
+  namespace: e2e-separate-static-appnetwork
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: meridio-2-network-sidecar
+subjects:
+- kind: ServiceAccount
+  name: meridio-2-network-sidecar
+  namespace: e2e-separate-static-appnetwork

--- a/test/e2e/suites/separate-static-appnetwork/routing.yaml
+++ b/test/e2e/suites/separate-static-appnetwork/routing.yaml
@@ -1,0 +1,74 @@
+---
+# gw-a1 router (VLAN 1100, static+BFD)
+apiVersion: meridio-2.nordix.org/v1alpha1
+kind: GatewayRouter
+metadata:
+  name: gw-a1-router-v4-static
+spec:
+  gatewayRef:
+    name: gw-a1
+  interface: "vlan-1100"
+  address: "169.254.110.150"
+  protocol: "Static"
+  static:
+    bfd:
+      minTx: 300ms
+      minRx: 300ms
+      multiplier: 3
+---
+apiVersion: meridio-2.nordix.org/v1alpha1
+kind: L34Route
+metadata:
+  name: route-a1
+spec:
+  parentRefs:
+  - name: gw-a1
+  backendRefs:
+  - group: meridio-2.nordix.org
+    kind: DistributionGroup
+    name: dg-a1
+  destinationCIDRs:
+  - "110.0.0.1/32"
+  protocols:
+  - TCP
+  - UDP
+  destinationPorts:
+  - "5000-5001"
+  priority: 100
+---
+# gw-a2 router (VLAN 1200, static+BFD)
+apiVersion: meridio-2.nordix.org/v1alpha1
+kind: GatewayRouter
+metadata:
+  name: gw-a2-router-v4-static
+spec:
+  gatewayRef:
+    name: gw-a2
+  interface: "vlan-1200"
+  address: "169.254.111.150"
+  protocol: "Static"
+  static:
+    bfd:
+      minTx: 300ms
+      minRx: 300ms
+      multiplier: 3
+---
+apiVersion: meridio-2.nordix.org/v1alpha1
+kind: L34Route
+metadata:
+  name: route-a2
+spec:
+  parentRefs:
+  - name: gw-a2
+  backendRefs:
+  - group: meridio-2.nordix.org
+    kind: DistributionGroup
+    name: dg-a2
+  destinationCIDRs:
+  - "110.0.0.2/32"
+  protocols:
+  - TCP
+  - UDP
+  destinationPorts:
+  - "5000-5001"
+  priority: 100

--- a/test/e2e/suites/separate-static-appnetwork/targets.yaml
+++ b/test/e2e/suites/separate-static-appnetwork/targets.yaml
@@ -1,0 +1,77 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: target-a
+  labels:
+    app: target-a
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: target-a
+  template:
+    metadata:
+      labels:
+        app: target-a
+      annotations:
+        k8s.v1.cni.cncf.io/networks: app-net-a1, app-net-a2
+    spec:
+      serviceAccountName: meridio-2-network-sidecar
+      volumes:
+      - name: restart-gate
+        emptyDir: {}
+      - name: sidecar-state
+        emptyDir: {}
+      containers:
+      - name: example-target
+        image: registry.nordix.org/cloud-native/meridio-2/example-target:latest
+        imagePullPolicy: IfNotPresent
+        command: ["/bin/bash", "-c"]
+        args:
+        - |
+          screen -d -m bash -c "./ctraffic -server -address [::]:5000" ;
+          screen -d -m bash -c "./ctraffic -server -udp -address [::]:5001" ;
+          trap 'exit 0' TERM; sleep infinity & wait
+        securityContext:
+          runAsNonRoot: true
+          capabilities:
+            drop: ["ALL"]
+            add: ["DAC_OVERRIDE", "NET_RAW", "SYS_PTRACE"]
+      - name: network-sidecar
+        image: registry.nordix.org/cloud-native/meridio-2/network-sidecar:latest
+        imagePullPolicy: IfNotPresent
+        command: ["/bin/sh", "-c"]
+        args:
+        - |
+          if [ -f /restart-gate/already-started ]; then
+            echo "Restart detected - waiting for release signal"
+            while [ ! -f /restart-gate/release-restart ]; do
+              sleep 1
+            done
+            echo "Release signal received - proceeding with startup"
+          fi
+          touch /restart-gate/already-started
+          exec ./network-sidecar run --pod-name="$POD_NAME" --pod-namespace="$POD_NAMESPACE" --pod-uid="$POD_UID" --log-level=debug
+        volumeMounts:
+        - name: restart-gate
+          mountPath: /restart-gate
+        - name: sidecar-state
+          mountPath: /var/run/meridio
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
+        securityContext:
+          capabilities:
+            drop: ["ALL"]
+            add: ["NET_ADMIN"]


### PR DESCRIPTION
https://github.com/Nordix/Meridio-2/issues/104
https://github.com/Nordix/Meridio-2/issues/115

AI summary:
```  Static+BFD Readiness Gates

  What it does

  Extends the connectivity monitoring to support static routing with BFD. Previously, readiness gates (meridio-2.nordix.org/ipv4-connectivity / ipv6-connectivity) only worked for
  BGP sessions. Now, for GatewayRouters using static routing with BFD configured, the readiness gate reflects the BFD session health — if BFD goes down, the protocol is marked as
  not established, the gate goes False, and the ENC controller stops routing traffic through that LB pod.

  How it works

  1. Monitor queries both birdc show protocols and birdc show bfd sessions each tick
  2. applyBfdState() in run.go mutates static protocol statuses:
    - Static + BFD configured + BFD session Up → Info = "Established"
    - Static + BFD configured + BFD session Down/missing → State = Down
    - Static + no BFD → Info = "Established" (always connected)
    - BGP → untouched (BIRD already reports correct state)

  3. All downstream logic (protocolsUp, ClassifyConnectivityByFamily, gate manager) just uses IsEstablished() uniformly — no protocol-specific branching needed

  Files modified

  - internal/bird/monitor.go — BfdSession struct, parseBfdOutput(), BfdSessions on MonitorStatus, BFD query in checkStatus(), BgpInfoEstablished constant
  - internal/controller/router/connectivity.go — unchanged (original simple ClassifyConnectivityByFamily)
  - cmd/router/cmd/run.go — applyBfdState(), routers fetched earlier in monitor loop, passed to mutation before downstream logic

  Tests

  - cmd/router/cmd/run_test.go — unit tests for applyBfdState (8 cases: BFD up/down/missing, no BFD, BGP untouched, mixed protocols, etc.)
  - api/v1alpha1/gatewayrouter_validation_test.go — added test confirming empty static: {} (no BFD) is accepted by the API

  E2E suite

  - test/e2e/suites/separate-static-appnetwork/ — new suite with static+BFD routing, VIPs 110.0.0.1/110.0.0.2, VLANs 1100/1200
  - VPN gateway configured with 10 static routes per VIP with BFD — allows scaling to 10 replicas without gateway reconfiguration
  - NADs use range_start/range_end to constrain LB pod IPs to .1-.10
  - Added to SUITES_IPV4 in test/e2e/Makefile and testCases in e2e_suite_appnetwork_test.go
  - Updated all e2e routing.yaml files to explicitly set protocol: "BGP" or "Static"
  - Updated VPN gateway (init.sh, bird-gw.conf) addresses from 169.254.60/61 to 169.254.110/111

  API fixes

  - Added +kubebuilder:validation:Format="" + Maximum=4294967295 + Minimum=0 on RemoteASN/LocalASN to allow 4-byte ASNs
  - Removed the immutability of BGPSpec, StaticSpec, and Protocol fields.
  ```
