### PR TITLE
Change HorizontalScaling EnforceReplicas default to true

### DIFF
--- a/api/v1alpha1/gatewayconfiguration_types.go
+++ b/api/v1alpha1/gatewayconfiguration_types.go
@@ -117,7 +117,7 @@ type HorizontalScaling struct {
 	// If true, the controller enforces the replicas value on every reconcile.
 	// If false, the controller only sets replicas on initial creation, allowing
 	// HPA or other autoscalers to manage the count afterward.
-	// +kubebuilder:default=false
+	// +kubebuilder:default=true
 	EnforceReplicas bool `json:"enforceReplicas"`
 }
 

--- a/config/crd/bases/meridio-2.nordix.org_gatewayconfigurations.yaml
+++ b/config/crd/bases/meridio-2.nordix.org_gatewayconfigurations.yaml
@@ -47,7 +47,7 @@ spec:
                   https://kubernetes.io/docs/concepts/workloads/autoscaling/horizontal-pod-autoscale/
                 properties:
                   enforceReplicas:
-                    default: false
+                    default: true
                     description: |-
                       enforceReplicas controls whether the controller manages the replica count.
                       If true, the controller enforces the replicas value on every reconcile.

--- a/docs/controllers/distributiongroup.md
+++ b/docs/controllers/distributiongroup.md
@@ -501,7 +501,7 @@ spec:
     - cidr: "2001:db8:100::/64"
   horizontalScaling:
     replicas: 1
-    enforceReplicas: false
+    enforceReplicas: false  # Not needed for single-replica test setup
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway

--- a/docs/controllers/gateway.md
+++ b/docs/controllers/gateway.md
@@ -327,12 +327,20 @@ Controls LB Deployment replica count with optional HPA integration:
 ```yaml
 horizontalScaling:
   replicas: 2
-  enforceReplicas: false  # Let HPA manage (default)
+  enforceReplicas: true  # Controller enforces on every reconcile (default)
+```
+
+To defer scaling to an external autoscaler (HPA, KEDA), opt out explicitly:
+
+```yaml
+horizontalScaling:
+  replicas: 2             # Seed value for initial creation
+  enforceReplicas: false  # Let HPA/KEDA manage after initial deployment
 ```
 
 **Behavior:**
-- `enforceReplicas=false`: Apply replicas on initial creation, skip updates (HPA manages)
-- `enforceReplicas=true`: Always enforce replicas value (override HPA)
+- `enforceReplicas=true` (default): Always enforce the configured replicas value — manual edits or external changes are reconciled back
+- `enforceReplicas=false`: Apply replicas on initial creation only, skip updates (HPA/KEDA manages)
 
 ### Vertical Scaling
 

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -60,7 +60,7 @@ kubectl get pods -n <namespace>
 
 Expected Pods:
 - **controller-manager** — 1 Pod, 1/1 Ready
-- **sllbr-\<gateway-name\>** — LB Pods (2 containers each: `loadbalancer` + `router`), count matches `GatewayConfiguration.spec.horizontalScaling.replicas` (default: 2) unless HPA is managing the Deployment (`enforceReplicas: false`)
+- **sllbr-\<gateway-name\>** — LB Pods (2 containers each: `loadbalancer` + `router`), count matches `GatewayConfiguration.spec.horizontalScaling.replicas` (default: 2). If `enforceReplicas: false` is set, the controller only seeds the initial count and defers to an external scaler (HPA/KEDA).
 - **Application Pods** — with network-sidecar container if using EndpointNetworkConfiguration
 
 All Pods should be Running with all containers ready. Check for restarts.


### PR DESCRIPTION
#209

Flips HorizontalScaling.EnforceReplicas default from false to true so the controller enforces the configured replica count on every reconcile by default.

**Rationale:** Users declaring replicas: 3 expect the system to maintain 3 replicas. The previous default silently allowed drift from manual edits or external changes with no correction. 
Users integrating HPA/KEDA can explicitly opt out with enforceReplicas: false.

**Changes:**
- gatewayconfiguration_types.go: Flip kubebuilder:default
- CRD YAML regenerated
- Docs updated (gateway.md, troubleshooting.md, distributiongroup.md)

**No test impact** — existing unit and e2e tests don't rely on the previous false default behavior.