### PR TITLE
Add missing +optional markers for omitempty fields

### DIFF
--- a/api/v1alpha1/distributiongroup_types.go
+++ b/api/v1alpha1/distributiongroup_types.go
@@ -140,16 +140,16 @@ type DistributionGroup struct {
 	metav1.TypeMeta `json:",inline"`
 
 	// +optional
-	metav1.ObjectMeta `json:"metadata,omitempty"`
+	metav1.ObjectMeta `json:"metadata,omitzero"`
 
 	// Spec defines the behavior of a DistributionGroup.
 	// +optional
-	Spec DistributionGroupSpec `json:"spec,omitempty"`
+	Spec DistributionGroupSpec `json:"spec,omitzero"`
 
 	// Most recently observed status of the DistributionGroup.
 	// Populated by the system. Read-only.
 	// +optional
-	Status DistributionGroupStatus `json:"status,omitempty"`
+	Status DistributionGroupStatus `json:"status,omitzero"`
 }
 
 // +kubebuilder:object:root=true
@@ -158,7 +158,7 @@ type DistributionGroup struct {
 type DistributionGroupList struct {
 	metav1.TypeMeta `json:",inline"`
 	// +optional
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata,omitzero"`
 	Items           []DistributionGroup `json:"items"`
 }
 

--- a/api/v1alpha1/distributiongroup_types.go
+++ b/api/v1alpha1/distributiongroup_types.go
@@ -157,6 +157,7 @@ type DistributionGroup struct {
 // DistributionGroupList contains a list of DistributionGroup
 type DistributionGroupList struct {
 	metav1.TypeMeta `json:",inline"`
+	// +optional
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []DistributionGroup `json:"items"`
 }

--- a/api/v1alpha1/endpointnetworkconfiguration_types.go
+++ b/api/v1alpha1/endpointnetworkconfiguration_types.go
@@ -126,12 +126,12 @@ type EndpointNetworkConfiguration struct {
 	metav1.TypeMeta `json:",inline"`
 
 	// +optional
-	metav1.ObjectMeta `json:"metadata,omitempty"`
+	metav1.ObjectMeta `json:"metadata,omitzero"`
 
 	// +optional
-	Spec EndpointNetworkConfigurationSpec `json:"spec,omitempty"`
+	Spec EndpointNetworkConfigurationSpec `json:"spec,omitzero"`
 	// +optional
-	Status EndpointNetworkConfigurationStatus `json:"status,omitempty"`
+	Status EndpointNetworkConfigurationStatus `json:"status,omitzero"`
 }
 
 // +kubebuilder:object:root=true
@@ -140,7 +140,7 @@ type EndpointNetworkConfiguration struct {
 type EndpointNetworkConfigurationList struct {
 	metav1.TypeMeta `json:",inline"`
 	// +optional
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata,omitzero"`
 	Items           []EndpointNetworkConfiguration `json:"items"`
 }
 

--- a/api/v1alpha1/endpointnetworkconfiguration_types.go
+++ b/api/v1alpha1/endpointnetworkconfiguration_types.go
@@ -139,6 +139,7 @@ type EndpointNetworkConfiguration struct {
 // EndpointNetworkConfigurationList contains a list of EndpointNetworkConfiguration
 type EndpointNetworkConfigurationList struct {
 	metav1.TypeMeta `json:",inline"`
+	// +optional
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []EndpointNetworkConfiguration `json:"items"`
 }

--- a/api/v1alpha1/endpointnetworkconfiguration_types.go
+++ b/api/v1alpha1/endpointnetworkconfiguration_types.go
@@ -123,10 +123,14 @@ type EndpointNetworkConfigurationStatus struct {
 // The name of the resource MUST be identical to the Pod's name for
 // automatic discovery by local agents.
 type EndpointNetworkConfiguration struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
+
+	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   EndpointNetworkConfigurationSpec   `json:"spec,omitempty"`
+	// +optional
+	Spec EndpointNetworkConfigurationSpec `json:"spec,omitempty"`
+	// +optional
 	Status EndpointNetworkConfigurationStatus `json:"status,omitempty"`
 }
 

--- a/api/v1alpha1/gatewayconfiguration_types.go
+++ b/api/v1alpha1/gatewayconfiguration_types.go
@@ -136,7 +136,7 @@ type ContainerArgs struct {
 
 	// resources specifies the CPU and memory requests and limits for this container.
 	// +optional
-	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
+	Resources corev1.ResourceRequirements `json:"resources,omitzero"`
 
 	// enforceResources controls whether the controller manages this container's resources.
 	// If true, the controller enforces the resources value on every reconcile.

--- a/api/v1alpha1/gatewayconfiguration_types.go
+++ b/api/v1alpha1/gatewayconfiguration_types.go
@@ -198,6 +198,7 @@ type GatewayConfiguration struct {
 // GatewayConfigurationList contains a list of GatewayConfiguration
 type GatewayConfigurationList struct {
 	metav1.TypeMeta `json:",inline"`
+	// +optional
 	metav1.ListMeta `json:"metadata,omitzero"`
 	Items           []GatewayConfiguration `json:"items"`
 }

--- a/api/v1alpha1/gatewayrouter_types.go
+++ b/api/v1alpha1/gatewayrouter_types.go
@@ -249,6 +249,7 @@ type GatewayRouter struct {
 // GatewayRouterList contains a list of GatewayRouter
 type GatewayRouterList struct {
 	metav1.TypeMeta `json:",inline"`
+	// +optional
 	metav1.ListMeta `json:"metadata,omitzero"`
 	Items           []GatewayRouter `json:"items"`
 }

--- a/api/v1alpha1/l34route_types.go
+++ b/api/v1alpha1/l34route_types.go
@@ -65,6 +65,7 @@ type L34RouteSpec struct {
 	//
 	// Support for weight: Extended
 	//
+	// +optional
 	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:MaxItems=1
 	BackendRefs []gatewayapiv1.BackendRef `json:"backendRefs,omitempty"`
@@ -81,6 +82,7 @@ type L34RouteSpec struct {
 
 	// Source CIDRs allowed in the L34Route.
 	// The source CIDRs should not have overlaps.
+	// +optional
 	// +kubebuilder:validation:MaxItems=100
 	// +kubebuilder:validation:items:MaxLength=50
 	// +kubebuilder:validation:XValidation:message="each sourceCIDR must be a valid CIDR",rule="self.all(c, isCIDR(c))"
@@ -93,6 +95,7 @@ type L34RouteSpec struct {
 	// - a single port, such as 3000;
 	// - a port range, such as 3000-4000;
 	// - "any", which is equivalent to port range 0-65535.
+	// +optional
 	// +kubebuilder:validation:MaxItems=20
 	// +kubebuilder:validation:items:MaxLength=11
 	// +kubebuilder:validation:XValidation:message="each sourcePort must be a single port, a port range, or 'any'",rule="self.all(port, port == 'any' || (port.matches('^\\\\d+$') && int(port) >= 0 && int(port) <= 65535) || (port.matches('^\\\\d+-\\\\d+$') && int(port.split('-')[0]) >= 0 && int(port.split('-')[0]) <= 65535 && int(port.split('-')[1]) >= 0 && int(port.split('-')[1]) <= 65535 && int(port.split('-')[0]) <= int(port.split('-')[1])))"
@@ -104,6 +107,7 @@ type L34RouteSpec struct {
 	// - a single port, such as 3000;
 	// - a port range, such as 3000-4000;
 	// - "any", which is equivalent to port range 0-65535.
+	// +optional
 	// +kubebuilder:validation:MaxItems=20
 	// +kubebuilder:validation:items:MaxLength=11
 	// +kubebuilder:validation:XValidation:message="each destinationPort must be a single port, a port range, or 'any'",rule="self.all(port, port == 'any' || (port.matches('^\\\\d+$') && int(port) >= 0 && int(port) <= 65535) || (port.matches('^\\\\d+-\\\\d+$') && int(port.split('-')[0]) >= 0 && int(port.split('-')[0]) <= 65535 && int(port.split('-')[1]) >= 0 && int(port.split('-')[1]) <= 65535 && int(port.split('-')[0]) <= int(port.split('-')[1])))"

--- a/api/v1alpha1/l34route_types.go
+++ b/api/v1alpha1/l34route_types.go
@@ -162,7 +162,8 @@ type L34Route struct {
 // L34RouteList contains a list of L34Route resources.
 type L34RouteList struct {
 	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata"`
+	// +optional
+	metav1.ListMeta `json:"metadata,omitzero"`
 	Items           []L34Route `json:"items"`
 }
 

--- a/api/v1alpha1/loadbalancerendpointslice_types.go
+++ b/api/v1alpha1/loadbalancerendpointslice_types.go
@@ -39,6 +39,7 @@ type LoadBalancerEndpointSliceSpec struct {
 
 	// endpoints is the list of endpoints in this slice.
 	// A Pod's addresses always reside in the same slice object (no cross-object correlation).
+	// +optional
 	// +listType=atomic
 	Endpoints []LoadBalancerEndpoint `json:"endpoints,omitempty"`
 }

--- a/api/v1alpha1/loadbalancerendpointslice_types.go
+++ b/api/v1alpha1/loadbalancerendpointslice_types.go
@@ -134,7 +134,7 @@ type LoadBalancerEndpointSlice struct {
 	metav1.TypeMeta `json:",inline"`
 
 	// +optional
-	metav1.ObjectMeta `json:"metadata,omitempty"`
+	metav1.ObjectMeta `json:"metadata,omitzero"`
 
 	// spec defines the endpoints and their distribution metadata.
 	// +required
@@ -147,7 +147,7 @@ type LoadBalancerEndpointSlice struct {
 type LoadBalancerEndpointSliceList struct {
 	metav1.TypeMeta `json:",inline"`
 	// +optional
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata,omitzero"`
 	Items           []LoadBalancerEndpointSlice `json:"items"`
 }
 

--- a/api/v1alpha1/loadbalancerendpointslice_types.go
+++ b/api/v1alpha1/loadbalancerendpointslice_types.go
@@ -146,6 +146,7 @@ type LoadBalancerEndpointSlice struct {
 // LoadBalancerEndpointSliceList contains a list of LoadBalancerEndpointSlice.
 type LoadBalancerEndpointSliceList struct {
 	metav1.TypeMeta `json:",inline"`
+	// +optional
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []LoadBalancerEndpointSlice `json:"items"`
 }


### PR DESCRIPTION
## Summary

Several optional fields across our CRD API types had `omitempty` on the JSON struct tag but were missing the `// +optional` comment marker. Per [Kubernetes API conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#optional-vs-required), these should always be paired for consistency and clarity.

This PR audits all `api/v1alpha1/*_types.go` files and adds `// +optional` to every field that has `omitempty` or `omitzero` but lacked the marker.

## Issue

#219

## Changes

- **`l34route_types.go`** (`L34RouteSpec`): `backendRefs`, `sourceCIDRs`, `sourcePorts`, `destinationPorts`
- **`loadbalancerendpointslice_types.go`** (`LoadBalancerEndpointSliceSpec`): `endpoints`
- **`endpointnetworkconfiguration_types.go`** (`EndpointNetworkConfiguration`): `metadata`, `spec`, `status`. These were inconsistent with the other Kind types (`L34Route`, `GatewayRouter`, `GatewayConfiguration`), which already had `+optional`/`+required` markers on the same fields.
- **`ListMeta`** on `DistributionGroupList`, `LoadBalancerEndpointSliceList`, `GatewayRouterList`, `EndpointNetworkConfigurationList`, and `GatewayConfigurationList`: found in a follow-up pass, these `metadata` fields carry `omitempty`/`omitzero` but lacked the marker. `L34RouteList.ListMeta` was left unchanged since it has no `omitempty`/`omitzero` tag.

All other `omitempty`/`omitzero` fields in the package were already consistent and required no change.

## Why it matters

- `+optional` is the Kubernetes API convention for documenting optional fields
- Tools and documentation generators use it as a signal
- Functionally harmless (modern `controller-gen` infers optionality from `omitempty`), but the inconsistency causes confusion for contributors

## Testing

- `go build ./...` passes
- `make manifests generate` produces no diff (confirms no schema or behavioral change)
- `make lint-fix` reports 0 issues
- `make test` passes for all packages