### PR TITLE
Add OpenShift CRC e2e validation suite (dual-stack)

### DIFF
--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -134,16 +134,17 @@ cluster-cleanup: ## Cleanup cluster dependencies.
 ################################################################################
 
 # deploy-suite: Deploy a test suite
-# Args: $(1)=namespace, $(2)=suite-dir, $(3)=suite-label, $(4)=sllbr-deployments
+# Args: $(1)=namespace, $(2)=suite-dir, $(3)=suite-label, $(4)=sllbr-deployments, $(5)=lb-template (optional)
 define deploy-suite
 	@NS=$(1); \
 	SUITE_DIR=$(2); \
 	SUITE_LABEL=$(3); \
+	LB_TEMPLATE=$(if $(5),$(5),$(PROJECT_ROOT)/config/templates/lb-deployment.yaml); \
 	$(KUBECTL) create namespace $$NS --dry-run=client -o yaml | $(KUBECTL) apply -f -; \
 	$(KUBECTL) label namespace $$NS e2e-suite=$$SUITE_LABEL --overwrite; \
 	$(KUBECTL) apply -f suites/common/gatewayclass.yaml; \
 	sed 's|registry.nordix.org/cloud-native/meridio-2|$(REGISTRY)|g; s|:latest|:$(VERSION)|g' \
-		$(PROJECT_ROOT)/config/templates/lb-deployment.yaml | \
+		$$LB_TEMPLATE | \
 		$(KUBECTL) create configmap lb-template-override-$$SUITE_LABEL --from-file=lb-deployment.yaml=/dev/stdin -n $$NS --dry-run=client -o yaml | \
 		$(KUBECTL) apply -f -; \
 	cd $$SUITE_DIR && $(KUSTOMIZE) edit set image controller-manager=$(REGISTRY)/controller-manager:$(VERSION); \
@@ -418,3 +419,81 @@ test-dual-stack: ## Run all dual-stack e2e tests in parallel.
 .PHONY: undeploy-dual-stack
 undeploy-dual-stack: ## Undeploy all dual-stack suites.
 	@for suite in $(SUITES_DS); do $(MAKE) undeploy-$$suite; done
+
+################################################################################
+##@ Suite: openshift-crc
+################################################################################
+
+# OpenShift CRC registry configuration.
+# OCP_REGISTRY_HOST: external route hostname for docker push (from host).
+# OCP_NAMESPACE: namespace where images and workloads are deployed.
+# Derived:
+#   OCP_PUSH_REGISTRY: used for docker tag/push (external route).
+#   OCP_INTERNAL_REGISTRY: used by pods to pull images (cluster-internal service).
+OCP_REGISTRY_HOST ?= default-route-openshift-image-registry.apps-crc.testing
+OCP_NAMESPACE ?= meridio-2
+OCP_PUSH_REGISTRY = $(OCP_REGISTRY_HOST)/$(OCP_NAMESPACE)
+OCP_INTERNAL_REGISTRY = image-registry.openshift-image-registry.svc:5000/$(OCP_NAMESPACE)
+OCP_IMAGES ?= controller-manager stateless-load-balancer router network-sidecar example-target vpn-gateway
+
+.PHONY: crc-registry-login
+crc-registry-login: ## [CRC-only] Trust CRC registry CA and docker login (needs sudo).
+	@echo "Extracting CRC registry CA..."
+	@$(KUBECTL) get secret -n openshift-ingress-operator router-ca -o jsonpath='{.data.tls\.crt}' | base64 -d > /tmp/crc-ca.crt
+	@$(KUBECTL) get secret -n openshift-ingress router-certs-default -o jsonpath='{.data.tls\.crt}' | base64 -d >> /tmp/crc-ca.crt
+	@echo "Installing CA into /etc/docker/certs.d/$(OCP_REGISTRY_HOST) (requires sudo)..."
+	@sudo mkdir -p /etc/docker/certs.d/$(OCP_REGISTRY_HOST)
+	@sudo cp /tmp/crc-ca.crt /etc/docker/certs.d/$(OCP_REGISTRY_HOST)/ca.crt
+	@echo "Logging in to $(OCP_REGISTRY_HOST)..."
+	@docker login -u kubeadmin -p "$$($(KUBECTL) whoami -t)" $(OCP_REGISTRY_HOST)
+	@echo "Registry login complete"
+
+.PHONY: push-images-openshift-crc
+push-images-openshift-crc: ## Tag and push all images to CRC internal registry (requires docker login).
+	@echo "Ensuring namespace $(OCP_NAMESPACE) exists..."
+	@$(KUBECTL) create namespace $(OCP_NAMESPACE) --dry-run=client -o yaml | $(KUBECTL) apply -f -
+	@echo "Creating ImageStreams in namespace $(OCP_NAMESPACE)..."
+	@for img in $(OCP_IMAGES); do \
+		$(KUBECTL) create imagestream $$img -n $(OCP_NAMESPACE) 2>/dev/null || true; \
+	done
+	@echo "Building VPN gateway (not covered by root Makefile)..."
+	@docker build -t vpn-gateway:$(VERSION) $(PROJECT_ROOT)/hack/vpn-gateway/
+	@echo "Tagging and pushing images to $(OCP_PUSH_REGISTRY)..."
+	@for img in $(OCP_IMAGES); do \
+		docker tag $$img:$(VERSION) $(OCP_PUSH_REGISTRY)/$$img:$(VERSION); \
+		docker push $(OCP_PUSH_REGISTRY)/$$img:$(VERSION); \
+	done
+	@echo "All images pushed to $(OCP_PUSH_REGISTRY)"
+
+.PHONY: deploy-openshift-crc
+deploy-openshift-crc: kustomize cert-manager push-images-openshift-crc ## Deploy openshift-crc topology (requires CRC prerequisites + pushed images).
+deploy-openshift-crc: REGISTRY = $(OCP_INTERNAL_REGISTRY)
+deploy-openshift-crc:
+	@echo "Deploying OpenShift CRC suite (namespace: $(OCP_NAMESPACE))..."
+	@NS=$(OCP_NAMESPACE); \
+	$(KUBECTL) apply -f suites/openshift-crc/namespace.yaml; \
+	$(KUBECTL) apply -f suites/openshift-crc/scc.yaml; \
+	$(KUBECTL) apply -f suites/openshift-crc/rbac.yaml -n $$NS; \
+	$(KUBECTL) adm policy add-scc-to-user meridio-lb -z meridio-2-stateless-load-balancer-ocp -n $$NS; \
+	$(KUBECTL) adm policy add-scc-to-user meridio-sidecar -z meridio-2-network-sidecar -n $$NS; \
+	$(KUBECTL) adm policy add-scc-to-user privileged -z vpn-gateway -n $$NS
+	@echo "Deploying VPN gateway pod (must be up before LB readiness gates can clear)..."
+	@NS=$(OCP_NAMESPACE); \
+	$(KUBECTL) apply -f suites/openshift-crc/nad.yaml -n $$NS; \
+	sed 's|registry.nordix.org/cloud-native/meridio-2|$(OCP_INTERNAL_REGISTRY)|g; s|:latest|:$(VERSION)|g' \
+		suites/openshift-crc/vpn-gateway.yaml | $(KUBECTL) apply -n $$NS -f -; \
+	timeout=120; elapsed=0; \
+	until $(KUBECTL) get pod vpn-gateway -n $$NS -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null | grep -q "True"; do \
+		sleep 2; elapsed=$$((elapsed + 2)); \
+		if [ $$elapsed -ge $$timeout ]; then echo "Timeout waiting for vpn-gateway pod"; exit 1; fi; \
+	done; \
+	echo "VPN gateway ready"
+	$(call deploy-suite,$(OCP_NAMESPACE),$(shell pwd)/suites/openshift-crc,ocp,sllbr-gw-ocp,$(shell pwd)/suites/openshift-crc/lb-deployment.yaml)
+	@echo "OpenShift CRC suite deployed successfully"
+
+.PHONY: undeploy-openshift-crc
+undeploy-openshift-crc: ## Undeploy openshift-crc topology.
+	@NS=$(OCP_NAMESPACE); \
+	$(KUBECTL) delete validatingwebhookconfiguration meridio-2-validating-webhook-configuration-ocp --ignore-not-found=true; \
+	$(KUBECTL) delete -f suites/openshift-crc/scc.yaml --ignore-not-found=true; \
+	$(KUBECTL) delete namespace $$NS --ignore-not-found=true

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -430,11 +430,20 @@ undeploy-dual-stack: ## Undeploy all dual-stack suites.
 # Derived:
 #   OCP_PUSH_REGISTRY: used for docker tag/push (external route).
 #   OCP_INTERNAL_REGISTRY: used by pods to pull images (cluster-internal service).
+# OCP_USE_NORDIX: if true, pull controller-manager/stateless-load-balancer/router/
+#   network-sidecar/example-target directly from registry.nordix.org instead of
+#   building and pushing them to the CRC internal registry. vpn-gateway has no
+#   published image and is always built/pushed locally regardless of this flag.
 OCP_REGISTRY_HOST ?= default-route-openshift-image-registry.apps-crc.testing
 OCP_NAMESPACE ?= meridio-2
 OCP_PUSH_REGISTRY = $(OCP_REGISTRY_HOST)/$(OCP_NAMESPACE)
 OCP_INTERNAL_REGISTRY = image-registry.openshift-image-registry.svc:5000/$(OCP_NAMESPACE)
+OCP_USE_NORDIX ?= false
+ifeq ($(OCP_USE_NORDIX),true)
+OCP_IMAGES ?= vpn-gateway
+else
 OCP_IMAGES ?= controller-manager stateless-load-balancer router network-sidecar example-target vpn-gateway
+endif
 
 .PHONY: crc-registry-login
 crc-registry-login: ## [CRC-only] Trust CRC registry CA and docker login (needs sudo).
@@ -467,7 +476,9 @@ push-images-openshift-crc: ## Tag and push all images to CRC internal registry (
 
 .PHONY: deploy-openshift-crc
 deploy-openshift-crc: kustomize cert-manager push-images-openshift-crc ## Deploy openshift-crc topology (requires CRC prerequisites + pushed images).
+ifneq ($(OCP_USE_NORDIX),true)
 deploy-openshift-crc: REGISTRY = $(OCP_INTERNAL_REGISTRY)
+endif
 deploy-openshift-crc:
 	@echo "Deploying OpenShift CRC suite (namespace: $(OCP_NAMESPACE))..."
 	@NS=$(OCP_NAMESPACE); \

--- a/test/e2e/suites/openshift-crc/README.md
+++ b/test/e2e/suites/openshift-crc/README.md
@@ -131,10 +131,11 @@ make -C test/e2e/ deploy-openshift-crc KUBECTL=oc
 make -C test/e2e undeploy-openshift-crc KUBECTL=oc
 ```
 
-The `openshift-crc` target handles: namespace creation, ImageStreams, image push (tag+push of
-locally-built images + vpn-gateway build), cert-manager install, SCCs, RBAC, controller-manager
-(via kustomize overlay with RBAC finalizer patches + LB template override), VPN gateway, NADs,
-Gateway, routing, targets, and waits for all pods to become Ready.
+Together, `push-images-openshift-crc` and `deploy-openshift-crc` handle: namespace creation,
+ImageStreams, image push (tag+push of locally-built images + vpn-gateway build), cert-manager
+install, SCCs, RBAC, controller-manager (via kustomize overlay with RBAC finalizer patches + LB
+template override), VPN gateway, NADs, Gateway, routing, targets, and waits for all pods to
+become Ready.
 
 ---
 
@@ -232,7 +233,6 @@ make -C test/e2e undeploy-openshift-crc KUBECTL=oc
 | `push-images-openshift-crc` | Create namespace + ImageStreams, build vpn-gateway, tag+push all 6 images |
 | `deploy-openshift-crc` | Full deployment (cert-manager, SCCs, controller-manager, VPN gateway, topology, wait for Ready) |
 | `undeploy-openshift-crc` | Delete webhook config, SCCs, and namespace (removes everything) |
-| `openshift-crc` | Umbrella: push-images + deploy |
 
 All targets accept `KUBECTL=oc` and derive registry paths from:
 - `OCP_REGISTRY_HOST` (default: `default-route-openshift-image-registry.apps-crc.testing`)
@@ -247,7 +247,7 @@ All targets accept `KUBECTL=oc` and derive registry paths from:
 | `namespace.yaml` | Namespace with PSA=privileged labels |
 | `kubeletconfig.yaml` | KubeletConfig to allowlist unsafe sysctls (triggers node reboot) |
 | `scc.yaml` | Custom SCCs: `meridio-lb` (LB pods) and `meridio-sidecar` (target+sidecar pods) |
-| `kustomization.yaml` | Deploys controller-manager with OpenShift patches (RBAC finalizers + LB template) |
+| `kustomization.yaml` | Deploys controller-manager with OpenShift patches (RBAC finalizers + webhook/cert naming) |
 | `nad.yaml` | NetworkAttachmentDefinitions (bridge CNI: bgp-net with VLAN 100, app-net) |
 | `gateway.yaml` | Gateway + GatewayConfiguration |
 | `routing.yaml` | GatewayRouter (IPv4 + IPv6, protocol: BGP) + L34Route |
@@ -255,7 +255,7 @@ All targets accept `KUBECTL=oc` and derive registry paths from:
 | `targets.yaml` | Target Pod Deployment (2 replicas + network-sidecar) |
 | `rbac.yaml` | ServiceAccounts + Role + RoleBinding |
 | `vpn-gateway.yaml` | VPN gateway ConfigMap (BIRD config, passive BGP) + Pod |
-| `lb-deployment.yaml` | OpenShift-adapted LB template (reference; embedded in kustomization.yaml) |
+| `lb-deployment.yaml` | OpenShift-adapted LB template, injected via the `deploy-suite` override mechanism (`MERIDIO_TEMPLATE_PATH`) |
 
 ---
 

--- a/test/e2e/suites/openshift-crc/README.md
+++ b/test/e2e/suites/openshift-crc/README.md
@@ -1,0 +1,304 @@
+# OpenShift CRC Validation Suite (Dual-Stack)
+
+This suite validates Meridio-2 end-to-end on OpenShift (CRC single-node) with dual-stack (IPv4 + IPv6).
+
+It is designed for **occasional manual validation** of OpenShift compatibility. Follow it top to
+bottom on a fresh CRC instance, or use the Makefile targets for the deployment steps.
+
+All commands are written to be run from the **project root** (`Meridio-2/`).
+
+---
+
+## Architecture
+
+All components run inside the cluster using bridge CNI networks:
+
+```
+┌──────────────────────────────────────────────────────────────────────────┐
+│  CRC Node (single)                                                       │
+│                                                                          │
+│  ┌───────────────────┐  bridge br-meridio (VLAN 100) ┌──────────────────┐│
+│  │  VPN Gateway Pod  │◄──── BGP peering ──────────►  │  LB Pod (SLLBR)  ││
+│  │  (BIRD, ctraffic) │   169.254.100.0/24            │  router + nfqlb  ││
+│  │  169.254.100.150  │   fd00:cafe:100::/64          │  169.254.100.X   ││
+│  └───────────────────┘                               └────────┬─────────┘│
+│                                                               │          │
+│                                                 bridge br-meridio-app    │
+│                                                 169.111.100.0/24         │
+│                                                 fd00:cafe:1100::/64      │
+│                                                               │          │
+│                                                 ┌─────────────┴────────┐ │
+│                                                 │  Target Pods (x2)    │ │
+│                                                 │  + network-sidecar   │ │
+│                                                 │  169.111.100.X + VIP │ │
+│                                                 └──────────────────────┘ │
+│                                                                          │
+└──────────────────────────────────────────────────────────────────────────┘
+```
+
+## Addressing (Dual-Stack)
+
+| Role | IPv4 | IPv6 | Notes |
+|------|------|------|-------|
+| BGP peering (external) | 169.254.100.0/24 | fd00:cafe:100::/64 | VPN gateway at .150 / ::150 |
+| App network (internal) | 169.111.100.0/24 | fd00:cafe:1100::/64 | LB → target traffic |
+| VIP | 100.0.0.1/32 | fd00:cafe:1::1/128 | Advertised via BGP |
+| LB local ASN | 64512 | 64512 | Same for both families |
+| VPN gateway ASN | 4200000000 | 4200000000 | Same for both families |
+| BGP port | 10179 | 10179 | Both sides |
+
+**Critical**: External and internal subnets MUST differ. The kernel resolves BGP next-hops
+by matching against locally-connected subnets. Shared subnets would pick the wrong interface.
+
+---
+
+## Prerequisites (one-time per CRC instance)
+
+These steps configure the CRC node for Meridio-2's kernel and security requirements.
+They persist across `crc stop`/`crc start` cycles but require a node reboot on first apply.
+
+### 1. Start CRC and log in
+
+```bash
+# Recommended: set disk to 50GB before first 'crc start' to avoid disk pressure
+crc config set disk-size 50
+
+crc start
+eval $(crc oc-env)
+oc login -u kubeadmin -p $(cat ~/.crc/machines/crc/kubeadmin-password) https://api.crc.testing:6443
+```
+
+### 2. Load nfnetlink_queue kernel module
+
+NFQLB requires the `nfnetlink_queue` module which is not auto-loaded on CoreOS/OpenShift.
+Make it persistent across reboots:
+
+```bash
+ssh -o StrictHostKeyChecking=no -i ~/.crc/machines/crc/id_ed25519 -p 2222 core@127.0.0.1 \
+  "echo nfnetlink_queue | sudo tee /etc/modules-load.d/meridio.conf && sudo modprobe nfnetlink_queue"
+```
+
+### 3. Allowlist unsafe sysctls via KubeletConfig
+
+OpenShift's kubelet rejects Pod-level unsafe sysctls unless explicitly allowlisted.
+This is a two-layer requirement:
+1. The **SCC** allows the Pod to declare the sysctls (admission control) — handled by the deploy step.
+2. The **KubeletConfig** allows the kubelet to actually apply them (runtime enforcement) — done here.
+
+```bash
+oc apply -f test/e2e/suites/openshift-crc/kubeletconfig.yaml
+```
+
+> **⚠️ This triggers a MachineConfig rollout which reboots the CRC node.**
+>
+> The most reliable recovery on CRC single-node is `crc stop && crc start`:
+> ```bash
+> # Wait ~2 min for the rollout to start, then:
+> crc stop
+> crc start
+>
+> # Re-login after restart:
+> eval $(crc oc-env)
+> oc login -u kubeadmin -p $(cat ~/.crc/machines/crc/kubeadmin-password) https://api.crc.testing:6443
+> ```
+>
+> Verify the kubelet accepted the sysctl allowlist:
+> ```bash
+> ssh -o StrictHostKeyChecking=no -i ~/.crc/machines/crc/id_ed25519 -p 2222 core@127.0.0.1 \
+>   "sudo cat /etc/kubernetes/kubelet.conf | grep -A12 allowedUnsafe"
+> ```
+
+---
+
+## Deploy (Makefile — recommended)
+
+Once the prerequisites are complete, the entire deployment and teardown can be done via Make:
+
+```bash
+# Trust the CRC registry CA and login (prompts for sudo)
+make -C test/e2e crc-registry-login KUBECTL=oc
+
+# Build images locally first (from project root)
+make IMAGES="controller-manager stateless-load-balancer router network-sidecar example-target" BUILD_STEPS=build
+
+# Push images to the local OpenShift registry
+make -C test/e2e/ push-images-openshift-crc KUBECTL=oc
+
+# Deploy the full topology
+make -C test/e2e/ deploy-openshift-crc KUBECTL=oc
+
+# Teardown
+make -C test/e2e undeploy-openshift-crc KUBECTL=oc
+```
+
+The `openshift-crc` target handles: namespace creation, ImageStreams, image push (tag+push of
+locally-built images + vpn-gateway build), cert-manager install, SCCs, RBAC, controller-manager
+(via kustomize overlay with RBAC finalizer patches + LB template override), VPN gateway, NADs,
+Gateway, routing, targets, and waits for all pods to become Ready.
+
+---
+
+## Deploy (manual steps)
+
+If you prefer to run each step individually (e.g., for debugging):
+
+### Step 1 — Install cert-manager
+
+```bash
+oc apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.16.2/cert-manager.yaml
+
+oc wait --for=condition=Available --timeout=300s -n cert-manager \
+  deployment/cert-manager \
+  deployment/cert-manager-webhook \
+  deployment/cert-manager-cainjector
+```
+
+> **Note**: Gateway API CRDs are pre-installed on OpenShift — no action needed.
+
+### Step 2 — Registry login and image push
+
+```bash
+# Trust CRC registry CA (one-time per machine)
+make -C test/e2e crc-registry-login KUBECTL=oc
+
+# Build all component images locally
+make IMAGES="controller-manager stateless-load-balancer router network-sidecar example-target" BUILD_STEPS=build
+
+# Push to CRC internal registry (creates namespace + ImageStreams automatically)
+make -C test/e2e push-images-openshift-crc KUBECTL=oc
+```
+
+### Step 3 — Deploy
+
+```bash
+make -C test/e2e deploy-openshift-crc KUBECTL=oc
+```
+
+This single command deploys everything: namespace (with PSA labels), SCCs, RBAC, SCC bindings,
+NADs, VPN gateway (waits for Ready), cert-manager (idempotent), controller-manager (with
+OpenShift patches), GatewayClass, Gateway, routing, targets, and waits for all pods Running.
+
+### Step 4 — Validate
+
+Wait ~30 seconds after deployment for BGP convergence and nfqlb flow programming, then:
+
+```bash
+NS=meridio-2
+
+# All pods should be Running
+oc get pods -n $NS
+
+# Check BGP sessions — expect GW4_OCP_1 and GW6_OCP_1 both Established
+oc exec vpn-gateway -n $NS -- birdc show protocols
+
+# Check VIP routes learned via BGP
+oc exec vpn-gateway -n $NS -- birdc show route
+
+# Ping VIPs
+oc exec vpn-gateway -n $NS -- ping -c 3 100.0.0.1
+oc exec vpn-gateway -n $NS -- ping6 -c 3 fd00:cafe:1::1
+
+# TCP load balancing — IPv4
+oc exec vpn-gateway -n $NS -- ctraffic -address 100.0.0.1:5000 -nconn 100 -timeout 10s -stats all
+
+# TCP load balancing — IPv6
+oc exec vpn-gateway -n $NS -- ctraffic -address '[fd00:cafe:1::1]:5000' -nconn 100 -timeout 10s -stats all
+
+# UDP load balancing — IPv4
+oc exec vpn-gateway -n $NS -- ctraffic -udp -address 100.0.0.1:5001 -nconn 100 -timeout 10s -stats all
+
+# UDP load balancing — IPv6
+oc exec vpn-gateway -n $NS -- ctraffic -udp -address '[fd00:cafe:1::1]:5001' -nconn 100 -timeout 10s -stats all
+```
+
+Expected results:
+- `birdc show protocols`: `GW4_OCP_1` and `GW6_OCP_1` both `Established`
+- `birdc show route`: `100.0.0.1/32` and `fd00:cafe:1::1/128` learned via BGP
+- `ctraffic`: 0 failed connections, traffic distributed across 2 target pods
+
+### Step 5 — Teardown
+
+```bash
+make -C test/e2e undeploy-openshift-crc KUBECTL=oc
+```
+
+---
+
+## Makefile Targets Reference
+
+| Target | Description |
+|--------|-------------|
+| `crc-registry-login` | Trust CRC registry CA + docker login (needs sudo) |
+| `push-images-openshift-crc` | Create namespace + ImageStreams, build vpn-gateway, tag+push all 6 images |
+| `deploy-openshift-crc` | Full deployment (cert-manager, SCCs, controller-manager, VPN gateway, topology, wait for Ready) |
+| `undeploy-openshift-crc` | Delete webhook config, SCCs, and namespace (removes everything) |
+| `openshift-crc` | Umbrella: push-images + deploy |
+
+All targets accept `KUBECTL=oc` and derive registry paths from:
+- `OCP_REGISTRY_HOST` (default: `default-route-openshift-image-registry.apps-crc.testing`)
+- `OCP_NAMESPACE` (default: `meridio-2`)
+
+---
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `namespace.yaml` | Namespace with PSA=privileged labels |
+| `kubeletconfig.yaml` | KubeletConfig to allowlist unsafe sysctls (triggers node reboot) |
+| `scc.yaml` | Custom SCCs: `meridio-lb` (LB pods) and `meridio-sidecar` (target+sidecar pods) |
+| `kustomization.yaml` | Deploys controller-manager with OpenShift patches (RBAC finalizers + LB template) |
+| `nad.yaml` | NetworkAttachmentDefinitions (bridge CNI: bgp-net with VLAN 100, app-net) |
+| `gateway.yaml` | Gateway + GatewayConfiguration |
+| `routing.yaml` | GatewayRouter (IPv4 + IPv6, protocol: BGP) + L34Route |
+| `dg.yaml` | DistributionGroup |
+| `targets.yaml` | Target Pod Deployment (2 replicas + network-sidecar) |
+| `rbac.yaml` | ServiceAccounts + Role + RoleBinding |
+| `vpn-gateway.yaml` | VPN gateway ConfigMap (BIRD config, passive BGP) + Pod |
+| `lb-deployment.yaml` | OpenShift-adapted LB template (reference; embedded in kustomization.yaml) |
+
+---
+
+## Key Differences from Kind-based Suites
+
+| Aspect | Kind suites | This suite |
+|--------|-------------|------------|
+| VPN gateway | Docker container on host | Pod inside cluster |
+| External network | VLAN subinterfaces on Docker bridge | Bridge CNI (`br-meridio`) with VLAN 100 |
+| Internal network | macvlan on node eth0 | Bridge CNI (`br-meridio-app`) |
+| Pod anti-affinity | Required (4 workers) | Removed (single node) |
+| SCC | N/A (vanilla K8s) | Custom `meridio-lb` + `meridio-sidecar` SCCs |
+| LB security context | runAsNonRoot, RuntimeDefault | sysctls in pod spec, `spc_t` on loadbalancer container only, Unconfined seccomp |
+| Sysctl tuning | Via tuning CNI NAD | Pod `securityContext.sysctls` (requires KubeletConfig allowlist) |
+| nfnetlink_queue | Auto-loaded | Persisted via `/etc/modules-load.d/meridio.conf` |
+| Image registry | localhost:5001 (Kind) | Internal OpenShift registry |
+| IPv6 convergence | Immediate | ~30s after deployment (nfqlb flow programming) |
+
+---
+
+## Known Issues / Notes
+
+- **KubeletConfig reboot**: Applying `kubeletconfig.yaml` triggers a MachineConfig rollout that
+  reboots the CRC node. The single-node kubelet does not reliably auto-restart after reboot.
+  **Recommended recovery**: `crc stop && crc start` (not SSH kubelet nudge). One-time operation —
+  the sysctl allowlist and module load persist across subsequent `crc stop`/`crc start` cycles.
+
+- **Disk pressure**: Default CRC disk is 32GB which is too small for all Meridio-2 images.
+  Set `crc config set disk-size 50` before creating the instance. If disk pressure occurs,
+  prune images: `ssh ... core@127.0.0.1 "sudo crictl rmi --prune"` and remove the taint:
+  `oc adm taint nodes crc node.kubernetes.io/disk-pressure:NoSchedule-`
+
+- **IPv6 convergence**: After fresh deployment, IPv6 traffic may fail for ~30 seconds while
+  nfqlb programs its flows and IPv6 NDP completes. Wait and retry — this is not a bug.
+
+- **Ghost pods after CRC restart**: Force-delete with
+  `oc delete pod <name> -n meridio-2 --force --grace-period=0`
+
+- **cert-manager webhook timing**: If `deploy-openshift-crc` fails with webhook errors on the
+  first run, wait 30s and re-run (cert-manager webhook takes time to inject CA certificates).
+
+- **SELinux AVC denials**: If LB pods crash with `Operation not permitted` despite correct SCCs:
+  ```bash
+  ssh -o StrictHostKeyChecking=no -i ~/.crc/machines/crc/id_ed25519 -p 2222 core@127.0.0.1 \
+    "sudo ausearch -m AVC -ts recent"
+  ```

--- a/test/e2e/suites/openshift-crc/README.md
+++ b/test/e2e/suites/openshift-crc/README.md
@@ -110,7 +110,7 @@ oc apply -f test/e2e/suites/openshift-crc/kubeletconfig.yaml
 
 ---
 
-## Deploy (Makefile — recommended)
+## Deploy
 
 Once the prerequisites are complete, the entire deployment and teardown can be done via Make:
 
@@ -131,9 +131,9 @@ make -C test/e2e undeploy-openshift-crc KUBECTL=oc
 
 `deploy-openshift-crc` depends on `push-images-openshift-crc`, so a single call handles:
 namespace creation, ImageStreams, image push (tag+push of locally-built images + vpn-gateway
-build), cert-manager install, SCCs, RBAC, controller-manager (via kustomize overlay with RBAC
-finalizer patches + LB template override), VPN gateway, NADs, Gateway, routing, targets, and
-waits for all pods to become Ready.
+build), cert-manager install (idempotent — skipped if already present), SCCs, RBAC,
+controller-manager (via kustomize overlay with RBAC finalizer patches + LB template override),
+VPN gateway, NADs, Gateway, routing, targets, and waits for all pods to become Ready.
 
 ### Alternative: pull images from registry.nordix.org
 
@@ -160,58 +160,7 @@ make -C test/e2e undeploy-openshift-crc KUBECTL=oc
 **Use the default (build-and-push) flow when iterating on component code** — `OCP_USE_NORDIX=true`
 deploys whatever is currently published on nordix, not your local changes.
 
----
-
-## Deploy (manual steps)
-
-If you prefer to run each step individually (e.g., for debugging):
-
-### Step 1 — Install cert-manager
-
-> **Note**: `deploy-openshift-crc` already depends on the `cert-manager` target and installs it
-> automatically (idempotent — skipped if already present). This step is only needed if you want
-> cert-manager installed ahead of time, independent of the rest of the deployment.
-
-```bash
-oc apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.16.2/cert-manager.yaml
-
-oc wait --for=condition=Available --timeout=300s -n cert-manager \
-  deployment/cert-manager \
-  deployment/cert-manager-webhook \
-  deployment/cert-manager-cainjector
-```
-
-> **Note**: Gateway API CRDs are pre-installed on OpenShift — no action needed.
-
-### Step 2 — Registry login and image push
-
-```bash
-# Trust CRC registry CA (one-time per machine)
-make -C test/e2e crc-registry-login KUBECTL=oc
-
-# Build all component images locally
-make IMAGES="controller-manager stateless-load-balancer router network-sidecar example-target" BUILD_STEPS=build
-
-# Push to CRC internal registry (creates namespace + ImageStreams automatically)
-make -C test/e2e push-images-openshift-crc KUBECTL=oc
-```
-
-> **Alternative**: set `OCP_USE_NORDIX=true` to skip the local build and pull
-> `controller-manager`/`stateless-load-balancer`/`router`/`network-sidecar`/`example-target`
-> directly from `registry.nordix.org` instead. `vpn-gateway` has no published image and is
-> always built/pushed locally regardless. See [Makefile Targets Reference](#makefile-targets-reference).
-
-### Step 3 — Deploy
-
-```bash
-make -C test/e2e deploy-openshift-crc KUBECTL=oc
-```
-
-This single command deploys everything: namespace (with PSA labels), SCCs, RBAC, SCC bindings,
-NADs, VPN gateway (waits for Ready), cert-manager (idempotent), controller-manager (with
-OpenShift patches), GatewayClass, Gateway, routing, targets, and waits for all pods Running.
-
-### Step 4 — Validate
+### Validate
 
 Wait ~30 seconds after deployment for BGP convergence and nfqlb flow programming, then:
 
@@ -249,11 +198,7 @@ Expected results:
 - `birdc show route`: `100.0.0.1/32` and `fd00:cafe:1::1/128` learned via BGP
 - `ctraffic`: 0 failed connections, traffic distributed across 2 target pods
 
-### Step 5 — Teardown
-
-```bash
-make -C test/e2e undeploy-openshift-crc KUBECTL=oc
-```
+> **Note**: Gateway API CRDs are pre-installed on OpenShift — no action needed.
 
 ---
 

--- a/test/e2e/suites/openshift-crc/README.md
+++ b/test/e2e/suites/openshift-crc/README.md
@@ -260,6 +260,61 @@ All targets accept `KUBECTL=oc` and derive registry paths from:
 | Image registry | localhost:5001 (Kind) | Internal OpenShift registry |
 | IPv6 convergence | Immediate | ~30s after deployment (nfqlb flow programming) |
 
+### OpenShift Compatibility Notes
+
+The differences above stem from OpenShift's stricter default security posture compared to vanilla
+Kubernetes. This section explains the underlying cause for each requirement.
+
+- **Seccomp (`Unconfined` on loadbalancer container)**: The `RuntimeDefault` seccomp profile blocks
+  `NETLINK_NETFILTER` messages — specifically nftables set management (`NFT_MSG_NEWSET`) and nfqueue
+  binding (`NFQNL_CFG_CMD_BIND`). Both are required by NFQLB/nftables in the loadbalancer container.
+  Standard netlink operations (interface addresses, routes, policy rules) used by the router and
+  network-sidecar containers are **not** affected by `RuntimeDefault` — only the loadbalancer
+  container needs `Unconfined`.
+
+- **SELinux (`spc_t` on loadbalancer container)**: SELinux enforces at a separate kernel security
+  module layer, independent of seccomp. Even when seccomp allows a syscall, `container_t`'s SELinux
+  policy still lacks permissions for nfqueue bind and nftables set operations. Both seccomp **and**
+  SELinux restrictions must be relaxed together — fixing only one still results in denial from the
+  other. `spc_t` (super-privileged container) is scoped to the loadbalancer container only; the
+  router container works fine under the default SELinux type.
+
+- **Custom SCCs**: OpenShift's default `restricted-v2` SCC blocks the capabilities (`NET_ADMIN`,
+  `IPC_LOCK`, `IPC_OWNER`, `NET_BIND_SERVICE`, `NET_RAW`), unsafe sysctls, and seccomp/SELinux
+  settings above. `meridio-lb` and `meridio-sidecar` SCCs grant the minimum needed per Pod type.
+
+- **KubeletConfig for unsafe sysctls**: Declaring unsafe sysctls in a Pod spec is a two-layer gate.
+  The SCC's `allowedUnsafeSysctls` only satisfies *admission control* (whether the Pod spec is
+  accepted). The kubelet separately enforces its own allowlist at *runtime* — without a matching
+  `KubeletConfig`, the kubelet refuses to apply the sysctls even if the Pod was admitted.
+
+- **Pod-level sysctls instead of tuning CNI NAD**: OpenShift's Multus blocks the `tuning` CNI plugin
+  from setting *global* sysctls (e.g. `net.ipv4.conf.all.forwarding`) via NetworkAttachmentDefinition.
+  Per-interface sysctls via NAD are unaffected, but this suite's requirements are global, so they're
+  set via Pod `securityContext.sysctls` instead.
+
+- **Bridge CNI instead of macvlan/VLAN-subinterfaces**: The macvlan-on-host-interface and raw VLAN
+  subinterface approaches used by the Kind suites are Docker/host-networking conveniences not
+  applicable inside a single OpenShift node. Bridge CNI with a VLAN-aware bridge (`br-meridio`,
+  `br-meridio-app`) reproduces equivalent L2 adjacency using constructs OpenShift/Multus supports.
+
+- **RBAC finalizer permissions**: OpenShift enables the `OwnerReferencesPermissionEnforcement`
+  admission controller by default (optional on vanilla Kubernetes). `ctrl.SetControllerReference()`
+  sets `blockOwnerDeletion: true`, which requires explicit `/finalizers` sub-resource RBAC permissions
+  on the owner resources — `gateways/finalizers`, `distributiongroups/finalizers`, and
+  `pods/finalizers` — otherwise the controller-manager cannot set owner references on Deployments,
+  LoadBalancerEndpointSlices, and EndpointNetworkConfigurations respectively. This is patched in here
+  via `kustomization.yaml` rather than the base `config/rbac/manager-role.yaml` because vanilla
+  Kubernetes doesn't enforce the check by default; moving these rules into the base role would be a
+  cleaner long-term fix since the underlying `SetControllerReference()` calls are unconditional.
+
+- **nfnetlink_queue persistence**: Unlike some other distros, this module is not auto-loaded on
+  CoreOS/OpenShift nodes and must be explicitly persisted via `/etc/modules-load.d/`.
+
+- **Pod anti-affinity removed**: The LB Deployment template's default anti-affinity (spread across
+  nodes) is meaningless — and blocks scheduling entirely — on a single-node cluster. Since Bridge CNI
+  supports multiple LB Pods sharing the same bridge on one node, anti-affinity is safely dropped here.
+
 ---
 
 ## Known Issues / Notes

--- a/test/e2e/suites/openshift-crc/README.md
+++ b/test/e2e/suites/openshift-crc/README.md
@@ -121,21 +121,44 @@ make -C test/e2e crc-registry-login KUBECTL=oc
 # Build images locally first (from project root)
 make IMAGES="controller-manager stateless-load-balancer router network-sidecar example-target" BUILD_STEPS=build
 
-# Push images to the local OpenShift registry
-make -C test/e2e/ push-images-openshift-crc KUBECTL=oc
-
-# Deploy the full topology
+# Deploy the full topology (depends on push-images-openshift-crc, so this also
+# creates the namespace/ImageStreams and pushes all images)
 make -C test/e2e/ deploy-openshift-crc KUBECTL=oc
 
 # Teardown
 make -C test/e2e undeploy-openshift-crc KUBECTL=oc
 ```
 
-Together, `push-images-openshift-crc` and `deploy-openshift-crc` handle: namespace creation,
-ImageStreams, image push (tag+push of locally-built images + vpn-gateway build), cert-manager
-install, SCCs, RBAC, controller-manager (via kustomize overlay with RBAC finalizer patches + LB
-template override), VPN gateway, NADs, Gateway, routing, targets, and waits for all pods to
-become Ready.
+`deploy-openshift-crc` depends on `push-images-openshift-crc`, so a single call handles:
+namespace creation, ImageStreams, image push (tag+push of locally-built images + vpn-gateway
+build), cert-manager install, SCCs, RBAC, controller-manager (via kustomize overlay with RBAC
+finalizer patches + LB template override), VPN gateway, NADs, Gateway, routing, targets, and
+waits for all pods to become Ready.
+
+### Alternative: pull images from registry.nordix.org
+
+If you want to validate the OCP suite itself (network/RBAC/SCC/topology) against known-good
+published images instead of your local working tree, set `OCP_USE_NORDIX=true`. This skips the
+local build step; `deploy-openshift-crc` will only build/push `vpn-gateway` (which has no
+published image):
+
+```bash
+# Still required: vpn-gateway has no published image and is always built/pushed locally
+make -C test/e2e crc-registry-login KUBECTL=oc
+
+# No local build step (`make IMAGES=... BUILD_STEPS=build`) needed for the other 5 images
+
+# controller-manager, stateless-load-balancer, router, network-sidecar, example-target
+# all resolve to registry.nordix.org/cloud-native/meridio-2/<name>:latest;
+# only vpn-gateway is built and pushed to the CRC internal registry
+make -C test/e2e deploy-openshift-crc KUBECTL=oc OCP_USE_NORDIX=true
+
+# Teardown is unchanged
+make -C test/e2e undeploy-openshift-crc KUBECTL=oc
+```
+
+**Use the default (build-and-push) flow when iterating on component code** — `OCP_USE_NORDIX=true`
+deploys whatever is currently published on nordix, not your local changes.
 
 ---
 
@@ -144,6 +167,10 @@ become Ready.
 If you prefer to run each step individually (e.g., for debugging):
 
 ### Step 1 — Install cert-manager
+
+> **Note**: `deploy-openshift-crc` already depends on the `cert-manager` target and installs it
+> automatically (idempotent — skipped if already present). This step is only needed if you want
+> cert-manager installed ahead of time, independent of the rest of the deployment.
 
 ```bash
 oc apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.16.2/cert-manager.yaml
@@ -168,6 +195,11 @@ make IMAGES="controller-manager stateless-load-balancer router network-sidecar e
 # Push to CRC internal registry (creates namespace + ImageStreams automatically)
 make -C test/e2e push-images-openshift-crc KUBECTL=oc
 ```
+
+> **Alternative**: set `OCP_USE_NORDIX=true` to skip the local build and pull
+> `controller-manager`/`stateless-load-balancer`/`router`/`network-sidecar`/`example-target`
+> directly from `registry.nordix.org` instead. `vpn-gateway` has no published image and is
+> always built/pushed locally regardless. See [Makefile Targets Reference](#makefile-targets-reference).
 
 ### Step 3 — Deploy
 
@@ -237,6 +269,15 @@ make -C test/e2e undeploy-openshift-crc KUBECTL=oc
 All targets accept `KUBECTL=oc` and derive registry paths from:
 - `OCP_REGISTRY_HOST` (default: `default-route-openshift-image-registry.apps-crc.testing`)
 - `OCP_NAMESPACE` (default: `meridio-2`)
+- `OCP_USE_NORDIX` (default: `false`) — if set to `true`, `controller-manager`,
+  `stateless-load-balancer`, `router`, `network-sidecar`, and `example-target` are pulled
+  directly from `registry.nordix.org` instead of being built and pushed to the CRC internal
+  registry. `vpn-gateway` has no published image and is always built/pushed locally regardless
+  of this flag:
+  ```bash
+  make -C test/e2e push-images-openshift-crc KUBECTL=oc OCP_USE_NORDIX=true
+  make -C test/e2e deploy-openshift-crc KUBECTL=oc OCP_USE_NORDIX=true
+  ```
 
 ---
 

--- a/test/e2e/suites/openshift-crc/dg.yaml
+++ b/test/e2e/suites/openshift-crc/dg.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: meridio-2.nordix.org/v1alpha1
+kind: DistributionGroup
+metadata:
+  name: dg-ocp
+spec:
+  selector:
+    matchLabels:
+      app: target-ocp
+  maglev:
+    maxEndpoints: 32
+  parentRefs:
+  - name: gw-ocp

--- a/test/e2e/suites/openshift-crc/gateway.yaml
+++ b/test/e2e/suites/openshift-crc/gateway.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gw-ocp
+spec:
+  gatewayClassName: meridio
+  infrastructure:
+    parametersRef:
+      group: meridio-2.nordix.org
+      kind: GatewayConfiguration
+      name: gwconfig-ocp
+  listeners:
+  - name: default
+    protocol: TCP
+    port: 80
+---
+apiVersion: meridio-2.nordix.org/v1alpha1
+kind: GatewayConfiguration
+metadata:
+  name: gwconfig-ocp
+spec:
+  networkAttachments:
+  - type: NAD
+    nad:
+      name: bgp-net
+      namespace: meridio-2
+      interface: bgp-net
+  - type: NAD
+    nad:
+      name: app-net
+      namespace: meridio-2
+      interface: app-net
+  internalSubnets:
+  - attachmentType: NAD
+    cidr: "169.111.100.0/24"
+  - attachmentType: NAD
+    cidr: "fd00:cafe:1100::/64"
+  horizontalScaling:
+    replicas: 1

--- a/test/e2e/suites/openshift-crc/kubeletconfig.yaml
+++ b/test/e2e/suites/openshift-crc/kubeletconfig.yaml
@@ -1,0 +1,30 @@
+---
+# KubeletConfig: allowlist unsafe sysctls required by Meridio-2 LB Pods
+#
+# OpenShift's kubelet rejects Pod-level unsafe sysctls at runtime unless
+# explicitly allowlisted here. This works together with the meridio-lb SCC
+# (which allows pods to declare them at admission) — both layers are required.
+#
+# WARNING: Applying this triggers a MachineConfig rollout which reboots the
+# CRC node (~3-5 minutes). Wait for the node to return to Ready before proceeding.
+#
+# For CRC (single-node, master+worker), the pool selector targets the master pool.
+apiVersion: machineconfiguration.openshift.io/v1
+kind: KubeletConfig
+metadata:
+  name: meridio-unsafe-sysctls
+spec:
+  machineConfigPoolSelector:
+    matchLabels:
+      pools.operator.machineconfiguration.openshift.io/master: ""
+  kubeletConfig:
+    allowedUnsafeSysctls:
+    - "net.ipv4.conf.all.forwarding"
+    - "net.ipv6.conf.all.forwarding"
+    - "net.ipv4.fib_multipath_hash_policy"
+    - "net.ipv6.fib_multipath_hash_policy"
+    - "net.ipv4.conf.all.rp_filter"
+    - "net.ipv4.conf.default.rp_filter"
+    - "net.ipv4.fwmark_reflect"
+    - "net.ipv6.fwmark_reflect"
+    - "net.ipv4.ip_local_port_range"

--- a/test/e2e/suites/openshift-crc/kustomization.yaml
+++ b/test/e2e/suites/openshift-crc/kustomization.yaml
@@ -1,0 +1,254 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: meridio-2
+
+resources:
+- ../../../../config/default
+
+images:
+- name: controller-manager
+  newName: registry.nordix.org/cloud-native/meridio-2/controller-manager
+  newTag: latest
+
+nameSuffix: -ocp
+
+# Patch the webhook to use the correct suffixed namespace/names
+
+# OpenShift RBAC patch: add finalizer permissions required for blockOwnerDeletion.
+#
+# Meridio-2 controllers use ctrl.SetControllerReference() which sets
+# blockOwnerDeletion: true on ownerReferences. OpenShift's
+# OwnerReferencesPermissionEnforcement admission controller (enabled by default,
+# unlike vanilla Kubernetes) requires the creator to have "update" permission on
+# the owner resource's /finalizers subresource.
+#
+# Affected relationships:
+#   - Gateway controller:  Gateway → Deployment  (needs gateways/finalizers)
+#   - DG controller:       DistributionGroup → LoadBalancerEndpointSlice (needs distributiongroups/finalizers)
+#   - ENC controller:      Pod → EndpointNetworkConfiguration (needs pods/finalizers)
+#
+# Proper fix: add these to config/rbac/manager-role.yaml in the Meridio-2 repo.
+
+# Override LB template ConfigMap with OpenShift-adapted version.
+# See lb-deployment.yaml for full explanation of each change.
+patches:
+- patch: |-
+    apiVersion: admissionregistration.k8s.io/v1
+    kind: ValidatingWebhookConfiguration
+    metadata:
+      name: not-important
+      annotations:
+        cert-manager.io/inject-ca-from: meridio-2/meridio-2-serving-cert-ocp
+    webhooks:
+    - name: vl34route-v1alpha1.kb.io
+      namespaceSelector:
+        matchLabels:
+          e2e-suite: ocp
+      clientConfig:
+        service:
+          name: meridio-2-webhook-service-ocp
+          namespace: meridio-2
+  target:
+    kind: ValidatingWebhookConfiguration
+- patch: |-
+    - op: replace
+      path: /spec/dnsNames
+      value:
+      - meridio-2-webhook-service-ocp.meridio-2.svc
+      - meridio-2-webhook-service-ocp.meridio-2.svc.cluster.local
+    - op: replace
+      path: /spec/secretName
+      value: webhook-server-cert-ocp
+  target:
+    group: cert-manager.io
+    kind: Certificate
+    name: serving-cert
+- patch: |-
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: not-important
+    spec:
+      template:
+        spec:
+          containers:
+          - name: manager
+            imagePullPolicy: Always
+            env:
+            - name: MERIDIO_LB_SERVICE_ACCOUNT
+              value: meridio-2-stateless-load-balancer-ocp
+          volumes:
+          - name: webhook-certs
+            secret:
+              secretName: webhook-server-cert-ocp
+  target:
+    kind: Deployment
+    labelSelector: control-plane=controller-manager
+- patch: |-
+    - op: add
+      path: /rules/-
+      value:
+        apiGroups: ["gateway.networking.k8s.io"]
+        resources: ["gateways/finalizers"]
+        verbs: ["update"]
+    - op: add
+      path: /rules/-
+      value:
+        apiGroups: ["meridio-2.nordix.org"]
+        resources: ["distributiongroups/finalizers"]
+        verbs: ["update"]
+    - op: add
+      path: /rules/-
+      value:
+        apiGroups: [""]
+        resources: ["pods/finalizers"]
+        verbs: ["update"]
+  target:
+    kind: Role
+    name: manager-role
+- patch: |-
+    - op: replace
+      path: /data/lb-deployment.yaml
+      value: |
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: stateless-load-balancer
+          namespace: placeholder
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: stateless-load-balancer
+          template:
+            metadata:
+              labels:
+                app: stateless-load-balancer
+            spec:
+              serviceAccountName: stateless-load-balancer
+              securityContext:
+                runAsNonRoot: true
+                seccompProfile:
+                  type: Unconfined
+                sysctls:
+                - name: net.ipv4.conf.all.forwarding
+                  value: "1"
+                - name: net.ipv6.conf.all.forwarding
+                  value: "1"
+                - name: net.ipv4.fib_multipath_hash_policy
+                  value: "1"
+                - name: net.ipv6.fib_multipath_hash_policy
+                  value: "1"
+                - name: net.ipv4.conf.all.rp_filter
+                  value: "2"
+                - name: net.ipv4.conf.default.rp_filter
+                  value: "2"
+                - name: net.ipv4.fwmark_reflect
+                  value: "1"
+                - name: net.ipv6.fwmark_reflect
+                  value: "1"
+                - name: net.ipv4.ip_local_port_range
+                  value: "49152 65535"
+              containers:
+              - name: loadbalancer
+                image: registry.nordix.org/cloud-native/meridio-2/stateless-load-balancer:latest
+                imagePullPolicy: Always
+                args:
+                  - run
+                env:
+                - name: MERIDIO_READINESS_DIR
+                  value: '/var/run/meridio'
+                - name: MERIDIO_GATEWAY_NAME
+                  value: ""
+                - name: MERIDIO_GATEWAY_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  readOnlyRootFilesystem: true
+                  runAsNonRoot: true
+                  seLinuxOptions:
+                    type: spc_t
+                  capabilities:
+                    drop: [ALL]
+                    add: [NET_ADMIN, IPC_LOCK, IPC_OWNER]
+                volumeMounts:
+                - name: lb-run
+                  mountPath: /var/run/meridio
+                resources:
+                  requests:
+                    cpu: 100m
+                    memory: 128Mi
+                  limits:
+                    cpu: 500m
+                    memory: 512Mi
+              - name: router
+                image: registry.nordix.org/cloud-native/meridio-2/router:latest
+                imagePullPolicy: Always
+                args:
+                  - run
+                env:
+                - name: MERIDIO_GATEWAY_NAME
+                  value: ""
+                - name: MERIDIO_GATEWAY_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: MERIDIO_BIRD_LOG
+                  value: "file:/var/log/bird/bird.log:104857600:/var/log/bird/bird.log.1:all"
+                - name: MERIDIO_READINESS_DIR
+                  value: '/var/run/meridio'
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: POD_UID
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.uid
+                - name: POD_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  readOnlyRootFilesystem: true
+                  runAsNonRoot: true
+                  capabilities:
+                    drop: [ALL]
+                    add: [NET_ADMIN, NET_BIND_SERVICE, NET_RAW]
+                volumeMounts:
+                - name: bird-run
+                  mountPath: /var/run/bird
+                - name: bird-etc
+                  mountPath: /etc/bird
+                - name: bird-log
+                  mountPath: /var/log/bird
+                - name: lb-run
+                  mountPath: /var/run/meridio
+                  readOnly: true
+                resources:
+                  requests:
+                    cpu: 100m
+                    memory: 128Mi
+                  limits:
+                    cpu: 500m
+                    memory: 512Mi
+              volumes:
+              - name: lb-run
+                emptyDir:
+                  medium: Memory
+              - name: bird-run
+                emptyDir:
+                  medium: Memory
+              - name: bird-etc
+                emptyDir:
+                  medium: Memory
+              - name: bird-log
+                emptyDir:
+                  medium: Memory
+  target:
+    kind: ConfigMap
+    name: stateless-load-balancer-templates

--- a/test/e2e/suites/openshift-crc/kustomization.yaml
+++ b/test/e2e/suites/openshift-crc/kustomization.yaml
@@ -4,12 +4,12 @@ kind: Kustomization
 namespace: meridio-2
 
 resources:
-- ../../../../config/default
+  - ../../../../config/default
 
 images:
-- name: controller-manager
-  newName: registry.nordix.org/cloud-native/meridio-2/controller-manager
-  newTag: latest
+  - name: controller-manager
+    newName: registry.nordix.org/cloud-native/meridio-2/controller-manager
+    newTag: latest
 
 nameSuffix: -ocp
 
@@ -29,226 +29,83 @@ nameSuffix: -ocp
 #   - ENC controller:      Pod → EndpointNetworkConfiguration (needs pods/finalizers)
 #
 # Proper fix: add these to config/rbac/manager-role.yaml in the Meridio-2 repo.
-
-# Override LB template ConfigMap with OpenShift-adapted version.
-# See lb-deployment.yaml for full explanation of each change.
+#
+# Note: the OpenShift-adapted LB template (lb-deployment.yaml) is NOT applied via a
+# ConfigMap patch here. It is injected by the deploy-suite Makefile macro, which
+# overrides MERIDIO_TEMPLATE_PATH to /templates-override — this takes precedence over
+# the default /templates path a ConfigMap patch would target.
 patches:
-- patch: |-
-    apiVersion: admissionregistration.k8s.io/v1
-    kind: ValidatingWebhookConfiguration
-    metadata:
-      name: not-important
-      annotations:
-        cert-manager.io/inject-ca-from: meridio-2/meridio-2-serving-cert-ocp
-    webhooks:
-    - name: vl34route-v1alpha1.kb.io
-      namespaceSelector:
-        matchLabels:
-          e2e-suite: ocp
-      clientConfig:
-        service:
-          name: meridio-2-webhook-service-ocp
-          namespace: meridio-2
-  target:
-    kind: ValidatingWebhookConfiguration
-- patch: |-
-    - op: replace
-      path: /spec/dnsNames
-      value:
-      - meridio-2-webhook-service-ocp.meridio-2.svc
-      - meridio-2-webhook-service-ocp.meridio-2.svc.cluster.local
-    - op: replace
-      path: /spec/secretName
-      value: webhook-server-cert-ocp
-  target:
-    group: cert-manager.io
-    kind: Certificate
-    name: serving-cert
-- patch: |-
-    apiVersion: apps/v1
-    kind: Deployment
-    metadata:
-      name: not-important
-    spec:
-      template:
-        spec:
-          containers:
-          - name: manager
-            imagePullPolicy: Always
-            env:
-            - name: MERIDIO_LB_SERVICE_ACCOUNT
-              value: meridio-2-stateless-load-balancer-ocp
-          volumes:
-          - name: webhook-certs
-            secret:
-              secretName: webhook-server-cert-ocp
-  target:
-    kind: Deployment
-    labelSelector: control-plane=controller-manager
-- patch: |-
-    - op: add
-      path: /rules/-
-      value:
-        apiGroups: ["gateway.networking.k8s.io"]
-        resources: ["gateways/finalizers"]
-        verbs: ["update"]
-    - op: add
-      path: /rules/-
-      value:
-        apiGroups: ["meridio-2.nordix.org"]
-        resources: ["distributiongroups/finalizers"]
-        verbs: ["update"]
-    - op: add
-      path: /rules/-
-      value:
-        apiGroups: [""]
-        resources: ["pods/finalizers"]
-        verbs: ["update"]
-  target:
-    kind: Role
-    name: manager-role
-- patch: |-
-    - op: replace
-      path: /data/lb-deployment.yaml
-      value: |
-        apiVersion: apps/v1
-        kind: Deployment
-        metadata:
-          name: stateless-load-balancer
-          namespace: placeholder
-        spec:
-          replicas: 1
-          selector:
-            matchLabels:
-              app: stateless-load-balancer
-          template:
-            metadata:
-              labels:
-                app: stateless-load-balancer
-            spec:
-              serviceAccountName: stateless-load-balancer
-              securityContext:
-                runAsNonRoot: true
-                seccompProfile:
-                  type: Unconfined
-                sysctls:
-                - name: net.ipv4.conf.all.forwarding
-                  value: "1"
-                - name: net.ipv6.conf.all.forwarding
-                  value: "1"
-                - name: net.ipv4.fib_multipath_hash_policy
-                  value: "1"
-                - name: net.ipv6.fib_multipath_hash_policy
-                  value: "1"
-                - name: net.ipv4.conf.all.rp_filter
-                  value: "2"
-                - name: net.ipv4.conf.default.rp_filter
-                  value: "2"
-                - name: net.ipv4.fwmark_reflect
-                  value: "1"
-                - name: net.ipv6.fwmark_reflect
-                  value: "1"
-                - name: net.ipv4.ip_local_port_range
-                  value: "49152 65535"
-              containers:
-              - name: loadbalancer
-                image: registry.nordix.org/cloud-native/meridio-2/stateless-load-balancer:latest
-                imagePullPolicy: Always
-                args:
-                  - run
-                env:
-                - name: MERIDIO_READINESS_DIR
-                  value: '/var/run/meridio'
-                - name: MERIDIO_GATEWAY_NAME
-                  value: ""
-                - name: MERIDIO_GATEWAY_NAMESPACE
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: metadata.namespace
-                securityContext:
-                  allowPrivilegeEscalation: false
-                  readOnlyRootFilesystem: true
-                  runAsNonRoot: true
-                  seLinuxOptions:
-                    type: spc_t
-                  capabilities:
-                    drop: [ALL]
-                    add: [NET_ADMIN, IPC_LOCK, IPC_OWNER]
-                volumeMounts:
-                - name: lb-run
-                  mountPath: /var/run/meridio
-                resources:
-                  requests:
-                    cpu: 100m
-                    memory: 128Mi
-                  limits:
-                    cpu: 500m
-                    memory: 512Mi
-              - name: router
-                image: registry.nordix.org/cloud-native/meridio-2/router:latest
-                imagePullPolicy: Always
-                args:
-                  - run
-                env:
-                - name: MERIDIO_GATEWAY_NAME
-                  value: ""
-                - name: MERIDIO_GATEWAY_NAMESPACE
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: metadata.namespace
-                - name: MERIDIO_BIRD_LOG
-                  value: "file:/var/log/bird/bird.log:104857600:/var/log/bird/bird.log.1:all"
-                - name: MERIDIO_READINESS_DIR
-                  value: '/var/run/meridio'
-                - name: POD_NAME
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: metadata.name
-                - name: POD_UID
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: metadata.uid
-                - name: POD_NAMESPACE
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: metadata.namespace
-                securityContext:
-                  allowPrivilegeEscalation: false
-                  readOnlyRootFilesystem: true
-                  runAsNonRoot: true
-                  capabilities:
-                    drop: [ALL]
-                    add: [NET_ADMIN, NET_BIND_SERVICE, NET_RAW]
-                volumeMounts:
-                - name: bird-run
-                  mountPath: /var/run/bird
-                - name: bird-etc
-                  mountPath: /etc/bird
-                - name: bird-log
-                  mountPath: /var/log/bird
-                - name: lb-run
-                  mountPath: /var/run/meridio
-                  readOnly: true
-                resources:
-                  requests:
-                    cpu: 100m
-                    memory: 128Mi
-                  limits:
-                    cpu: 500m
-                    memory: 512Mi
-              volumes:
-              - name: lb-run
-                emptyDir:
-                  medium: Memory
-              - name: bird-run
-                emptyDir:
-                  medium: Memory
-              - name: bird-etc
-                emptyDir:
-                  medium: Memory
-              - name: bird-log
-                emptyDir:
-                  medium: Memory
-  target:
-    kind: ConfigMap
-    name: stateless-load-balancer-templates
+  - patch: |-
+      apiVersion: admissionregistration.k8s.io/v1
+      kind: ValidatingWebhookConfiguration
+      metadata:
+        name: not-important
+        annotations:
+          cert-manager.io/inject-ca-from: meridio-2/meridio-2-serving-cert-ocp
+      webhooks:
+      - name: vl34route-v1alpha1.kb.io
+        namespaceSelector:
+          matchLabels:
+            e2e-suite: ocp
+        clientConfig:
+          service:
+            name: meridio-2-webhook-service-ocp
+            namespace: meridio-2
+    target:
+      kind: ValidatingWebhookConfiguration
+  - patch: |-
+      - op: replace
+        path: /spec/dnsNames
+        value:
+        - meridio-2-webhook-service-ocp.meridio-2.svc
+        - meridio-2-webhook-service-ocp.meridio-2.svc.cluster.local
+      - op: replace
+        path: /spec/secretName
+        value: webhook-server-cert-ocp
+    target:
+      group: cert-manager.io
+      kind: Certificate
+      name: serving-cert
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: not-important
+      spec:
+        template:
+          spec:
+            containers:
+            - name: manager
+              imagePullPolicy: Always
+              env:
+              - name: MERIDIO_LB_SERVICE_ACCOUNT
+                value: meridio-2-stateless-load-balancer-ocp
+            volumes:
+            - name: webhook-certs
+              secret:
+                secretName: webhook-server-cert-ocp
+    target:
+      kind: Deployment
+      labelSelector: control-plane=controller-manager
+  - patch: |-
+      - op: add
+        path: /rules/-
+        value:
+          apiGroups: ["gateway.networking.k8s.io"]
+          resources: ["gateways/finalizers"]
+          verbs: ["update"]
+      - op: add
+        path: /rules/-
+        value:
+          apiGroups: ["meridio-2.nordix.org"]
+          resources: ["distributiongroups/finalizers"]
+          verbs: ["update"]
+      - op: add
+        path: /rules/-
+        value:
+          apiGroups: [""]
+          resources: ["pods/finalizers"]
+          verbs: ["update"]
+    target:
+      kind: Role
+      name: manager-role

--- a/test/e2e/suites/openshift-crc/kustomization.yaml
+++ b/test/e2e/suites/openshift-crc/kustomization.yaml
@@ -4,12 +4,12 @@ kind: Kustomization
 namespace: meridio-2
 
 resources:
-  - ../../../../config/default
+- ../../../../config/default
 
 images:
-  - name: controller-manager
-    newName: registry.nordix.org/cloud-native/meridio-2/controller-manager
-    newTag: latest
+- name: controller-manager
+  newName: registry.nordix.org/cloud-native/meridio-2/controller-manager
+  newTag: latest
 
 nameSuffix: -ocp
 
@@ -35,77 +35,77 @@ nameSuffix: -ocp
 # overrides MERIDIO_TEMPLATE_PATH to /templates-override — this takes precedence over
 # the default /templates path a ConfigMap patch would target.
 patches:
-  - patch: |-
-      apiVersion: admissionregistration.k8s.io/v1
-      kind: ValidatingWebhookConfiguration
-      metadata:
-        name: not-important
-        annotations:
-          cert-manager.io/inject-ca-from: meridio-2/meridio-2-serving-cert-ocp
-      webhooks:
-      - name: vl34route-v1alpha1.kb.io
-        namespaceSelector:
-          matchLabels:
-            e2e-suite: ocp
-        clientConfig:
-          service:
-            name: meridio-2-webhook-service-ocp
-            namespace: meridio-2
-    target:
-      kind: ValidatingWebhookConfiguration
-  - patch: |-
-      - op: replace
-        path: /spec/dnsNames
-        value:
-        - meridio-2-webhook-service-ocp.meridio-2.svc
-        - meridio-2-webhook-service-ocp.meridio-2.svc.cluster.local
-      - op: replace
-        path: /spec/secretName
-        value: webhook-server-cert-ocp
-    target:
-      group: cert-manager.io
-      kind: Certificate
-      name: serving-cert
-  - patch: |-
-      apiVersion: apps/v1
-      kind: Deployment
-      metadata:
-        name: not-important
-      spec:
-        template:
-          spec:
-            containers:
-            - name: manager
-              imagePullPolicy: Always
-              env:
-              - name: MERIDIO_LB_SERVICE_ACCOUNT
-                value: meridio-2-stateless-load-balancer-ocp
-            volumes:
-            - name: webhook-certs
-              secret:
-                secretName: webhook-server-cert-ocp
-    target:
-      kind: Deployment
-      labelSelector: control-plane=controller-manager
-  - patch: |-
-      - op: add
-        path: /rules/-
-        value:
-          apiGroups: ["gateway.networking.k8s.io"]
-          resources: ["gateways/finalizers"]
-          verbs: ["update"]
-      - op: add
-        path: /rules/-
-        value:
-          apiGroups: ["meridio-2.nordix.org"]
-          resources: ["distributiongroups/finalizers"]
-          verbs: ["update"]
-      - op: add
-        path: /rules/-
-        value:
-          apiGroups: [""]
-          resources: ["pods/finalizers"]
-          verbs: ["update"]
-    target:
-      kind: Role
-      name: manager-role
+- patch: |-
+    apiVersion: admissionregistration.k8s.io/v1
+    kind: ValidatingWebhookConfiguration
+    metadata:
+      name: not-important
+      annotations:
+        cert-manager.io/inject-ca-from: meridio-2/meridio-2-serving-cert-ocp
+    webhooks:
+    - name: vl34route-v1alpha1.kb.io
+      namespaceSelector:
+        matchLabels:
+          e2e-suite: ocp
+      clientConfig:
+        service:
+          name: meridio-2-webhook-service-ocp
+          namespace: meridio-2
+  target:
+    kind: ValidatingWebhookConfiguration
+- patch: |-
+    - op: replace
+      path: /spec/dnsNames
+      value:
+      - meridio-2-webhook-service-ocp.meridio-2.svc
+      - meridio-2-webhook-service-ocp.meridio-2.svc.cluster.local
+    - op: replace
+      path: /spec/secretName
+      value: webhook-server-cert-ocp
+  target:
+    group: cert-manager.io
+    kind: Certificate
+    name: serving-cert
+- patch: |-
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: not-important
+    spec:
+      template:
+        spec:
+          containers:
+          - name: manager
+            imagePullPolicy: Always
+            env:
+            - name: MERIDIO_LB_SERVICE_ACCOUNT
+              value: meridio-2-stateless-load-balancer-ocp
+          volumes:
+          - name: webhook-certs
+            secret:
+              secretName: webhook-server-cert-ocp
+  target:
+    kind: Deployment
+    labelSelector: control-plane=controller-manager
+- patch: |-
+    - op: add
+      path: /rules/-
+      value:
+        apiGroups: ["gateway.networking.k8s.io"]
+        resources: ["gateways/finalizers"]
+        verbs: ["update"]
+    - op: add
+      path: /rules/-
+      value:
+        apiGroups: ["meridio-2.nordix.org"]
+        resources: ["distributiongroups/finalizers"]
+        verbs: ["update"]
+    - op: add
+      path: /rules/-
+      value:
+        apiGroups: [""]
+        resources: ["pods/finalizers"]
+        verbs: ["update"]
+  target:
+    kind: Role
+    name: manager-role

--- a/test/e2e/suites/openshift-crc/lb-deployment.yaml
+++ b/test/e2e/suites/openshift-crc/lb-deployment.yaml
@@ -1,0 +1,157 @@
+# OpenShift-adapted LB deployment template
+#
+# Key differences from vanilla Kubernetes:
+# - Pod securityContext.sysctls: declares the per-pod unsafe sysctls (requires KubeletConfig
+#   allowlist + meridio-lb SCC). This replaces the tuning CNI NAD approach which OpenShift blocks.
+# - seccompProfile: Unconfined (Pod-level): RuntimeDefault blocks NETLINK_NETFILTER messages
+#   required by nftables and nfqueue in the loadbalancer container.
+# - seLinuxOptions: type: spc_t (loadbalancer container only): SELinux container_t blocks
+#   nfqueue bind and nftables set operations. The router container does NOT need this.
+# - runAsNonRoot: true (MustRunAsNonRoot SCC — no longer needs runAsUser: 0)
+# - No pod anti-affinity (CRC is single-node)
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: stateless-load-balancer
+  namespace: placeholder
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: stateless-load-balancer
+  template:
+    metadata:
+      labels:
+        app: stateless-load-balancer
+    spec:
+      serviceAccountName: stateless-load-balancer
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: Unconfined
+        sysctls:
+        - name: net.ipv4.conf.all.forwarding
+          value: "1"
+        - name: net.ipv6.conf.all.forwarding
+          value: "1"
+        - name: net.ipv4.fib_multipath_hash_policy
+          value: "1"
+        - name: net.ipv6.fib_multipath_hash_policy
+          value: "1"
+        - name: net.ipv4.conf.all.rp_filter
+          value: "2"
+        - name: net.ipv4.conf.default.rp_filter
+          value: "2"
+        - name: net.ipv4.fwmark_reflect
+          value: "1"
+        - name: net.ipv6.fwmark_reflect
+          value: "1"
+        - name: net.ipv4.ip_local_port_range
+          value: "49152 65535"
+      containers:
+      - name: loadbalancer
+        image: registry.nordix.org/cloud-native/meridio-2/stateless-load-balancer:latest
+        imagePullPolicy: Always
+        args:
+          - run
+        env:
+        - name: MERIDIO_READINESS_DIR
+          value: '/var/run/meridio'
+        - name: MERIDIO_GATEWAY_NAME
+          value:  # to be filled by operator
+        - name: MERIDIO_GATEWAY_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          seLinuxOptions:
+            type: spc_t
+          capabilities:
+            drop:
+            - ALL
+            add:
+            - NET_ADMIN
+            - IPC_LOCK
+            - IPC_OWNER
+        volumeMounts:
+        - name: lb-run
+          mountPath: /var/run/meridio
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi
+      - name: router
+        image: registry.nordix.org/cloud-native/meridio-2/router:latest
+        imagePullPolicy: Always
+        args:
+          - run
+        env:
+        - name: MERIDIO_GATEWAY_NAME
+          value:  # to be filled by operator
+        - name: MERIDIO_GATEWAY_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: MERIDIO_BIRD_LOG
+          value: "file:/var/log/bird/bird.log:104857600:/var/log/bird/bird.log.1:all"
+        - name: MERIDIO_READINESS_DIR
+          value: '/var/run/meridio'
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          capabilities:
+            drop:
+            - ALL
+            add:
+            - NET_ADMIN
+            - NET_BIND_SERVICE
+            - NET_RAW
+        volumeMounts:
+        - name: bird-run
+          mountPath: /var/run/bird
+        - name: bird-etc
+          mountPath: /etc/bird
+        - name: bird-log
+          mountPath: /var/log/bird
+        - name: lb-run
+          mountPath: /var/run/meridio
+          readOnly: true
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi
+      volumes:
+      - name: lb-run
+        emptyDir:
+          medium: Memory
+      - name: bird-run
+        emptyDir:
+          medium: Memory
+      - name: bird-etc
+        emptyDir:
+          medium: Memory
+      - name: bird-log
+        emptyDir:
+          medium: Memory

--- a/test/e2e/suites/openshift-crc/nad.yaml
+++ b/test/e2e/suites/openshift-crc/nad.yaml
@@ -1,0 +1,53 @@
+# NOTE: Unlike the Kind-based suites, this suite does NOT use a `sysctl-tuning` NAD.
+# On OpenShift the LB Pod's sysctls are set via the pod's securityContext.sysctls
+# (see lb-deployment.yaml), allowlisted by the KubeletConfig (kubeletconfig.yaml).
+# OpenShift's tuning CNI only permits per-interface sysctls, so the NAD approach
+# cannot set the global sysctls Meridio-2 requires.
+---
+# BGP peering network (external) - bridge CNI with VLAN, dual-stack
+# Bridge CNI auto-creates br-meridio with vlan_filtering.
+# All Pods on same node share L2 (including IPv6 NDP) — no external wiring needed.
+# IPv4: 169.254.100.0/24 (.150 reserved for VPN gateway)
+# IPv6: fd00:cafe:100::/64 (::150 reserved for VPN gateway)
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: bgp-net
+spec:
+  config: '{
+    "cniVersion": "0.4.0",
+    "name": "bgp-net",
+    "type": "bridge",
+    "bridge": "br-meridio",
+    "vlan": 100,
+    "ipam": {
+      "type": "whereabouts",
+      "ipRanges": [
+        { "range": "169.254.100.0/24", "exclude": ["169.254.100.150/32"] },
+        { "range": "fd00:cafe:100::/64", "exclude": ["fd00:cafe:100::150/128"] }
+      ]
+    }
+  }'
+---
+# App network (internal) - bridge CNI, dual-stack
+# Uses a separate bridge for internal LB → target traffic.
+# IPv4: 169.111.100.0/24
+# IPv6: fd00:cafe:1100::/64 (must differ from external fd00:cafe:100::/64)
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: app-net
+spec:
+  config: '{
+    "cniVersion": "0.4.0",
+    "name": "app-net",
+    "type": "bridge",
+    "bridge": "br-meridio-app",
+    "ipam": {
+      "type": "whereabouts",
+      "ipRanges": [
+        { "range": "169.111.100.0/24" },
+        { "range": "fd00:cafe:1100::/64" }
+      ]
+    }
+  }'

--- a/test/e2e/suites/openshift-crc/namespace.yaml
+++ b/test/e2e/suites/openshift-crc/namespace.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: meridio-2
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
+    security.openshift.io/scc.podSecurityLabelSync: "false"

--- a/test/e2e/suites/openshift-crc/rbac.yaml
+++ b/test/e2e/suites/openshift-crc/rbac.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: meridio-2-network-sidecar
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: meridio-2-network-sidecar
+rules:
+- apiGroups: ["meridio-2.nordix.org"]
+  resources: ["endpointnetworkconfigurations"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["meridio-2.nordix.org"]
+  resources: ["endpointnetworkconfigurations/status"]
+  verbs: ["get", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: meridio-2-network-sidecar
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: meridio-2-network-sidecar
+subjects:
+- kind: ServiceAccount
+  name: meridio-2-network-sidecar
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vpn-gateway

--- a/test/e2e/suites/openshift-crc/routing.yaml
+++ b/test/e2e/suites/openshift-crc/routing.yaml
@@ -1,0 +1,67 @@
+---
+# IPv4 GatewayRouter - BGP peering on bgp-net
+# LB router (ASN 64512) peers with VPN gateway (ASN 4200000000)
+apiVersion: meridio-2.nordix.org/v1alpha1
+kind: GatewayRouter
+metadata:
+  name: gwr-ocp-v4
+spec:
+  gatewayRef:
+    name: gw-ocp
+  interface: "bgp-net"
+  address: "169.254.100.150"
+  protocol: "BGP"
+  bgp:
+    localASN: 64512
+    remoteASN: 4200000000
+    localPort: 10179
+    remotePort: 10179
+    holdTime: 24s
+    bfd:
+      minTx: 300ms
+      minRx: 300ms
+      multiplier: 3
+---
+# IPv6 GatewayRouter - BGP peering on bgp-net
+apiVersion: meridio-2.nordix.org/v1alpha1
+kind: GatewayRouter
+metadata:
+  name: gwr-ocp-v6
+spec:
+  gatewayRef:
+    name: gw-ocp
+  interface: "bgp-net"
+  address: "fd00:cafe:100::150"
+  protocol: "BGP"
+  bgp:
+    localASN: 64512
+    remoteASN: 4200000000
+    localPort: 10179
+    remotePort: 10179
+    holdTime: 24s
+    bfd:
+      minTx: 300ms
+      minRx: 300ms
+      multiplier: 3
+---
+# L34Route with both IPv4 and IPv6 VIPs
+apiVersion: meridio-2.nordix.org/v1alpha1
+kind: L34Route
+metadata:
+  name: route-ocp
+spec:
+  parentRefs:
+  - name: gw-ocp
+  backendRefs:
+  - group: meridio-2.nordix.org
+    kind: DistributionGroup
+    name: dg-ocp
+  destinationCIDRs:
+  - "100.0.0.1/32"
+  - "fd00:cafe:1::1/128"
+  protocols:
+  - TCP
+  - UDP
+  destinationPorts:
+  - "5000-5001"
+  priority: 100

--- a/test/e2e/suites/openshift-crc/scc.yaml
+++ b/test/e2e/suites/openshift-crc/scc.yaml
@@ -1,0 +1,81 @@
+---
+# SCC for LB Pods (loadbalancer + router containers)
+#
+# Why these settings are needed:
+# - allowedCapabilities: nftables (NET_ADMIN), NFQLB shared memory (IPC_LOCK, IPC_OWNER),
+#   BIRD port 179 (NET_BIND_SERVICE), BIRD SO_BINDTODEVICE (NET_RAW)
+# - allowedUnsafeSysctls: IP forwarding, multipath hashing, rp_filter, fwmark_reflect —
+#   required per-Pod for traffic forwarding. Set in pod securityContext.sysctls after
+#   KubeletConfig allowlists them.
+# - seccompProfiles: ["*"]: RuntimeDefault blocks NETLINK_NETFILTER messages (nftables/nfqueue).
+#   The loadbalancer container must run with Unconfined seccomp.
+# - seLinuxContext: RunAsAny: allows the pod spec to set seLinuxOptions.type: spc_t on the
+#   loadbalancer container only. SELinux container_t blocks nfqueue bind and nftables set
+#   operations. The router container works fine with the default SELinux type.
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: meridio-lb
+allowPrivilegeEscalation: false
+requiredDropCapabilities:
+- ALL
+allowedCapabilities:
+- NET_ADMIN
+- NET_BIND_SERVICE
+- NET_RAW
+- IPC_LOCK
+- IPC_OWNER
+allowedUnsafeSysctls:
+- net.ipv4.conf.all.forwarding
+- net.ipv6.conf.all.forwarding
+- net.ipv4.fib_multipath_hash_policy
+- net.ipv6.fib_multipath_hash_policy
+- net.ipv4.conf.all.rp_filter
+- net.ipv4.conf.default.rp_filter
+- net.ipv4.fwmark_reflect
+- net.ipv6.fwmark_reflect
+- net.ipv4.ip_local_port_range
+runAsUser:
+  type: MustRunAsNonRoot
+seLinuxContext:
+  type: RunAsAny
+fsGroup:
+  type: RunAsAny
+seccompProfiles:
+- "*"
+volumes:
+- configMap
+- emptyDir
+- downwardAPI
+- projected
+- secret
+readOnlyRootFilesystem: true
+---
+# SCC for application Pods running the network-sidecar
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: meridio-sidecar
+allowPrivilegeEscalation: false
+requiredDropCapabilities:
+- ALL
+allowedCapabilities:
+- NET_ADMIN
+- NET_RAW
+- DAC_OVERRIDE
+- SYS_PTRACE
+runAsUser:
+  type: MustRunAsNonRoot
+seLinuxContext:
+  type: MustRunAs
+fsGroup:
+  type: RunAsAny
+seccompProfiles:
+- runtime/default
+volumes:
+- configMap
+- emptyDir
+- downwardAPI
+- projected
+- secret
+readOnlyRootFilesystem: false

--- a/test/e2e/suites/openshift-crc/targets.yaml
+++ b/test/e2e/suites/openshift-crc/targets.yaml
@@ -1,0 +1,69 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: target-ocp
+  labels:
+    app: target-ocp
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: target-ocp
+  template:
+    metadata:
+      labels:
+        app: target-ocp
+      annotations:
+        k8s.v1.cni.cncf.io/networks: app-net
+    spec:
+      serviceAccountName: meridio-2-network-sidecar
+      volumes:
+      - name: sidecar-state
+        emptyDir: {}
+      containers:
+      - name: example-target
+        image: registry.nordix.org/cloud-native/meridio-2/example-target:latest
+        imagePullPolicy: Always
+        command: ["/bin/bash", "-c"]
+        args:
+        - |
+          screen -d -m bash -c "./ctraffic -server -address [::]:5000" ;
+          screen -d -m bash -c "./ctraffic -server -udp -address [::]:5001" ;
+          trap 'exit 0' TERM; sleep infinity & wait
+        securityContext:
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+            add: ["DAC_OVERRIDE", "NET_RAW", "SYS_PTRACE"]
+      - name: network-sidecar
+        image: registry.nordix.org/cloud-native/meridio-2/network-sidecar:latest
+        imagePullPolicy: Always
+        args:
+        - --pod-name=$(POD_NAME)
+        - --pod-namespace=$(POD_NAMESPACE)
+        - --pod-uid=$(POD_UID)
+        - --log-level=debug
+        volumeMounts:
+        - name: sidecar-state
+          mountPath: /var/run/meridio
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
+        securityContext:
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+            add: ["NET_ADMIN"]

--- a/test/e2e/suites/openshift-crc/vpn-gateway.yaml
+++ b/test/e2e/suites/openshift-crc/vpn-gateway.yaml
@@ -1,0 +1,154 @@
+---
+# VPN Gateway BIRD configuration (dual-stack)
+# Uses passive BGP — the gateway waits for LB router to initiate the session.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vpn-gateway-bird-config
+data:
+  bird.conf: |
+    log stderr all;
+    router id 169.254.100.150;
+
+    protocol device {
+      scan time 10;
+    }
+
+    protocol bfd {
+      interface "*" {
+        passive on;
+      };
+    }
+
+    protocol static DEFAULT4 {
+      ipv4 { preference 110; };
+      route 0.0.0.0/0 blackhole;
+    }
+
+    protocol static DEFAULT6 {
+      ipv6 { preference 110; };
+      route ::/0 blackhole;
+    }
+
+    filter gw_kernel_export {
+      if source = RTS_STATIC && dest = RTD_BLACKHOLE then reject;
+      else accept;
+    }
+
+    filter gw_kernel_export6 {
+      if source = RTS_STATIC && dest = RTD_BLACKHOLE then reject;
+      else accept;
+    }
+
+    filter bgp_announce {
+      if ( net ~ [ 0.0.0.0/0 ] ) then accept;
+      if source = RTS_STATIC && dest = RTD_BLACKHOLE then accept;
+      else reject;
+    }
+
+    filter bgp_announce6 {
+      if ( net ~ [ ::/0 ] ) then accept;
+      if source = RTS_STATIC && dest = RTD_BLACKHOLE then accept;
+      else reject;
+    }
+
+    protocol kernel {
+      ipv4 {
+        import none;
+        export filter gw_kernel_export;
+      };
+      merge paths on;
+    }
+
+    protocol kernel {
+      ipv6 {
+        import none;
+        export filter gw_kernel_export6;
+      };
+      merge paths on;
+    }
+
+    template bgp LINK {
+      debug {events};
+      direct;
+      hold time 24;
+      bfd on;
+      graceful restart off;
+    }
+
+    # IPv4 BGP — passive, waits for LB router (ASN 64512) to connect
+    protocol bgp GW4_OCP from LINK {
+      local 169.254.100.150 port 10179 as 4200000000;
+      neighbor range 169.254.100.0/24 port 10179 as 64512;
+      passive;
+      dynamic name "GW4_OCP_";
+      ipv4 {
+        import all;
+        export filter bgp_announce;
+        next hop self;
+      };
+    }
+
+    # IPv6 BGP — passive, waits for LB router (ASN 64512) to connect
+    protocol bgp GW6_OCP from LINK {
+      local fd00:cafe:100::150 port 10179 as 4200000000;
+      neighbor range fd00:cafe:100::/64 port 10179 as 64512;
+      passive;
+      dynamic name "GW6_OCP_";
+      ipv6 {
+        import all;
+        export filter bgp_announce6;
+        next hop self;
+      };
+    }
+  init.sh: |
+    #!/bin/sh
+    set -e
+
+    sysctl -w net.ipv4.fib_multipath_hash_policy=1
+    sysctl -w net.ipv4.conf.all.forwarding=1
+    sysctl -w net.ipv6.conf.all.forwarding=1
+    sysctl -w net.ipv6.conf.all.disable_ipv6=0
+    sysctl -w net.ipv4.conf.all.rp_filter=2
+    sysctl -w net.ipv4.conf.default.rp_filter=2
+
+    ethtool -K net1 tx off 2>/dev/null || true
+
+    echo "VPN Gateway ready (dual-stack) on 169.254.100.150 / fd00:cafe:100::150"
+
+    exec /usr/sbin/bird -d -c /etc/bird/bird.conf
+---
+# VPN Gateway Pod (dual-stack)
+apiVersion: v1
+kind: Pod
+metadata:
+  name: vpn-gateway
+  annotations:
+    k8s.v1.cni.cncf.io/networks: '[
+      {
+        "name": "bgp-net",
+        "ips": ["169.254.100.150/24", "fd00:cafe:100::150/64"],
+        "interface": "net1"
+      }
+    ]'
+spec:
+  serviceAccountName: vpn-gateway
+  containers:
+  - name: vpn-gateway
+    image: registry.nordix.org/cloud-native/meridio-2/vpn-gateway:latest
+    imagePullPolicy: Always
+    command: ["/bin/sh", "/config/init.sh"]
+    securityContext:
+      privileged: true
+    volumeMounts:
+    - name: bird-config
+      mountPath: /etc/bird/bird.conf
+      subPath: bird.conf
+    - name: bird-config
+      mountPath: /config/init.sh
+      subPath: init.sh
+  volumes:
+  - name: bird-config
+    configMap:
+      name: vpn-gateway-bird-config
+  restartPolicy: Always


### PR DESCRIPTION
## Summary

Adds a new e2e test suite for validating Meridio-2 on OpenShift Local (CRC,
single-node) with dual-stack (IPv4 + IPv6) traffic. This suite is intended for
occasional manual validation of OpenShift compatibility, not CI automation.

## Issue

#187 

## What's included

`test/e2e/suites/openshift-crc/`:
- Custom SCCs (`meridio-lb`, `meridio-sidecar`) scoped to the minimum
  capabilities/sysctls each pod type needs
- `KubeletConfig` to allowlist the unsafe sysctls required by the LB pod
- Kustomize overlay on top of `config/default` with OpenShift-specific patches:
  RBAC finalizer permissions (required by OpenShift's
  OwnerReferencesPermissionEnforcement admission controller) and
  webhook/certificate naming
- Bridge CNI NetworkAttachmentDefinitions for the BGP peering and app networks
  (replacing the VLAN-subinterface/macvlan approach used by the Kind suites)
- VPN gateway pod (BIRD, passive BGP, dual-stack) running inside the cluster
- Gateway / GatewayConfiguration, GatewayRouter (IPv4 + IPv6), L34Route,
  DistributionGroup, and target Deployment (2 replicas + network-sidecar)
- Self-contained README covering prerequisites, deployment (Makefile and
  manual), validation steps, and known issues specific to CRC

`test/e2e/Makefile`:
- `deploy-suite` macro: optional 5th parameter for a custom LB template path
- `crc-registry-login`, `push-images-openshift-crc`, `deploy-openshift-crc`,
  `undeploy-openshift-crc`, `openshift-crc` targets

The OpenShift-adapted LB template (`lb-deployment.yaml`) is injected via the
generic `deploy-suite` override mechanism (`MERIDIO_TEMPLATE_PATH`), the same
mechanism already used by the other suites — no duplicate copy is baked into
the kustomize overlay.

## Testing

Deployed and validated manually on CRC 4.21.14 (OpenShift single-node):
- BGP sessions (`GW4_OCP_1`, `GW6_OCP_1`) reach `Established`
- VIPs (`100.0.0.1/32`, `fd00:cafe:1::1/128`) learned via BGP and reachable
- TCP and UDP load balancing across both target pods, 0 failed/dropped
  connections, for both IPv4 and IPv6, with traffic well distributed across
  both replicas (roughly 45-55% split per pod across all four
  protocol/family combinations)

No existing code, controllers, or CI workflows are touched — this is purely
additive under `test/e2e/`.