### PR TITLE
Fix gateway enqueue l34route

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,9 @@ Always use `kubebuilder create api` and `kubebuilder create webhook` to scaffold
 The e2e tests are designed to validate the solution in an isolated environment (similar to GitHub Actions CI).
 Ensure you run them against a dedicated [Kind](https://kind.sigs.k8s.io/) cluster (not your “real” dev/prod cluster).
 
+### Branch Naming
+Do not use `/` in branch names (e.g., `fix/my-feature`). The CI pipeline uses branch names as Docker image tags, and `/` is not valid in container image tags. Use hyphens instead: `fix-my-feature`.
+
 ## After Making Changes
 
 **After editing `*_types.go` or markers:**

--- a/docs/controllers/loadbalancer.md
+++ b/docs/controllers/loadbalancer.md
@@ -223,13 +223,13 @@ nftables (shared across all DGs in this LB Pod)
 |----------|---------|-----------------|-------------------|
 | DistributionGroup | Create/Update/Delete | Direct (`.For()`) | None (all events) |
 | LoadBalancerEndpointSlice | Create/Update/Delete | `endpointSliceEnqueue` | OwnerReference to DistributionGroup + `spec.gatewayRef` matches this Gateway |
-| Gateway | Create/Update/Delete | `gatewayEnqueue` | Name matches controller's Gateway + lists DGs with direct `parentRefs` to this Gateway |
+| Gateway | Create/Update/Delete | `gatewayEnqueue` | Name matches controller's Gateway + discovers DGs via direct `parentRefs` and indirect L34Route `backendRefs` |
 | L34Route | Create/Update/Delete | `l34RouteEnqueue` | Checks parentRefs for this Gateway AND backendRefs for DG kind |
 
 ### Filtering Strategy Rationale
 
 - **LoadBalancerEndpointSlice mapper**: Checks namespace matches this Gateway's namespace, `spec.gatewayRef` matches this Gateway, and ownerReference points to a DistributionGroup. Enqueues the owning DG.
-- **Gateway mapper**: Only triggers if Gateway name matches this controller's Gateway. Lists all DistributionGroups and enqueues those with `spec.parentRefs` referencing this Gateway. Note: DGs linked only via L34Route (no direct `parentRefs`) are not re-reconciled by this mapper — they rely on the L34Route mapper instead.
+- **Gateway mapper**: Only triggers if Gateway name matches this controller's Gateway. Discovers DGs via both direct `spec.parentRefs` and indirectly via L34Route `backendRefs`. Deduplicates results.
 - **L34Route mapper**: Checks both `parentRefs` (Gateway match) and `backendRefs` (DG kind). Enqueues each referenced DG.
 - **All mappers enqueue broadly**: The reconcile loop makes the final decision via `belongsToGateway()`. This is simpler and more robust than pre-filtering in mappers.
 

--- a/internal/controller/loadbalancer/controller.go
+++ b/internal/controller/loadbalancer/controller.go
@@ -86,6 +86,7 @@ const (
 	kindDistributionGroup = "DistributionGroup"
 	groupGatewayAPI       = gatewayv1.GroupName
 	kindGateway           = "Gateway"
+	defaultBackendKind    = "Service"
 )
 
 func (c *Controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -225,7 +226,7 @@ func (c *Controller) belongsToGateway(ctx context.Context, distGroup *meridio2v1
 			}
 
 			// Default Kind to "Service" when unspecified
-			kind := "Service"
+			kind := defaultBackendKind
 			if backendRef.Kind != nil {
 				kind = string(*backendRef.Kind)
 			}
@@ -256,31 +257,62 @@ func (c *Controller) gatewayEnqueue(ctx context.Context, obj client.Object) []ct
 		return nil
 	}
 
-	// List all DistributionGroups
+	// Deduplicate: a DG may be referenced both directly and via L34Route
+	enqueued := make(map[client.ObjectKey]struct{})
+
+	// 1. Direct: DGs with spec.parentRefs pointing to this Gateway
 	dgList := &meridio2v1alpha1.DistributionGroupList{}
 	if err := c.List(ctx, dgList); err != nil {
-		return nil
-	}
+		log.FromContext(ctx).Error(err, "Failed to list DistributionGroups in gatewayEnqueue")
+	} else {
+		for _, dg := range dgList.Items {
+			for _, parentRef := range dg.Spec.ParentRefs {
+				namespace := dg.Namespace
+				if parentRef.Namespace != nil {
+					namespace = *parentRef.Namespace
+				}
 
-	// Enqueue all DGs that reference this Gateway
-	requests := []ctrl.Request{}
-	for _, dg := range dgList.Items {
-		for _, parentRef := range dg.Spec.ParentRefs {
-			namespace := dg.Namespace
-			if parentRef.Namespace != nil {
-				namespace = *parentRef.Namespace
-			}
-
-			if parentRef.Name == c.GatewayName && namespace == c.GatewayNamespace {
-				requests = append(requests, ctrl.Request{
-					NamespacedName: client.ObjectKey{
-						Name:      dg.Name,
-						Namespace: dg.Namespace,
-					},
-				})
-				break
+				if parentRef.Name == c.GatewayName && namespace == c.GatewayNamespace {
+					enqueued[client.ObjectKey{Name: dg.Name, Namespace: dg.Namespace}] = struct{}{}
+					break
+				}
 			}
 		}
+	}
+
+	// 2. Indirect: DGs referenced by L34Routes that point to this Gateway
+	l34routeList := &meridio2v1alpha1.L34RouteList{}
+	if err := c.List(ctx, l34routeList, client.InNamespace(c.GatewayNamespace)); err != nil {
+		log.FromContext(ctx).Error(err, "Failed to list L34Routes in gatewayEnqueue, returning partial results")
+	} else {
+		for i := range l34routeList.Items {
+			route := &l34routeList.Items[i]
+			if !c.referencesGateway(route) {
+				continue
+			}
+			for _, backendRef := range route.Spec.BackendRefs {
+				group := ""
+				if backendRef.Group != nil {
+					group = string(*backendRef.Group)
+				}
+				kind := defaultBackendKind
+				if backendRef.Kind != nil {
+					kind = string(*backendRef.Kind)
+				}
+				namespace := route.Namespace
+				if backendRef.Namespace != nil {
+					namespace = string(*backendRef.Namespace)
+				}
+				if group == meridio2v1alpha1.GroupVersion.Group && kind == kindDistributionGroup {
+					enqueued[client.ObjectKey{Name: string(backendRef.Name), Namespace: namespace}] = struct{}{}
+				}
+			}
+		}
+	}
+
+	requests := make([]ctrl.Request, 0, len(enqueued))
+	for key := range enqueued {
+		requests = append(requests, ctrl.Request{NamespacedName: key})
 	}
 
 	return requests
@@ -401,7 +433,7 @@ func (c *Controller) l34RouteEnqueue(ctx context.Context, obj client.Object) []c
 		}
 
 		// Default Kind to "Service" when unspecified
-		kind := "Service"
+		kind := defaultBackendKind
 		if backendRef.Kind != nil {
 			kind = string(*backendRef.Kind)
 		}

--- a/internal/controller/loadbalancer/controller.go
+++ b/internal/controller/loadbalancer/controller.go
@@ -89,6 +89,29 @@ const (
 	defaultBackendKind    = "Service"
 )
 
+// resolveBackendRefDG checks if a BackendRef points to a DistributionGroup.
+// Returns the resolved ObjectKey and true if it is a DG reference, or an empty key and false otherwise.
+// Applies Gateway API defaulting: Group defaults to "" (core), Kind defaults to "Service",
+// Namespace defaults to routeNamespace.
+func resolveBackendRefDG(backendRef gatewayv1.BackendRef, routeNamespace string) (client.ObjectKey, bool) {
+	group := ""
+	if backendRef.Group != nil {
+		group = string(*backendRef.Group)
+	}
+	kind := defaultBackendKind
+	if backendRef.Kind != nil {
+		kind = string(*backendRef.Kind)
+	}
+	if group != meridio2v1alpha1.GroupVersion.Group || kind != kindDistributionGroup {
+		return client.ObjectKey{}, false
+	}
+	namespace := routeNamespace
+	if backendRef.Namespace != nil {
+		namespace = string(*backendRef.Namespace)
+	}
+	return client.ObjectKey{Name: string(backendRef.Name), Namespace: namespace}, true
+}
+
 func (c *Controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logr := log.FromContext(ctx)
 
@@ -219,29 +242,8 @@ func (c *Controller) belongsToGateway(ctx context.Context, distGroup *meridio2v1
 
 		// Check if route references this DistributionGroup
 		for _, backendRef := range route.Spec.BackendRefs {
-			// Default Group to "" (core API group) when unspecified
-			group := ""
-			if backendRef.Group != nil {
-				group = string(*backendRef.Group)
-			}
-
-			// Default Kind to "Service" when unspecified
-			kind := defaultBackendKind
-			if backendRef.Kind != nil {
-				kind = string(*backendRef.Kind)
-			}
-
-			// Default Namespace to Route's namespace when unspecified
-			namespace := route.Namespace
-			if backendRef.Namespace != nil {
-				namespace = string(*backendRef.Namespace)
-			}
-
-			// Check if this backendRef matches our DistributionGroup
-			if group == meridio2v1alpha1.GroupVersion.Group &&
-				kind == kindDistributionGroup &&
-				string(backendRef.Name) == distGroup.Name &&
-				namespace == distGroup.Namespace {
+			key, isDG := resolveBackendRefDG(backendRef, route.Namespace)
+			if isDG && key.Name == distGroup.Name && key.Namespace == distGroup.Namespace {
 				return true, nil
 			}
 		}
@@ -291,20 +293,8 @@ func (c *Controller) gatewayEnqueue(ctx context.Context, obj client.Object) []ct
 				continue
 			}
 			for _, backendRef := range route.Spec.BackendRefs {
-				group := ""
-				if backendRef.Group != nil {
-					group = string(*backendRef.Group)
-				}
-				kind := defaultBackendKind
-				if backendRef.Kind != nil {
-					kind = string(*backendRef.Kind)
-				}
-				namespace := route.Namespace
-				if backendRef.Namespace != nil {
-					namespace = string(*backendRef.Namespace)
-				}
-				if group == meridio2v1alpha1.GroupVersion.Group && kind == kindDistributionGroup {
-					enqueued[client.ObjectKey{Name: string(backendRef.Name), Namespace: namespace}] = struct{}{}
+				if key, isDG := resolveBackendRefDG(backendRef, route.Namespace); isDG {
+					enqueued[key] = struct{}{}
 				}
 			}
 		}
@@ -426,33 +416,8 @@ func (c *Controller) l34RouteEnqueue(ctx context.Context, obj client.Object) []c
 	// Enqueue all DistributionGroups referenced by this route
 	var requests []ctrl.Request
 	for _, backendRef := range route.Spec.BackendRefs {
-		// Default Group to "" (core API group) when unspecified
-		group := ""
-		if backendRef.Group != nil {
-			group = string(*backendRef.Group)
-		}
-
-		// Default Kind to "Service" when unspecified
-		kind := defaultBackendKind
-		if backendRef.Kind != nil {
-			kind = string(*backendRef.Kind)
-		}
-
-		// Default Namespace to Route's namespace when unspecified
-		namespace := route.Namespace
-		if backendRef.Namespace != nil {
-			namespace = string(*backendRef.Namespace)
-		}
-
-		// Check if this backendRef is a DistributionGroup
-		if group == meridio2v1alpha1.GroupVersion.Group &&
-			kind == kindDistributionGroup {
-			requests = append(requests, ctrl.Request{
-				NamespacedName: client.ObjectKey{
-					Name:      string(backendRef.Name),
-					Namespace: namespace,
-				},
-			})
+		if key, isDG := resolveBackendRefDG(backendRef, route.Namespace); isDG {
+			requests = append(requests, ctrl.Request{NamespacedName: key})
 		}
 	}
 

--- a/internal/controller/loadbalancer/controller_test.go
+++ b/internal/controller/loadbalancer/controller_test.go
@@ -1258,4 +1258,345 @@ var _ = Describe("LoadBalancer Controller", func() {
 			Expect(controller.targets).ToNot(HaveKey(distGroup.Name))
 		})
 	})
+
+	Describe("gatewayEnqueue", func() {
+		It("should enqueue DG with direct parentRef to this Gateway", func() {
+			dg := &meridio2v1alpha1.DistributionGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "direct-dg",
+					Namespace: namespace,
+				},
+				Spec: meridio2v1alpha1.DistributionGroupSpec{
+					ParentRefs: []meridio2v1alpha1.ParentReference{
+						{Name: gatewayName},
+					},
+				},
+			}
+
+			fakeClient = newFakeClient(scheme, dg)
+			controller.Client = fakeClient
+
+			gateway := &gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      gatewayName,
+					Namespace: namespace,
+				},
+			}
+
+			requests := controller.gatewayEnqueue(ctx, gateway)
+			Expect(requests).To(HaveLen(1))
+			Expect(requests[0].Name).To(Equal("direct-dg"))
+		})
+
+		It("should enqueue DG referenced indirectly via L34Route", func() {
+			group := meridio2v1alpha1.GroupVersion.Group
+			kind := kindDistributionGroup
+
+			// DG with no parentRefs (indirect only)
+			dg := &meridio2v1alpha1.DistributionGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "indirect-dg",
+					Namespace: namespace,
+				},
+			}
+
+			// L34Route connecting Gateway → DG
+			l34route := &meridio2v1alpha1.L34Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: namespace,
+				},
+				Spec: meridio2v1alpha1.L34RouteSpec{
+					ParentRefs: []gatewayv1.ParentReference{
+						{Name: gatewayv1.ObjectName(gatewayName)},
+					},
+					BackendRefs: []gatewayv1.BackendRef{
+						{
+							BackendObjectReference: gatewayv1.BackendObjectReference{
+								Group: (*gatewayv1.Group)(&group),
+								Kind:  (*gatewayv1.Kind)(&kind),
+								Name:  "indirect-dg",
+							},
+						},
+					},
+					DestinationCIDRs: []string{"20.0.0.1/32"},
+					Protocols:        []meridio2v1alpha1.TransportProtocol{meridio2v1alpha1.TCP},
+					Priority:         1,
+				},
+			}
+
+			fakeClient = newFakeClient(scheme, dg, l34route)
+			controller.Client = fakeClient
+
+			gateway := &gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      gatewayName,
+					Namespace: namespace,
+				},
+			}
+
+			requests := controller.gatewayEnqueue(ctx, gateway)
+			Expect(requests).To(HaveLen(1))
+			Expect(requests[0].Name).To(Equal("indirect-dg"))
+		})
+
+		It("should deduplicate DG referenced both directly and via L34Route", func() {
+			group := meridio2v1alpha1.GroupVersion.Group
+			kind := kindDistributionGroup
+
+			// DG with direct parentRef AND referenced by L34Route
+			dg := &meridio2v1alpha1.DistributionGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "both-dg",
+					Namespace: namespace,
+				},
+				Spec: meridio2v1alpha1.DistributionGroupSpec{
+					ParentRefs: []meridio2v1alpha1.ParentReference{
+						{Name: gatewayName},
+					},
+				},
+			}
+
+			l34route := &meridio2v1alpha1.L34Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: namespace,
+				},
+				Spec: meridio2v1alpha1.L34RouteSpec{
+					ParentRefs: []gatewayv1.ParentReference{
+						{Name: gatewayv1.ObjectName(gatewayName)},
+					},
+					BackendRefs: []gatewayv1.BackendRef{
+						{
+							BackendObjectReference: gatewayv1.BackendObjectReference{
+								Group: (*gatewayv1.Group)(&group),
+								Kind:  (*gatewayv1.Kind)(&kind),
+								Name:  "both-dg",
+							},
+						},
+					},
+					DestinationCIDRs: []string{"20.0.0.1/32"},
+					Protocols:        []meridio2v1alpha1.TransportProtocol{meridio2v1alpha1.TCP},
+					Priority:         1,
+				},
+			}
+
+			fakeClient = newFakeClient(scheme, dg, l34route)
+			controller.Client = fakeClient
+
+			gateway := &gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      gatewayName,
+					Namespace: namespace,
+				},
+			}
+
+			requests := controller.gatewayEnqueue(ctx, gateway)
+			Expect(requests).To(HaveLen(1))
+			Expect(requests[0].Name).To(Equal("both-dg"))
+		})
+
+		It("should not enqueue DGs for a different Gateway", func() {
+			dg := &meridio2v1alpha1.DistributionGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "other-dg",
+					Namespace: namespace,
+				},
+				Spec: meridio2v1alpha1.DistributionGroupSpec{
+					ParentRefs: []meridio2v1alpha1.ParentReference{
+						{Name: "other-gateway"},
+					},
+				},
+			}
+
+			fakeClient = newFakeClient(scheme, dg)
+			controller.Client = fakeClient
+
+			gateway := &gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      gatewayName,
+					Namespace: namespace,
+				},
+			}
+
+			requests := controller.gatewayEnqueue(ctx, gateway)
+			Expect(requests).To(BeEmpty())
+		})
+
+		It("should return nil for a different Gateway name", func() {
+			gateway := &gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "other-gateway",
+					Namespace: namespace,
+				},
+			}
+
+			requests := controller.gatewayEnqueue(ctx, gateway)
+			Expect(requests).To(BeNil())
+		})
+
+		It("should not enqueue non-DistributionGroup backendRefs from L34Routes", func() {
+			// L34Route points to this Gateway but backendRef is a Service, not a DG
+			l34route := &meridio2v1alpha1.L34Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "service-route",
+					Namespace: namespace,
+				},
+				Spec: meridio2v1alpha1.L34RouteSpec{
+					ParentRefs: []gatewayv1.ParentReference{
+						{Name: gatewayv1.ObjectName(gatewayName)},
+					},
+					BackendRefs: []gatewayv1.BackendRef{
+						{
+							BackendObjectReference: gatewayv1.BackendObjectReference{
+								// Group and Kind default to "" and "Service" respectively
+								Name: "my-service",
+							},
+						},
+					},
+					DestinationCIDRs: []string{"20.0.0.1/32"},
+					Protocols:        []meridio2v1alpha1.TransportProtocol{meridio2v1alpha1.TCP},
+					Priority:         1,
+				},
+			}
+
+			fakeClient = newFakeClient(scheme, l34route)
+			controller.Client = fakeClient
+
+			gateway := &gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      gatewayName,
+					Namespace: namespace,
+				},
+			}
+
+			requests := controller.gatewayEnqueue(ctx, gateway)
+			Expect(requests).To(BeEmpty())
+		})
+
+		It("should not enqueue DGs from L34Routes referencing a different Gateway", func() {
+			group := meridio2v1alpha1.GroupVersion.Group
+			kind := kindDistributionGroup
+
+			l34route := &meridio2v1alpha1.L34Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "other-gw-route",
+					Namespace: namespace,
+				},
+				Spec: meridio2v1alpha1.L34RouteSpec{
+					ParentRefs: []gatewayv1.ParentReference{
+						{Name: "other-gateway"},
+					},
+					BackendRefs: []gatewayv1.BackendRef{
+						{
+							BackendObjectReference: gatewayv1.BackendObjectReference{
+								Group: (*gatewayv1.Group)(&group),
+								Kind:  (*gatewayv1.Kind)(&kind),
+								Name:  "some-dg",
+							},
+						},
+					},
+					DestinationCIDRs: []string{"20.0.0.1/32"},
+					Protocols:        []meridio2v1alpha1.TransportProtocol{meridio2v1alpha1.TCP},
+					Priority:         1,
+				},
+			}
+
+			fakeClient = newFakeClient(scheme, l34route)
+			controller.Client = fakeClient
+
+			gateway := &gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      gatewayName,
+					Namespace: namespace,
+				},
+			}
+
+			requests := controller.gatewayEnqueue(ctx, gateway)
+			Expect(requests).To(BeEmpty())
+		})
+
+		It("should enqueue multiple DGs from multiple L34Routes", func() {
+			group := meridio2v1alpha1.GroupVersion.Group
+			kind := kindDistributionGroup
+
+			route1 := &meridio2v1alpha1.L34Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "route-1",
+					Namespace: namespace,
+				},
+				Spec: meridio2v1alpha1.L34RouteSpec{
+					ParentRefs: []gatewayv1.ParentReference{
+						{Name: gatewayv1.ObjectName(gatewayName)},
+					},
+					BackendRefs: []gatewayv1.BackendRef{
+						{
+							BackendObjectReference: gatewayv1.BackendObjectReference{
+								Group: (*gatewayv1.Group)(&group),
+								Kind:  (*gatewayv1.Kind)(&kind),
+								Name:  "dg-alpha",
+							},
+						},
+					},
+					DestinationCIDRs: []string{"20.0.0.1/32"},
+					Protocols:        []meridio2v1alpha1.TransportProtocol{meridio2v1alpha1.TCP},
+					Priority:         1,
+				},
+			}
+
+			route2 := &meridio2v1alpha1.L34Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "route-2",
+					Namespace: namespace,
+				},
+				Spec: meridio2v1alpha1.L34RouteSpec{
+					ParentRefs: []gatewayv1.ParentReference{
+						{Name: gatewayv1.ObjectName(gatewayName)},
+					},
+					BackendRefs: []gatewayv1.BackendRef{
+						{
+							BackendObjectReference: gatewayv1.BackendObjectReference{
+								Group: (*gatewayv1.Group)(&group),
+								Kind:  (*gatewayv1.Kind)(&kind),
+								Name:  "dg-beta",
+							},
+						},
+					},
+					DestinationCIDRs: []string{"30.0.0.1/32"},
+					Protocols:        []meridio2v1alpha1.TransportProtocol{meridio2v1alpha1.TCP},
+					Priority:         2,
+				},
+			}
+
+			fakeClient = newFakeClient(scheme, route1, route2)
+			controller.Client = fakeClient
+
+			gateway := &gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      gatewayName,
+					Namespace: namespace,
+				},
+			}
+
+			requests := controller.gatewayEnqueue(ctx, gateway)
+			Expect(requests).To(HaveLen(2))
+			names := []string{requests[0].Name, requests[1].Name}
+			Expect(names).To(ContainElements("dg-alpha", "dg-beta"))
+		})
+
+		It("should return empty when no DGs and no L34Routes exist", func() {
+			fakeClient = newFakeClient(scheme)
+			controller.Client = fakeClient
+
+			gateway := &gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      gatewayName,
+					Namespace: namespace,
+				},
+			}
+
+			requests := controller.gatewayEnqueue(ctx, gateway)
+			Expect(requests).To(BeEmpty())
+		})
+	})
 })


### PR DESCRIPTION
Extend gatewayEnqueue to discover DistributionGroups connected to the gateway both directly (via spec.parentRefs) and indirectly (via L34Route backendRefs). Previously, only DGs with direct parentRefs were enqueued when Gateway status changed.

Without this fix, a DG linked to a Gateway only through an L34Route would not be re-reconciled when Gateway.status.addresses changed, leaving nftables VIP sets stale until an unrelated event triggered
reconciliation.

Changes:
- gatewayEnqueue now scans L34Routes for backendRefs to DGs
- Deduplicates DGs found via both paths (map-based)
- Extract "Service" literal to defaultBackendKind constant (goconst)
- Add 5 unit tests covering direct, indirect, dedup, wrong-gateway,  and different-gateway-name cases
- Extract shared helper for parsing Gateway API BackendRef into a DistributionGroup ObjectKey. Replaces 3 duplicate instances of the same group/kind/namespace defaulting logic in:
     - belongsToGateway()
     - gatewayEnqueue()
     - l34RouteEnqueue()

Fixes: #224