### PR TITLE
LB controller: minor cleanups (#225)

### DIFF
--- a/cmd/stateless-load-balancer/cmd/run.go
+++ b/cmd/stateless-load-balancer/cmd/run.go
@@ -21,7 +21,6 @@ import (
 	"crypto/tls"
 	"fmt"
 
-	"github.com/google/nftables"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -136,42 +135,6 @@ func runLoadBalancer(cfg *config.LoadBalancerConfig) error {
 		}
 	}()
 
-	// Initialize nftables
-	nftConn := &nftables.Conn{}
-	nftTable := nftConn.AddTable(&nftables.Table{
-		Name:   "meridio",
-		Family: nftables.TableFamilyINet,
-	})
-	if err := nftConn.Flush(); err != nil {
-		setupLog.Error(err, "failed to create nftables table")
-		return err
-	}
-
-	nftChain := nftConn.AddChain(&nftables.Chain{
-		Name:     "prerouting",
-		Table:    nftTable,
-		Type:     nftables.ChainTypeFilter,
-		Hooknum:  nftables.ChainHookPrerouting,
-		Priority: nftables.ChainPriorityFilter,
-	})
-	if err := nftConn.Flush(); err != nil {
-		setupLog.Error(err, "failed to create nftables chain")
-		return err
-	}
-
-	setupLog.Info("nftables initialized", "table", nftTable.Name, "chain", nftChain.Name)
-
-	// Cleanup nftables on shutdown
-	defer func() {
-		setupLog.Info("Cleaning up nftables")
-		conn := &nftables.Conn{}
-		conn.FlushTable(nftTable)
-		conn.DelTable(nftTable)
-		if err := conn.Flush(); err != nil {
-			setupLog.Error(err, "failed to cleanup nftables")
-		}
-	}()
-
 	// Metrics options
 	metricsServerOptions := metricsserver.Options{
 		BindAddress:   cfg.MetricsAddr,
@@ -212,9 +175,6 @@ func runLoadBalancer(cfg *config.LoadBalancerConfig) error {
 		GatewayNamespace: cfg.GatewayNamespace,
 		NFQLB:            &loadbalancer.NFQLBManagerAdapter{NFQLB: nfqlbInstance},
 		Readiness:        readiness.NewManager(cfg.ReadinessDir),
-		NFTConn:          nftConn,
-		NFTTable:         nftTable,
-		NFTChain:         nftChain,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "failed to setup controller")
 		return err

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -334,11 +334,6 @@ kubectl exec -n <ns> <sllbr-pod> -c loadbalancer -- nft list ruleset
 
 Example output:
 ```
-table inet meridio {
-	chain prerouting {
-		type filter hook prerouting priority filter; policy accept;
-	}
-}
 table inet meridio-lb {
 	set ipv4-vips {
 		type ipv4_addr

--- a/internal/controller/loadbalancer/controller.go
+++ b/internal/controller/loadbalancer/controller.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/google/nftables"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -62,9 +61,6 @@ type Controller struct {
 	GatewayNamespace  string
 	NFQLB             nfqlbManager
 	Readiness         *readiness.Manager
-	NFTConn           *nftables.Conn
-	NFTTable          *nftables.Table
-	NFTChain          *nftables.Chain
 	NftManagerFactory func(queueNum, queueTotal uint16) (nftablesManager, error)
 
 	mu          sync.Mutex

--- a/internal/nfqlb/nfqlb.go
+++ b/internal/nfqlb/nfqlb.go
@@ -99,12 +99,6 @@ func (nfqlb *NFQueueLoadBalancer) Start(ctx context.Context) error {
 	return nil
 }
 
-// updateNfQueueDestinationCIDRs is a no-op when nftables VIP management is external.
-// The LB controller manages VIP sets via internal/nftables.Manager.
-func (nfqlb *NFQueueLoadBalancer) updateNfQueueDestinationCIDRs(_ context.Context) error {
-	return nil
-}
-
 // flowList runs the nfqlb flow-list commands and returns the output.
 func (nfqlb *NFQueueLoadBalancer) flowList(ctx context.Context) ([]*nfqlbFlow, error) {
 	args := []string{
@@ -221,13 +215,12 @@ type Flow interface {
 // Instance represents a nfqlb instance instantiated with nfqlb init.
 type Instance struct {
 	*nfqlbInstanceConfig
-	name                              string
-	targets                           map[int][]string // Key: identifier ; Value: IPs
-	broken                            map[int]struct{} // identifiers in inconsistent state (partial route or activate failure)
-	offset                            int
-	mu                                sync.Mutex
-	updateNfQueueDestinationCIDRsFunc func(ctx context.Context) error
-	nfqlbPath                         string
+	name      string
+	targets   map[int][]string // Key: identifier ; Value: IPs
+	broken    map[int]struct{} // identifiers in inconsistent state (partial route or activate failure)
+	offset    int
+	mu        sync.Mutex
+	nfqlbPath string
 	// routeCreate and routeDelete are injectable for testing.
 	// When nil, the package-level createPolicyRoute/deletePolicyRoute are used.
 	routeCreate func(fwmark int, ip string) error
@@ -270,13 +263,12 @@ func (nfqlb *NFQueueLoadBalancer) AddInstance(ctx context.Context,
 	}
 
 	nfqlbInstance = &Instance{
-		name:                              name,
-		nfqlbInstanceConfig:               config,
-		targets:                           map[int][]string{},
-		broken:                            map[int]struct{}{},
-		updateNfQueueDestinationCIDRsFunc: nfqlb.updateNfQueueDestinationCIDRs,
-		offset:                            offset,
-		nfqlbPath:                         nfqlb.nfqlbPath,
+		name:                name,
+		nfqlbInstanceConfig: config,
+		targets:             map[int][]string{},
+		broken:              map[int]struct{}{},
+		offset:              offset,
+		nfqlbPath:           nfqlb.nfqlbPath,
 	}
 
 	//nolint:gosec
@@ -412,11 +404,6 @@ func (s *Instance) AddFlow(ctx context.Context, flowToAdd Flow) error {
 		return fmt.Errorf("failed setting nfqlb flow ; %w; %s", err, stdoutStderr)
 	}
 
-	err = s.updateNfQueueDestinationCIDRsFunc(ctx)
-	if err != nil {
-		return fmt.Errorf("failed setting nfqlb flow ; %w; %s", err, stdoutStderr)
-	}
-
 	ctrl.LoggerFrom(ctx).Info("nfqlb: flow added", "instance", s.name, "flow", flowToAdd)
 
 	return nil
@@ -441,11 +428,6 @@ func (s *Instance) DeleteFlow(ctx context.Context, flowToDelete Flow) error {
 	stdoutStderr, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("failed deleting nfqlb flow ; %w; %s", err, stdoutStderr)
-	}
-
-	err = s.updateNfQueueDestinationCIDRsFunc(ctx)
-	if err != nil {
-		return fmt.Errorf("failed setting nfqlb flow ; %w; %s", err, stdoutStderr)
 	}
 
 	ctrl.LoggerFrom(ctx).Info("nfqlb: flow deleted", "instance", s.name, "flow", flowToDelete)

--- a/internal/nfqlb/routing.go
+++ b/internal/nfqlb/routing.go
@@ -25,6 +25,8 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
+const rulePriority = 32000
+
 var errInvalidIP = errors.New("the ip address is invalid")
 
 // CleanupStaleRules removes all fwmark-based policy rules and their routing tables
@@ -73,9 +75,7 @@ func createPolicyRoute(fwMark int, ip string) error {
 
 // ensureRule adds the desired rule only if it doesn't already exist.
 // Linux allows duplicate ip rules, so we check first to avoid accumulating duplicates
-// across reconciles. Priority of -1 means "unset" in vishvananda/netlink (library skips
-// FRA_PRIORITY in the netlink message, causing the kernel to auto-assign a priority).
-// We cannot match on auto-assigned priorities, so skip the comparison when unset.
+// across reconciles.
 func ensureRule(desired *netlink.Rule) error {
 	rules, err := netlink.RuleList(desired.Family)
 	if err != nil {
@@ -85,7 +85,7 @@ func ensureRule(desired *netlink.Rule) error {
 
 	for _, existing := range rules {
 		if existing.Mark == desired.Mark && existing.Table == desired.Table &&
-			(desired.Priority < 0 || existing.Priority == desired.Priority) {
+			existing.Priority == desired.Priority {
 			return nil // Already exists
 		}
 	}
@@ -123,6 +123,7 @@ func getRoute(tableID int, ip net.IP) *netlink.Route {
 
 func getRule(fwMark int, ip net.IP) *netlink.Rule {
 	rule := netlink.NewRule()
+	rule.Priority = rulePriority
 	rule.Table = fwMark
 	rule.Mark = uint32(fwMark)
 	rule.Family = netlink.FAMILY_V6

--- a/internal/nfqlb/target_test.go
+++ b/internal/nfqlb/target_test.go
@@ -60,16 +60,15 @@ func (m *mockExec) run(_ context.Context, args ...string) ([]byte, error) {
 // newTestInstance creates an Instance with mock routing and exec for testing.
 func newTestInstance(name string, offset, maxTargets int, routing *mockRouting, executor *mockExec) *Instance {
 	return &Instance{
-		nfqlbInstanceConfig:               &nfqlbInstanceConfig{maxTargets: maxTargets},
-		name:                              name,
-		targets:                           map[int][]string{},
-		broken:                            map[int]struct{}{},
-		offset:                            offset,
-		nfqlbPath:                         "nfqlb",
-		updateNfQueueDestinationCIDRsFunc: func(_ context.Context) error { return nil },
-		routeCreate:                       routing.create,
-		routeDelete:                       routing.delete,
-		execCmd:                           executor.run,
+		nfqlbInstanceConfig: &nfqlbInstanceConfig{maxTargets: maxTargets},
+		name:                name,
+		targets:             map[int][]string{},
+		broken:              map[int]struct{}{},
+		offset:              offset,
+		nfqlbPath:           "nfqlb",
+		routeCreate:         routing.create,
+		routeDelete:         routing.delete,
+		execCmd:             executor.run,
 	}
 }
 


### PR DESCRIPTION
cleanup: Do not create nft table we never use after

Other than the meridio-lb nft table for some historical reason we also
created and deleted a table named meridio, which we never used after.
This patch deletes all code handling the meridio table.

Closes #225
Signed-off-by: Bence Romsics <bence.romsics@gmail.com>

cleanup: Remove no-op updateNfQueueDestinationCIDRsFunc

AddFlow and DeleteFlow called s.updateNfQueueDestinationCIDRsFunc(ctx)
which was legacy from the POC where nfqlb managed its own nftables
VIP sets.  Now internal/nftables.Manager handles this externally.
Therefore updateNfQueueDestinationCIDRsFunc became a permanent no-op.
This change removes updateNfQueueDestinationCIDRsFunc.

Related #225
Signed-off-by: Bence Romsics <bence.romsics@gmail.com>

cleanup: Set fix ip rule priority

ensureRule in internal/nfqlb/routing.go created ip rules without an
explicit priority (uses netlink.NewRule() default, which causes the
kernel to auto-assign). This makes the ensureRule duplicate-detection
less reliable and creates non-deterministic rule ordering. Start using
a fixed priority constant: 32000.

Related #225
Signed-off-by: Bence Romsics <bence.romsics@gmail.com>