### PR TITLE
Remove Node topology hints feature scaffolding (#101)

### DIFF
--- a/config/rbac/manager-clusterrole.yaml
+++ b/config/rbac/manager-clusterrole.yaml
@@ -1,6 +1,6 @@
 ---
 # ClusterRole for cluster-scoped resources only.
-# GatewayClass and Nodes are cluster-scoped and must be accessible
+# GatewayClass is cluster-scoped and must be accessible
 # regardless of --namespace.
 #
 # RBAC: This file is hand-maintained. Update when controller permissions change.
@@ -17,15 +17,6 @@ rules:
   - gateway.networking.k8s.io
   resources:
   - gatewayclasses
-  verbs:
-  - get
-  - list
-  - watch
-# DistributionGroup controller: topology-aware hints (optional, requires --enable-topology-hints)
-- apiGroups:
-  - ""
-  resources:
-  - nodes
   verbs:
   - get
   - list

--- a/docs/controllers/distributiongroup.md
+++ b/docs/controllers/distributiongroup.md
@@ -262,7 +262,6 @@ The controller reconciles when:
 | Gateway | Create/Update/Delete | Referenced in parentRefs or L34Routes |
 | L34Route | Create/Update/Delete | BackendRef points to DG |
 | GatewayConfiguration | Create/Update/Delete | Referenced by Gateway |
-| Node | Create/Update/Delete | Topology hints (optional) |
 
 **Note:** Gateway watch includes early filtering - only Gateways with `Accepted=True` trigger reconciliation.
 
@@ -691,8 +690,6 @@ Deploy to cluster and verify:
 
 **`--max-endpoints-per-slice`**: Maximum number of endpoints per LoadBalancerEndpointSlice (default: 200)
 
-**`--enable-topology-hints`**: Enable Node watching for faster endpoint removal when Nodes fail
-
 ### Environment Variables
 All flags can be set via `MERIDIO_*` environment variables (e.g., `MERIDIO_NAMESPACE`, `MERIDIO_MAX_ENDPOINTS_PER_SLICE`).
 
@@ -700,7 +697,7 @@ All flags can be set via `MERIDIO_*` environment variables (e.g., `MERIDIO_NAMES
 
 The controller manager's RBAC is split into:
 - **Role** (namespace-scoped): Pods, Deployments, Gateways, L34Routes, GatewayConfigurations, DistributionGroups, LoadBalancerEndpointSlices, EndpointNetworkConfigurations
-- **ClusterRole** (cluster-scoped): GatewayClasses, Nodes (optional, for topology hints)
+- **ClusterRole** (cluster-scoped): GatewayClasses
 
 See `config/rbac/manager-role.yaml` and `config/rbac/manager-clusterrole.yaml`.
 
@@ -709,13 +706,19 @@ The DG controller specifically requires:
 - Read/Write: LoadBalancerEndpointSlices (create, update, delete)
 - Write: DistributionGroups/status
 
-## Future Enhancements
+## Node Failure Detection
 
-### Node Availability Monitoring
-- Watch Node resources for NotReady conditions
-- Trigger immediate reconciliation when Nodes fail
-- Remove endpoints faster than waiting for Pod deletion
-- Requires `--enable-topology-hints` flag
+The DG controller does **not** watch Node events or independently detect node failure. When a Node becomes unreachable, the affected Pod's `PodReady` condition remains stale (`True`) because the dead kubelet cannot update it. Endpoint removal and Maglev ID reallocation are deferred until Kubernetes evicts and deletes the Pod.
+
+This is intentional:
+
+1. **Node unreachable ≠ node dead.** A control-plane network partition triggers NotReady, but the Pod may still be running and serving traffic on the data-plane path.
+2. **Premature Maglev ID reallocation disrupts active connections.** Revoking an ID reshuffles the hash table, reassigning in-flight connections to a different endpoint — even if the original Pod is still alive.
+3. **Kubernetes provides the control mechanism.** Applications set Pod `tolerationSeconds` for `node.kubernetes.io/not-ready` and `node.kubernetes.io/unreachable` taints to control the eviction window (default 300s, reducible to e.g. 30s for faster failover).
+
+Once the Pod is deleted or transitions out of `Running` phase, the DG controller removes it from EndpointSlices and the Maglev ID is freed — this is the safe trigger, as Kubernetes has committed to terminating the Pod.
+
+## Future Enhancements
 
 ### Additional Attachment Types
 - Future attachment types (e.g., DRA) could be added if needed

--- a/internal/common/config/manager.go
+++ b/internal/common/config/manager.go
@@ -47,7 +47,6 @@ type ManagerConfig struct {
 	LogLevelAPI string
 
 	// Features
-	EnableTopologyHints  bool
 	MaxEndpointsPerSlice int
 
 	// Filtering
@@ -100,8 +99,6 @@ func (c *ManagerConfig) AddFlags(fs *pflag.FlagSet) {
 		"Log level (debug, info, warn, error)")
 	fs.StringVar(&c.LogLevelAPI, "log-level-api", "",
 		"Address for dynamic log level HTTP endpoint (e.g., 127.0.0.1:9901). Empty disables the feature.")
-	fs.BoolVar(&c.EnableTopologyHints, "enable-topology-hints", false,
-		"Enable Node watching for topology-aware endpoint hints. Requires RBAC permissions for nodes.")
 	fs.IntVar(&c.MaxEndpointsPerSlice, "max-endpoints-per-slice", 200,
 		"Maximum number of endpoints per LoadBalancerEndpointSlice.")
 	fs.StringVar(&c.PodCacheLabel, "pod-cache-label", "",
@@ -147,7 +144,6 @@ func (c *ManagerConfig) BindEnv(fs *pflag.FlagSet) {
 	bindBool(fs, "enable-http2", "MERIDIO_ENABLE_HTTP2", &c.EnableHTTP2)
 	bindString(fs, "log-level", "MERIDIO_LOG_LEVEL", &c.LogLevel)
 	bindString(fs, "log-level-api", "MERIDIO_LOG_LEVEL_API", &c.LogLevelAPI)
-	bindBool(fs, "enable-topology-hints", "MERIDIO_ENABLE_TOPOLOGY_HINTS", &c.EnableTopologyHints)
 	bindInt(fs, "max-endpoints-per-slice", "MERIDIO_MAX_ENDPOINTS_PER_SLICE", &c.MaxEndpointsPerSlice)
 	bindString(fs, "pod-cache-label", "MERIDIO_POD_CACHE_LABEL", &c.PodCacheLabel)
 	bindString(fs, "template-path", "MERIDIO_TEMPLATE_PATH", &c.TemplatePath)

--- a/internal/controller/distributiongroup/controller.go
+++ b/internal/controller/distributiongroup/controller.go
@@ -205,7 +205,7 @@ func (r *DistributionGroupReconciler) Reconcile(ctx context.Context, req ctrl.Re
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *DistributionGroupReconciler) SetupWithManager(mgr ctrl.Manager, enableTopology bool) error {
+func (r *DistributionGroupReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// Register field indexer for LoadBalancerEndpointSlice lookups by DG name.
 	// This enables client.MatchingFields{"spec.distributionGroupName": ...} in List calls.
 	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &meridio2v1alpha1.LoadBalancerEndpointSlice{},
@@ -226,10 +226,6 @@ func (r *DistributionGroupReconciler) SetupWithManager(mgr ctrl.Manager, enableT
 		Watches(&meridio2v1alpha1.L34Route{}, handler.EnqueueRequestsFromMapFunc(r.mapL34RouteToDistributionGroup)).
 		Watches(&meridio2v1alpha1.GatewayConfiguration{}, handler.EnqueueRequestsFromMapFunc(r.mapGatewayConfigToDistributionGroup)).
 		Named("distributiongroup")
-
-	if enableTopology {
-		builder = builder.Watches(&corev1.Node{}, handler.EnqueueRequestsFromMapFunc(r.mapNodeToDistributionGroup))
-	}
 
 	return builder.Complete(r)
 }

--- a/internal/controller/distributiongroup/mappers.go
+++ b/internal/controller/distributiongroup/mappers.go
@@ -127,9 +127,3 @@ func (r *DistributionGroupReconciler) mapGatewayConfigToDistributionGroup(ctx co
 
 	return r.findDGsReferencingGateways(ctx, gatewayKeys)
 }
-
-// mapNodeToDistributionGroup maps Node changes to DistributionGroup reconciliation requests
-func (r *DistributionGroupReconciler) mapNodeToDistributionGroup(ctx context.Context, obj client.Object) []ctrl.Request {
-	// TODO: List all Pods on this Node, find DistributionGroups matching those Pods
-	return nil
-}

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -299,9 +299,6 @@ func setupManager(cfg *config.ManagerConfig) (ctrl.Manager, error) {
 		cacheOptions.ByObject = map[client.Object]cache.ByObject{
 			&gatewayapiv1.GatewayClass{}: {},
 		}
-		if cfg.EnableTopologyHints {
-			cacheOptions.ByObject[&corev1.Node{}] = cache.ByObject{}
-		}
 	}
 
 	// Apply pod cache label filter (already validated)
@@ -362,7 +359,7 @@ func registerBuiltinControllers(mgr ctrl.Manager, cfg *config.ManagerConfig) err
 		ControllerName:       cfg.ControllerName,
 		Namespace:            cfg.Namespace,
 		MaxEndpointsPerSlice: cfg.MaxEndpointsPerSlice,
-	}).SetupWithManager(mgr, cfg.EnableTopologyHints); err != nil {
+	}).SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("controller DistributionGroup: %w", err)
 	}
 


### PR DESCRIPTION
#220 

### Description:

The `--enable-topology-hints` flag and associated code was scaffolding for a potential Node-watching feature that was never implemented (the mapper was a no-op stub returning nil).

After investigation (#101), the conclusion is that Node events are not appropriate for this controller:
- Node unreachable ≠ node dead — a control-plane partition triggers NotReady, but the Pod may still serve traffic on the data-plane path
- Premature Maglev ID reallocation disrupts active connections
- Kubernetes already provides the mechanism via Pod tolerationSeconds

This PR removes the dead code and documents the architectural decision.

**Changes:**
- Remove --enable-topology-hints flag and env binding
- Remove mapNodeToDistributionGroup stub
- Remove Node RBAC from ClusterRole
- Remove conditional Node cache config
- Replace "Future Enhancement" with "Node Failure Detection" rationale in DG doc