### PR TITLE
LB controller: preserve flows regardless of endpoint readiness (#195)

### DIFF
--- a/internal/controller/loadbalancer/controller_test.go
+++ b/internal/controller/loadbalancer/controller_test.go
@@ -41,7 +41,7 @@ func TestLoadBalancerController(t *testing.T) {
 }
 
 // newFakeClient creates a fake client with the field indexer for LoadBalancerEndpointSlice
-// registered. All tests that call reconcileTargets or hasReadyEndpoints need this.
+// registered. All tests that call reconcileTargets need this.
 func newFakeClient(scheme *runtime.Scheme, objects ...client.Object) client.Client {
 	return fake.NewClientBuilder().
 		WithScheme(scheme).
@@ -938,7 +938,7 @@ var _ = Describe("LoadBalancer Controller", func() {
 			Expect(mockInstance.flows).To(BeEmpty())
 		})
 
-		It("should delete flows when DistributionGroup has no endpoints", func() {
+		It("should preserve flows when DistributionGroup has no ready endpoints", func() {
 			group := meridio2v1alpha1.GroupVersion.Group
 			kind := kindDistributionGroup
 
@@ -975,17 +975,29 @@ var _ = Describe("LoadBalancer Controller", func() {
 				},
 			}
 
-			// No EndpointSlice (no endpoints)
-			fakeClient = newFakeClient(scheme, distGroup, l34route)
+			// No LoadBalancerEndpointSlice (no endpoints) but L34Route and Gateway exist
+			ipAddrType := gatewayv1.IPAddressType
+			gateway := &gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      gatewayName,
+					Namespace: namespace,
+				},
+				Status: gatewayv1.GatewayStatus{
+					Addresses: []gatewayv1.GatewayStatusAddress{
+						{Type: &ipAddrType, Value: "20.0.0.1"},
+					},
+				},
+			}
+
+			fakeClient = newFakeClient(scheme, distGroup, l34route, gateway)
 			controller.Client = fakeClient
 
 			err := controller.reconcileFlows(ctx, distGroup)
 			Expect(err).ToNot(HaveOccurred())
 
-			// Flows should be deleted
+			// Flows should be preserved (L34Route still exists)
 			mockInstance := mockNfqlb.instances[distGroup.Name]
-			Expect(mockInstance.flows).To(BeEmpty())
-			Expect(mockInstance.flows).ToNot(HaveKey("test-route"))
+			Expect(mockInstance.flows).To(HaveKey("test-route"))
 		})
 
 		It("should delete flows when L34Route is removed", func() {

--- a/internal/controller/loadbalancer/flows.go
+++ b/internal/controller/loadbalancer/flows.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -50,24 +49,13 @@ func (c *Controller) reconcileFlows(ctx context.Context, distGroup *meridio2v1al
 		c.flows[distGroup.Name] = make(map[string]*meridio2v1alpha1.L34Route)
 	}
 
-	// Check if DistributionGroup has endpoints before configuring flows
-	hasEndpoints, err := c.hasReadyEndpoints(ctx, distGroup)
-	if err != nil {
-		return err
-	}
-
-	if !hasEndpoints {
-		logr.Info("No ready endpoints, deleting flows", "distGroup", distGroup.Name)
-		return c.deleteAllFlows(ctx, instance, distGroup.Name)
-	}
-
 	// Get L34Routes for this Gateway and DistributionGroup
 	newFlows, err := c.listMatchingL34Routes(ctx, distGroup)
 	if err != nil {
 		return err
 	}
 
-	// BUG FIX #2: Handle empty L34Route list
+	// Handle empty L34Route list — no routes means no flows needed
 	if len(newFlows) == 0 {
 		logr.Info("No L34Routes found, deleting all flows", "distGroup", distGroup.Name)
 		if err := c.deleteAllFlows(ctx, instance, distGroup.Name); err != nil {
@@ -94,7 +82,7 @@ func (c *Controller) reconcileFlows(ctx context.Context, distGroup *meridio2v1al
 		}
 	}
 
-	// IMPROVEMENT #5: Add/update flows BEFORE configuring nftables
+	// Add/update flows BEFORE configuring nftables
 	successfulFlows := make(map[string]*meridio2v1alpha1.L34Route)
 	for flowName, route := range newFlows {
 		flow := newL34RouteFlow(flowName, route)
@@ -118,37 +106,11 @@ func (c *Controller) reconcileFlows(ctx context.Context, distGroup *meridio2v1al
 		return fmt.Errorf("failed to configure nftables: %w", err)
 	}
 
-	// BUG FIX #3: Update tracked flows with only successful ones
+	// Update tracked flows with only successful ones
 	c.flows[distGroup.Name] = successfulFlows
 
 	logr.Info("Reconciled flows", "distGroup", distGroup.Name, "count", len(successfulFlows))
 	return errFinal
-}
-
-// hasReadyEndpoints checks if DistributionGroup has any ready endpoints.
-func (c *Controller) hasReadyEndpoints(ctx context.Context, distGroup *meridio2v1alpha1.DistributionGroup) (bool, error) {
-	sliceList := &meridio2v1alpha1.LoadBalancerEndpointSliceList{}
-	if err := c.List(ctx, sliceList,
-		client.InNamespace(c.GatewayNamespace),
-		client.MatchingFields{
-			"spec.distributionGroupName": distGroup.Name,
-			"spec.gatewayRef.name":       c.GatewayName,
-		},
-	); err != nil {
-		return false, err
-	}
-
-	for i := range sliceList.Items {
-		if !metav1.IsControlledBy(&sliceList.Items[i], distGroup) {
-			continue
-		}
-		for _, endpoint := range sliceList.Items[i].Spec.Endpoints {
-			if endpoint.Ready {
-				return true, nil
-			}
-		}
-	}
-	return false, nil
 }
 
 // deleteAllFlows deletes all flows for a DistributionGroup.


### PR DESCRIPTION
Remove the hasReadyEndpoints check from reconcileFlows. Flows are now only deleted when the L34Route itself is removed, not when endpoints are temporarily unavailable.

Previously, the controller deleted all NFQLB flows when a DistributionGroup had no ready endpoints. This caused:
- Lower-priority overlapping flows to hijack traffic intended for the temporarily-empty DG
- Silent violation of user-defined L34Route priority ordering
- Unnecessary flow churn on endpoint ready/not-ready transitions

With this fix, NFQLB drops packets at the correct priority level when no targets are active — preserving deterministic behavior and aligning with Meridio v1's approach where classifiers were never removed based on target availability.

Changes:
- Remove hasReadyEndpoints() function (no other callers)
- Remove early-exit path in reconcileFlows that deleted flows
- Update test to verify flows are preserved with no endpoints
- Clean up stale comments

Fixes: #195