### PR TITLE
Defensive ordering sorts (#172)

### DIFF
--- a/internal/bird/bird.go
+++ b/internal/bird/bird.go
@@ -172,6 +172,12 @@ func (b *Bird) generateConfig(vips []string, routers []*meridio2v1alpha1.Gateway
 		}
 	}
 
+	// Sort VIPs for deterministic config output: input order depends on
+	// Gateway status addresses which are pre-sorted, but sort defensively
+	// to guarantee stable BIRD config regardless of caller ordering.
+	slices.Sort(data.IPv4VIPs)
+	slices.Sort(data.IPv6VIPs)
+
 	slices.SortFunc(routers, func(a, b *meridio2v1alpha1.GatewayRouter) int {
 		return cmp.Compare(a.Name, b.Name)
 	})

--- a/internal/bird/bird.go
+++ b/internal/bird/bird.go
@@ -54,9 +54,10 @@ type Config struct {
 
 type Bird struct {
 	Config
-	nl      abstractNetlink
-	running bool
-	mu      sync.Mutex
+	nl         abstractNetlink
+	running    bool
+	lastConfig string // last written config for skip-if-unchanged guard
+	mu         sync.Mutex
 }
 
 func New(cfg Config) (*Bird, error) {
@@ -94,10 +95,16 @@ func (b *Bird) Run(ctx context.Context) error {
 	}
 
 	if _, err := os.Stat(b.ConfigFile); errors.Is(err, os.ErrNotExist) {
-		if err := b.writeConfig([]string{}, []*meridio2v1alpha1.GatewayRouter{}); err != nil {
+		conf, err := b.generateConfig([]string{}, []*meridio2v1alpha1.GatewayRouter{})
+		if err != nil {
 			b.mu.Unlock()
 			return err
 		}
+		if err := b.writeConfigString(conf); err != nil {
+			b.mu.Unlock()
+			return err
+		}
+		b.lastConfig = conf
 	}
 
 	cmd := exec.CommandContext(ctx, "bird", "-d", "-c", b.ConfigFile, "-s", b.SocketPath)
@@ -146,7 +153,18 @@ func (b *Bird) Configure(ctx context.Context, vips []string, routers []*meridio2
 		return err
 	}
 
-	if err := b.writeConfig(vips, routers); err != nil {
+	conf, err := b.generateConfig(vips, routers)
+	if err != nil {
+		return err
+	}
+
+	// Skip file write and BIRD reload if config is unchanged.
+	// Relies on generateConfig producing deterministic output (sorted VIPs and routers).
+	if conf == b.lastConfig {
+		return nil
+	}
+
+	if err := b.writeConfigString(conf); err != nil {
 		return err
 	}
 
@@ -157,6 +175,10 @@ func (b *Bird) Configure(ctx context.Context, vips []string, routers []*meridio2
 			return fmt.Errorf("birdc configure failed: %w: %s", err, out)
 		}
 	}
+
+	// Update lastConfig only after successful write and reload.
+	// If either fails, the next reconcile must retry.
+	b.lastConfig = conf
 
 	return nil
 }
@@ -222,12 +244,7 @@ func (b *Bird) generateConfig(vips []string, routers []*meridio2v1alpha1.Gateway
 	return buf.String(), nil
 }
 
-func (b *Bird) writeConfig(vips []string, routers []*meridio2v1alpha1.GatewayRouter) error {
-	conf, err := b.generateConfig(vips, routers)
-	if err != nil {
-		return err
-	}
-
+func (b *Bird) writeConfigString(conf string) error {
 	tmp := b.ConfigFile + ".tmp"
 	if err := os.WriteFile(tmp, []byte(conf), 0644); err != nil {
 		return err

--- a/internal/bird/bird_test.go
+++ b/internal/bird/bird_test.go
@@ -551,3 +551,62 @@ func normalizeWhitespace(s string) string {
 func uint16Ptr(i uint16) *uint16 {
 	return &i
 }
+
+func TestGenerateConfig_Deterministic(t *testing.T) {
+	b, err := New(testConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	routers := []*meridio2v1alpha1.GatewayRouter{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "router-a"},
+			Spec: meridio2v1alpha1.GatewayRouterSpec{
+				Interface: "ext1", Address: "169.254.100.1",
+				BGP: &testBGPSpec,
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "router-b"},
+			Spec: meridio2v1alpha1.GatewayRouterSpec{
+				Interface: "ext2", Address: "169.254.100.2",
+				BGP: &testBGPSpec,
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "router-c"},
+			Spec: meridio2v1alpha1.GatewayRouterSpec{
+				Interface: "ext3", Address: "169.254.100.3",
+				BGP: &testBGPSpec,
+			},
+		},
+	}
+
+	// Different input orderings must produce identical config output
+	vipPermutations := [][]string{
+		{"10.0.0.1/32", "10.0.0.2/32", "10.0.0.3/32", "2001:db8::1/128", "2001:db8::2/128", "2001:db8::3/128"},
+		{"2001:db8::3/128", "10.0.0.3/32", "2001:db8::1/128", "10.0.0.1/32", "2001:db8::2/128", "10.0.0.2/32"},
+		{"10.0.0.3/32", "10.0.0.2/32", "10.0.0.1/32", "2001:db8::3/128", "2001:db8::2/128", "2001:db8::1/128"},
+	}
+
+	routerPermutations := [][]*meridio2v1alpha1.GatewayRouter{
+		{routers[0], routers[1], routers[2]},
+		{routers[2], routers[0], routers[1]},
+		{routers[1], routers[2], routers[0]},
+	}
+
+	var reference string
+	for i, vips := range vipPermutations {
+		for j, rts := range routerPermutations {
+			conf, err := b.generateConfig(vips, rts)
+			if err != nil {
+				t.Fatalf("vips[%d] routers[%d]: generateConfig() error = %v", i, j, err)
+			}
+			if reference == "" {
+				reference = conf
+			} else if conf != reference {
+				t.Fatalf("vips[%d] routers[%d]: config differs from reference (input ordering affected output)", i, j)
+			}
+		}
+	}
+}

--- a/internal/bird/bird_test.go
+++ b/internal/bird/bird_test.go
@@ -17,8 +17,11 @@ limitations under the License.
 package bird
 
 import (
+	"context"
+	"os"
 	"strings"
 	"testing"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -608,5 +611,57 @@ func TestGenerateConfig_Deterministic(t *testing.T) {
 				t.Fatalf("vips[%d] routers[%d]: config differs from reference (input ordering affected output)", i, j)
 			}
 		}
+	}
+}
+
+func TestConfigure_SkipsRewriteWhenUnchanged(t *testing.T) {
+	dir := t.TempDir()
+	cfg := Config{
+		SocketPath:     dir + "/bird.ctl",
+		ConfigFile:     dir + "/bird.conf",
+		TableID:        4096,
+		RulePriority:   100,
+		KernelScanTime: 10,
+	}
+	b, err := New(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b.nl = &netlinkMock{} // avoid real netlink calls
+
+	vips := []string{"20.0.0.1", "2001:db8::1"}
+	routers := []*meridio2v1alpha1.GatewayRouter{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "router-a"},
+			Spec: meridio2v1alpha1.GatewayRouterSpec{
+				Interface: "ext1", Address: "169.254.100.1",
+				BGP: &testBGPSpec,
+			},
+		},
+	}
+
+	// First Configure writes the config file
+	if err := b.Configure(context.Background(), vips, routers); err != nil {
+		t.Fatal(err)
+	}
+	info1, err := os.Stat(cfg.ConfigFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Ensure mtime would differ if file is rewritten
+	time.Sleep(10 * time.Millisecond)
+
+	// Second Configure with same inputs should skip the write
+	if err := b.Configure(context.Background(), vips, routers); err != nil {
+		t.Fatal(err)
+	}
+	info2, err := os.Stat(cfg.ConfigFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if info2.ModTime() != info1.ModTime() {
+		t.Error("config file was rewritten despite no change (skip-if-unchanged guard failed)")
 	}
 }

--- a/internal/controller/router/controller.go
+++ b/internal/controller/router/controller.go
@@ -19,6 +19,7 @@ package router
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -165,6 +166,12 @@ func getVIPs(gateway *gatewayapiv1.Gateway) []string {
 			seen[addr.Value] = struct{}{}
 		}
 	}
+
+	// Sort for deterministic BIRD config generation: Gateway status addresses
+	// are pre-sorted by the gateway controller, but sort defensively to avoid
+	// config rewrites if that invariant is ever broken.
+	slices.Sort(vips)
+
 	return vips
 }
 

--- a/internal/controller/router/controller_test.go
+++ b/internal/controller/router/controller_test.go
@@ -478,3 +478,20 @@ done:
 	// At least 1 event was delivered (the first one); dropped events don't crash
 	assert.GreaterOrEqual(t, drained, 1)
 }
+
+func TestGetVIPs_Deterministic(t *testing.T) {
+	// Different address orderings must produce the same sorted output
+	permutations := [][]string{
+		{"40.0.0.1", "10.0.0.1", "2000::2", "20.0.0.1", "2000::1", "30.0.0.1"},
+		{"10.0.0.1", "20.0.0.1", "30.0.0.1", "40.0.0.1", "2000::1", "2000::2"},
+		{"2000::2", "2000::1", "40.0.0.1", "30.0.0.1", "20.0.0.1", "10.0.0.1"},
+	}
+
+	expected := []string{"10.0.0.1", "20.0.0.1", "2000::1", "2000::2", "30.0.0.1", "40.0.0.1"}
+
+	for i, addrs := range permutations {
+		gw := newGateway(testGatewayName, testNamespace, addrs...)
+		vips := getVIPs(gw)
+		assert.Equal(t, expected, vips, "permutation %d: input ordering affected output", i)
+	}
+}


### PR DESCRIPTION
Add defensive sorts at output boundaries to prevent non-deterministic ordering
Addresses #172: 
- Adds sorting at output boundaries where map iteration or cache list order could produce non-deterministic slices that propagate to API writes or config generation.
  Add defensive sorts in these locations:
   - distributiongroup/gateways.go:listReferencedGateways — sort returned gateways slice by namespace/name. Update: the sort in listReferencedGateways doesn't actually prevent any unnecessary update or reconcile — it's purely cosmetic (maybe slightly nicer log output). It doesn't fit the issue's scope)
   - router/controller.go:getVIPs — sort vips before returning
   - bird/bird.go:generateConfig — sort data.IPv4VIPs and data.IPv6VIPs after splitting
- tests verify that outputs remain stable across repeated calls with the same input, catching non-deterministic ordering from map iteration.
- Skip BIRD config write and reload when unchanged