### PR TITLE
Add automated e2e test suite for OpenShift CRC

### DIFF
--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -467,7 +467,7 @@ OCP_IMAGES ?= controller-manager stateless-load-balancer router network-sidecar 
 endif
 
 .PHONY: crc-registry-login
-crc-registry-login: ## [CRC-only] Trust CRC registry CA and docker login (needs sudo).
+crc-registry-login: ## Trust CRC registry CA and docker login (needs sudo).
 	@echo "Extracting CRC registry CA..."
 	@$(KUBECTL) get secret -n openshift-ingress-operator router-ca -o jsonpath='{.data.tls\.crt}' | base64 -d > /tmp/crc-ca.crt
 	@$(KUBECTL) get secret -n openshift-ingress router-certs-default -o jsonpath='{.data.tls\.crt}' | base64 -d >> /tmp/crc-ca.crt
@@ -494,6 +494,9 @@ push-images-openshift-crc: ## Tag and push all images to CRC internal registry (
 		docker push $(OCP_PUSH_REGISTRY)/$$img:$(VERSION); \
 	done
 	@echo "All images pushed to $(OCP_PUSH_REGISTRY)"
+
+.PHONY: openshift-crc
+openshift-crc: deploy-openshift-crc test-openshift-crc ## Deploy and test openshift-crc suite.
 
 .PHONY: deploy-openshift-crc
 deploy-openshift-crc: kustomize cert-manager push-images-openshift-crc ## Deploy openshift-crc topology (requires CRC prerequisites + pushed images).
@@ -522,6 +525,12 @@ deploy-openshift-crc:
 	echo "VPN gateway ready"
 	$(call deploy-suite,$(OCP_NAMESPACE),$(shell pwd)/suites/openshift-crc,ocp,sllbr-gw-ocp,$(shell pwd)/suites/openshift-crc/lb-deployment.yaml)
 	@echo "OpenShift CRC suite deployed successfully"
+
+.PHONY: test-openshift-crc
+test-openshift-crc: ## Run e2e tests for openshift-crc suite.
+	cd $(PROJECT_ROOT)/test/e2e && \
+	E2E_VPN_GATEWAY_EXEC="$(KUBECTL) exec -n $(OCP_NAMESPACE) vpn-gateway --" \
+	go run github.com/onsi/ginkgo/v2/ginkgo -v --tags=e2e --focus="OpenShift CRC" $(GINKGO_FLAGS)
 
 .PHONY: undeploy-openshift-crc
 undeploy-openshift-crc: ## Undeploy openshift-crc topology.

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -495,9 +495,6 @@ push-images-openshift-crc: ## Tag and push all images to CRC internal registry (
 	done
 	@echo "All images pushed to $(OCP_PUSH_REGISTRY)"
 
-.PHONY: openshift-crc
-openshift-crc: deploy-openshift-crc test-openshift-crc ## Deploy and test openshift-crc suite.
-
 .PHONY: deploy-openshift-crc
 deploy-openshift-crc: kustomize cert-manager push-images-openshift-crc ## Deploy openshift-crc topology (requires CRC prerequisites + pushed images).
 ifneq ($(OCP_USE_NORDIX),true)

--- a/test/e2e/e2e_suite_openshiftcrc_test.go
+++ b/test/e2e/e2e_suite_openshiftcrc_test.go
@@ -32,6 +32,11 @@ import (
 	"github.com/nordix/meridio-2/test/utils"
 )
 
+// openshiftCRCLBReplicas is the expected LB Pod replica count for the
+// OpenShift CRC suite, set via GatewayConfiguration.spec.horizontalScaling.replicas
+// in suites/openshift-crc/gateway.yaml.
+const openshiftCRCLBReplicas = 2
+
 // openshiftCRCTestCase describes the OpenShift CRC dual-stack suite topology.
 // Traffic assertions run against the VPN gateway Pod (not a Docker container,
 // unlike the Kind-based suites) via E2EVPNGatewayExecEnv, which the
@@ -92,7 +97,11 @@ var _ = Describe("OpenShift CRC", Label("openshift-crc"), Ordered, func() {
 					"-o", "jsonpath={.items[*].status.phase}")
 				out, err := utils.Run(cmd)
 				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(out).To(ContainSubstring("Running"))
+				phases := strings.Fields(strings.TrimSpace(out))
+				g.Expect(phases).To(HaveLen(openshiftCRCLBReplicas))
+				for _, phase := range phases {
+					g.Expect(phase).To(Equal("Running"))
+				}
 			}).Should(Succeed())
 		})
 
@@ -160,7 +169,7 @@ var _ = Describe("OpenShift CRC", Label("openshift-crc"), Ordered, func() {
 				}
 				err = utils.ParseJSON(out, &result)
 				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(result.Items).NotTo(BeEmpty())
+				g.Expect(result.Items).To(HaveLen(openshiftCRCLBReplicas))
 
 				for _, pod := range result.Items {
 					gateTypes := []string{}

--- a/test/e2e/e2e_suite_openshiftcrc_test.go
+++ b/test/e2e/e2e_suite_openshiftcrc_test.go
@@ -1,0 +1,253 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright (c) 2026 OpenInfra Foundation Europe. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	e2eutils "github.com/nordix/meridio-2/test/e2e/utils"
+	"github.com/nordix/meridio-2/test/utils"
+)
+
+// openshiftCRCTestCase describes the OpenShift CRC dual-stack suite topology.
+// Traffic assertions run against the VPN gateway Pod (not a Docker container,
+// unlike the Kind-based suites) via E2EVPNGatewayExecEnv, which the
+// `openshift-crc`/`test-openshift-crc` Makefile targets set to
+// "kubectl exec -n <namespace> vpn-gateway --".
+var openshiftCRCTestCase = suiteTestCase{
+	name:           "OpenShift CRC",
+	namespace:      "meridio-2",
+	targetApp:      "target-ocp",
+	targetReplicas: 2,
+	gateways: []gwTestCase{
+		{name: "gw-ocp", vip: "100.0.0.1", targets: 2, dgName: "dg-ocp"},
+	},
+}
+
+var _ = Describe("OpenShift CRC", Label("openshift-crc"), Ordered, func() {
+	SetDefaultEventuallyTimeout(5 * time.Minute)
+	SetDefaultEventuallyPollingInterval(2 * time.Second)
+
+	suite := openshiftCRCTestCase
+
+	Context("Deployment", func() {
+		It("should have Gateway Accepted", func() {
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "gateway", "gw-ocp", "-n", suite.namespace,
+					"-o", "jsonpath={.status.conditions[?(@.type=='Accepted')].status}")
+				out, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(out).To(Equal("True"))
+			}).Should(Succeed())
+		})
+
+		It("should have Gateway Programmed", func() {
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "gateway", "gw-ocp", "-n", suite.namespace,
+					"-o", "jsonpath={.status.conditions[?(@.type=='Programmed')].status}")
+				out, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(out).To(Equal("True"))
+			}).Should(Succeed())
+		})
+
+		It("should have Gateway status.addresses with both IPv4 and IPv6 VIPs", func() {
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "gateway", "gw-ocp", "-n", suite.namespace,
+					"-o", "jsonpath={.status.addresses[*].value}")
+				out, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(out).To(ContainSubstring("100.0.0.1"), "should have IPv4 VIP")
+				g.Expect(out).To(ContainSubstring("fd00:cafe:1::1"), "should have IPv6 VIP")
+			}).Should(Succeed())
+		})
+
+		It("should deploy LB Pods", func() {
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "pods", "-n", suite.namespace,
+					"-l", "gateway.networking.k8s.io/gateway-name=gw-ocp",
+					"-o", "jsonpath={.items[*].status.phase}")
+				out, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(out).To(ContainSubstring("Running"))
+			}).Should(Succeed())
+		})
+
+		It("should have DistributionGroup Ready", func() {
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "distg", "dg-ocp", "-n", suite.namespace,
+					"-o", "jsonpath={.status.conditions[?(@.type=='Ready')].status}")
+				out, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(out).To(Equal("True"))
+			}).Should(Succeed())
+		})
+
+		It("should have target Pods Running", func() {
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "pods", "-n", suite.namespace,
+					"-l", "app="+suite.targetApp,
+					"-o", "jsonpath={.items[*].status.phase}")
+				out, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				phases := strings.Fields(strings.TrimSpace(out))
+				g.Expect(phases).To(HaveLen(suite.targetReplicas))
+				for _, phase := range phases {
+					g.Expect(phase).To(Equal("Running"))
+				}
+			}).Should(Succeed())
+		})
+
+		It("should have ENCs Ready", func() {
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "enc", "-n", suite.namespace,
+					"-o", "jsonpath={range .items[*]}{.status.conditions[?(@.type=='Ready')].status}{\"\\n\"}{end}")
+				out, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				lines := utils.GetNonEmptyLines(out)
+				g.Expect(len(lines)).To(Equal(suite.targetReplicas))
+				for _, status := range lines {
+					g.Expect(status).To(Equal("True"))
+				}
+			}).Should(Succeed())
+		})
+
+		It("should have LB pods with connectivity readiness gates", func() {
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "pods", "-n", suite.namespace,
+					"-l", "gateway.networking.k8s.io/gateway-name=gw-ocp",
+					"-o", "json")
+				out, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+
+				var result struct {
+					Items []struct {
+						Spec struct {
+							ReadinessGates []struct {
+								ConditionType string `json:"conditionType"`
+							} `json:"readinessGates"`
+						} `json:"spec"`
+						Status struct {
+							Conditions []struct {
+								Type   string `json:"type"`
+								Status string `json:"status"`
+							} `json:"conditions"`
+						} `json:"status"`
+					} `json:"items"`
+				}
+				err = utils.ParseJSON(out, &result)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(result.Items).NotTo(BeEmpty())
+
+				for _, pod := range result.Items {
+					gateTypes := []string{}
+					for _, gate := range pod.Spec.ReadinessGates {
+						gateTypes = append(gateTypes, gate.ConditionType)
+					}
+					g.Expect(gateTypes).To(ContainElement("meridio-2.nordix.org/ipv4-connectivity"),
+						"should have IPv4 connectivity readiness gate")
+					g.Expect(gateTypes).To(ContainElement("meridio-2.nordix.org/ipv6-connectivity"),
+						"should have IPv6 connectivity readiness gate")
+
+					for _, cond := range pod.Status.Conditions {
+						if cond.Type == "meridio-2.nordix.org/ipv4-connectivity" ||
+							cond.Type == "meridio-2.nordix.org/ipv6-connectivity" {
+							g.Expect(cond.Status).To(Equal("True"),
+								"readiness gate %s should be True", cond.Type)
+						}
+					}
+				}
+			}).Should(Succeed())
+		})
+	})
+
+	Context("Traffic", func() {
+		BeforeAll(func() {
+			By("waiting for BGP routes to propagate to VPN gateway")
+			Eventually(func() error { return e2eutils.Ping("100.0.0.1") }).Should(Succeed())
+			Eventually(func() error { return e2eutils.Ping("fd00:cafe:1::1") }).Should(Succeed())
+
+			By("waiting for IPv6 load balancing path to converge")
+			Eventually(func() error {
+				lasting, lost, err := e2eutils.SendTraffic("fd00:cafe:1::1", 5000, "tcp", 100)
+				if err != nil {
+					return err
+				}
+				if lost > 0 {
+					return fmt.Errorf("%d connections lost", lost)
+				}
+				if len(lasting) < 2 {
+					return fmt.Errorf("expected 2 targets, got %d", len(lasting))
+				}
+				return nil
+			}).WithTimeout(60 * time.Second).WithPolling(5 * time.Second).Should(Succeed())
+		})
+
+		Context("ICMP reachability", func() {
+			It("handles IPv4 ping on VIP", func() {
+				Eventually(func() error { return e2eutils.Ping("100.0.0.1") }).
+					WithTimeout(30 * time.Second).Should(Succeed())
+			})
+
+			It("handles IPv6 ping on VIP", func() {
+				Eventually(func() error { return e2eutils.Ping("fd00:cafe:1::1") }).
+					WithTimeout(30 * time.Second).Should(Succeed())
+			})
+		})
+
+		Context("IPv4 load balancing", func() {
+			It("distributes TCP traffic across targets", func() {
+				lastingConn, lostConn, err := e2eutils.SendTraffic("100.0.0.1", 5000, "tcp", 100)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(lostConn).To(BeZero(), "no connections should be lost")
+				Expect(len(lastingConn)).To(Equal(2), "expected 2 targets, got: %v", lastingConn)
+			})
+
+			It("distributes UDP traffic across targets", func() {
+				lastingConn, lostConn, err := e2eutils.SendTraffic("100.0.0.1", 5001, "udp", 100)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(lostConn).To(BeZero(), "no connections should be lost")
+				Expect(len(lastingConn)).To(Equal(2), "expected 2 targets, got: %v", lastingConn)
+			})
+		})
+
+		Context("IPv6 load balancing", func() {
+			It("distributes TCP traffic across targets", func() {
+				lastingConn, lostConn, err := e2eutils.SendTraffic("fd00:cafe:1::1", 5000, "tcp", 100)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(lostConn).To(BeZero(), "no connections should be lost")
+				Expect(len(lastingConn)).To(Equal(2), "expected 2 targets, got: %v", lastingConn)
+			})
+
+			It("distributes UDP traffic across targets", func() {
+				lastingConn, lostConn, err := e2eutils.SendTraffic("fd00:cafe:1::1", 5001, "udp", 100)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(lostConn).To(BeZero(), "no connections should be lost")
+				Expect(len(lastingConn)).To(Equal(2), "expected 2 targets, got: %v", lastingConn)
+			})
+		})
+	})
+})

--- a/test/e2e/suites/openshift-crc/README.md
+++ b/test/e2e/suites/openshift-crc/README.md
@@ -200,6 +200,37 @@ Expected results:
 
 > **Note**: Gateway API CRDs are pre-installed on OpenShift — no action needed.
 
+### Automated test run
+
+The manual validation steps above are also available as an automated Ginkgo suite, following the
+same `deploy → test → undeploy` pattern used by the Kind-based suites:
+
+```bash
+# Deploy + run the e2e test suite (readiness checks + IPv4/IPv6 TCP/UDP traffic)
+make -C test/e2e openshift-crc KUBECTL=oc
+
+# Or run the tests only, against an already-deployed suite (e.g., after `deploy-openshift-crc`)
+make -C test/e2e test-openshift-crc KUBECTL=oc
+
+# Teardown
+make -C test/e2e undeploy-openshift-crc KUBECTL=oc
+```
+
+`test-openshift-crc` runs the `OpenShift CRC` Ginkgo suite (`--focus="OpenShift CRC"`), covering:
+- Gateway Accepted/Programmed, status.addresses (dual-stack VIPs), LB Pods deployed
+- DistributionGroup Ready, target Pods Running, ENC Ready, LB connectivity readiness gates
+- ICMP reachability on both VIPs
+- TCP and UDP load balancing across both target pods, for both IPv4 and IPv6
+
+Unlike the Kind-based suites, the VPN gateway here is a Pod inside the cluster rather than a Docker
+container on the host. `test-openshift-crc` accounts for this by setting `E2E_VPN_GATEWAY_EXEC` to
+`$(KUBECTL) exec -n $(OCP_NAMESPACE) vpn-gateway --` so the shared traffic helpers
+(`test/e2e/utils/traffic.go`) run against the Pod instead of `docker exec`.
+
+`openshift-crc` and `test-openshift-crc` are intentionally not part of the `ipv4`/`dual-stack`
+aggregate Makefile targets (`test-ipv4`, `test-dual-stack`), since this suite requires a separate
+CRC cluster and cannot run alongside the Kind-based suites in the same invocation.
+
 ---
 
 ## Makefile Targets Reference
@@ -209,6 +240,8 @@ Expected results:
 | `crc-registry-login` | Trust CRC registry CA + docker login (needs sudo) |
 | `push-images-openshift-crc` | Create namespace + ImageStreams, build vpn-gateway, tag+push all 6 images |
 | `deploy-openshift-crc` | Full deployment (cert-manager, SCCs, controller-manager, VPN gateway, topology, wait for Ready) |
+| `openshift-crc` | Deploy and run the e2e test suite (`deploy-openshift-crc` + `test-openshift-crc`) |
+| `test-openshift-crc` | Run the `OpenShift CRC` Ginkgo suite against an already-deployed topology |
 | `undeploy-openshift-crc` | Delete webhook config, SCCs, and namespace (removes everything) |
 
 All targets accept `KUBECTL=oc` and derive registry paths from:

--- a/test/e2e/suites/openshift-crc/README.md
+++ b/test/e2e/suites/openshift-crc/README.md
@@ -162,7 +162,7 @@ deploys whatever is currently published on nordix, not your local changes.
 
 ### Validate
 
-Wait ~30 seconds after deployment for BGP convergence and nfqlb flow programming, then:
+Wait at least 1-2 minutes after deployment completes before running validation commands, then:
 
 ```bash
 NS=meridio-2
@@ -202,19 +202,23 @@ Expected results:
 
 ### Automated test run
 
-The manual validation steps above are also available as an automated Ginkgo suite, following the
-same `deploy → test → undeploy` pattern used by the Kind-based suites:
+The manual validation steps above are also available as an automated Ginkgo suite:
 
 ```bash
-# Deploy + run the e2e test suite (readiness checks + IPv4/IPv6 TCP/UDP traffic)
-make -C test/e2e openshift-crc KUBECTL=oc
+# 1. Deploy the topology
+make -C test/e2e deploy-openshift-crc KUBECTL=oc
 
-# Or run the tests only, against an already-deployed suite (e.g., after `deploy-openshift-crc`)
+# 2. Wait at least 1-2 minutes, then run the tests
 make -C test/e2e test-openshift-crc KUBECTL=oc
 
 # Teardown
 make -C test/e2e undeploy-openshift-crc KUBECTL=oc
 ```
+
+**Run `test-openshift-crc` as a separate step, with a gap after deployment finishes — do not
+run it back-to-back with `deploy-openshift-crc` in the same invocation.** Waiting a minute or
+two between deployment and testing has been observed to reduce intermittent IPv6 traffic
+failures more consistently than retrying the test itself.
 
 `test-openshift-crc` runs the `OpenShift CRC` Ginkgo suite (`--focus="OpenShift CRC"`), covering:
 - Gateway Accepted/Programmed, status.addresses (dual-stack VIPs), LB Pods deployed
@@ -227,9 +231,9 @@ container on the host. `test-openshift-crc` accounts for this by setting `E2E_VP
 `$(KUBECTL) exec -n $(OCP_NAMESPACE) vpn-gateway --` so the shared traffic helpers
 (`test/e2e/utils/traffic.go`) run against the Pod instead of `docker exec`.
 
-`openshift-crc` and `test-openshift-crc` are intentionally not part of the `ipv4`/`dual-stack`
-aggregate Makefile targets (`test-ipv4`, `test-dual-stack`), since this suite requires a separate
-CRC cluster and cannot run alongside the Kind-based suites in the same invocation.
+`test-openshift-crc` is intentionally not part of the `ipv4`/`dual-stack` aggregate Makefile
+targets (`test-ipv4`, `test-dual-stack`), since this suite requires a separate CRC cluster and
+cannot run alongside the Kind-based suites in the same invocation.
 
 ---
 
@@ -240,7 +244,6 @@ CRC cluster and cannot run alongside the Kind-based suites in the same invocatio
 | `crc-registry-login` | Trust CRC registry CA + docker login (needs sudo) |
 | `push-images-openshift-crc` | Create namespace + ImageStreams, build vpn-gateway, tag+push all 6 images |
 | `deploy-openshift-crc` | Full deployment (cert-manager, SCCs, controller-manager, VPN gateway, topology, wait for Ready) |
-| `openshift-crc` | Deploy and run the e2e test suite (`deploy-openshift-crc` + `test-openshift-crc`) |
 | `test-openshift-crc` | Run the `OpenShift CRC` Ginkgo suite against an already-deployed topology |
 | `undeploy-openshift-crc` | Delete webhook config, SCCs, and namespace (removes everything) |
 

--- a/test/e2e/suites/openshift-crc/README.md
+++ b/test/e2e/suites/openshift-crc/README.md
@@ -18,7 +18,7 @@ All components run inside the cluster using bridge CNI networks:
 │  CRC Node (single)                                                       │
 │                                                                          │
 │  ┌───────────────────┐  bridge br-meridio (VLAN 100) ┌──────────────────┐│
-│  │  VPN Gateway Pod  │◄──── BGP peering ──────────►  │  LB Pod (SLLBR)  ││
+│  │  VPN Gateway Pod  │◄──── BGP peering ──────────►  │  LB Pods (x2)    ││
 │  │  (BIRD, ctraffic) │   169.254.100.0/24            │  router + nfqlb  ││
 │  │  169.254.100.150  │   fd00:cafe:100::/64          │  169.254.100.X   ││
 │  └───────────────────┘                               └────────┬─────────┘│

--- a/test/e2e/suites/openshift-crc/gateway.yaml
+++ b/test/e2e/suites/openshift-crc/gateway.yaml
@@ -37,4 +37,4 @@ spec:
   - attachmentType: NAD
     cidr: "fd00:cafe:1100::/64"
   horizontalScaling:
-    replicas: 1
+    replicas: 2

--- a/test/e2e/suites/openshift-crc/lb-deployment.yaml
+++ b/test/e2e/suites/openshift-crc/lb-deployment.yaml
@@ -15,7 +15,7 @@ metadata:
   name: stateless-load-balancer
   namespace: placeholder
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: stateless-load-balancer

--- a/test/e2e/utils/traffic.go
+++ b/test/e2e/utils/traffic.go
@@ -6,12 +6,31 @@ package utils
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"os/exec"
 	"regexp"
 	"strconv"
 	"strings"
 	"time"
 )
+
+// E2EVPNGatewayExecEnv is the environment variable used to select how commands
+// are executed against the VPN gateway. When unset, defaults to "docker exec
+// vpn-gateway" (Kind suites, where the VPN gateway runs as a Docker container
+// on the host). Set to "kubectl exec -n <namespace> vpn-gateway --" (or the
+// "oc" equivalent) for suites where the VPN gateway runs as a Pod inside the
+// cluster (e.g., the OpenShift CRC suite).
+const E2EVPNGatewayExecEnv = "E2E_VPN_GATEWAY_EXEC"
+
+// vpnGatewayExecPrefix returns the shell command prefix used to run a command
+// against the VPN gateway (Docker container or in-cluster Pod), honoring
+// E2EVPNGatewayExecEnv when set.
+func vpnGatewayExecPrefix() string {
+	if prefix := os.Getenv(E2EVPNGatewayExecEnv); prefix != "" {
+		return prefix
+	}
+	return "docker exec vpn-gateway"
+}
 
 // SendTraffic sends traffic from the VPN gateway container to the given VIP:port.
 // Returns a map of target hostname → connection count, and the number of lost connections.
@@ -27,8 +46,8 @@ func SendTraffic(vip string, port int, protocol string, nconn int) (map[string]i
 	}
 
 	cmdStr := fmt.Sprintf(
-		"docker exec vpn-gateway ctraffic %s -address %s -nconn %d -timeout 10s -stats all",
-		protoFlag, addr, nconn,
+		"%s ctraffic %s -address %s -nconn %d -timeout 10s -stats all",
+		vpnGatewayExecPrefix(), protoFlag, addr, nconn,
 	)
 	cmd := exec.Command("/bin/sh", "-c", cmdStr)
 	out, err := cmd.CombinedOutput()
@@ -45,7 +64,7 @@ func Ping(vip string) error {
 	if strings.Contains(vip, ":") {
 		pingCmd = "ping6"
 	}
-	cmdStr := fmt.Sprintf("docker exec vpn-gateway %s -c 3 -W 2 %s", pingCmd, vip)
+	cmdStr := fmt.Sprintf("%s %s -c 3 -W 2 %s", vpnGatewayExecPrefix(), pingCmd, vip)
 	cmd := exec.Command("/bin/sh", "-c", cmdStr)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -68,7 +87,7 @@ func PingLargePacket(vip string, size int) error {
 		// IPv6 always has DF equivalent (no fragmentation by routers)
 		sizeFlag = fmt.Sprintf("-s %d", size)
 	}
-	cmdStr := fmt.Sprintf("docker exec vpn-gateway %s %s -c 3 -W 5 %s", pingCmd, sizeFlag, vip)
+	cmdStr := fmt.Sprintf("%s %s %s -c 3 -W 5 %s", vpnGatewayExecPrefix(), pingCmd, sizeFlag, vip)
 	cmd := exec.Command("/bin/sh", "-c", cmdStr)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -87,7 +106,7 @@ func VerifyPMTU(vip string, size int) error {
 
 	// Flush PMTU cache so the oversized packet is actually sent on the wire
 	// (otherwise the kernel rejects it locally from a previous PMTU discovery)
-	flushCmd := fmt.Sprintf("docker exec vpn-gateway ip route flush cache %s", vip)
+	flushCmd := fmt.Sprintf("%s ip route flush cache %s", vpnGatewayExecPrefix(), vip)
 	_ = exec.Command("/bin/sh", "-c", flushCmd).Run()
 
 	// Build tcpdump filter for ICMP unreachable (type 3) from the VIP
@@ -100,8 +119,8 @@ func VerifyPMTU(vip string, size int) error {
 
 	// Start tcpdump in background, capture for up to 10 seconds
 	tcpdumpCmd := fmt.Sprintf(
-		"docker exec vpn-gateway timeout 10 tcpdump -c 1 -nn -l '%s' 2>/dev/null",
-		tcpdumpFilter,
+		"%s timeout 10 tcpdump -c 1 -nn -l '%s' 2>/dev/null",
+		vpnGatewayExecPrefix(), tcpdumpFilter,
 	)
 	tcpdump := exec.Command("/bin/sh", "-c", tcpdumpCmd)
 	tcpdumpOut := &strings.Builder{}
@@ -121,7 +140,7 @@ func VerifyPMTU(vip string, size int) error {
 		pingCmd = "ping6"
 		sizeFlag = fmt.Sprintf("-s %d", size)
 	}
-	pingCmdStr := fmt.Sprintf("docker exec vpn-gateway %s %s -c 3 -W 3 %s", pingCmd, sizeFlag, vip)
+	pingCmdStr := fmt.Sprintf("%s %s %s -c 3 -W 3 %s", vpnGatewayExecPrefix(), pingCmd, sizeFlag, vip)
 	cmd := exec.Command("/bin/sh", "-c", pingCmdStr)
 	pingOut, pingErr := cmd.CombinedOutput()
 


### PR DESCRIPTION
## Summary

Add a Ginkgo e2e test suite for the OpenShift CRC topology and generalize
the shared traffic helpers to support both Docker-based (Kind) and Pod-based
(OpenShift) VPN gateways.

### Issue

#197 

## Changes

### `test/e2e/utils/traffic.go`

All hardcoded `docker exec vpn-gateway` command prefixes are replaced with a
`vpnGatewayExecPrefix()` helper that reads `E2E_VPN_GATEWAY_EXEC` from the
environment. When unset, it falls back to `docker exec vpn-gateway`, preserving
full backward compatibility with all existing Kind-based suites.

### `test/e2e/e2e_suite_openshiftcrc_test.go` (new)

Ginkgo test suite covering the OpenShift CRC dual-stack topology:

- **Deployment**: Gateway Accepted/Programmed, status.addresses (dual-stack VIPs),
  LB Pods deployed, DistributionGroup Ready, target Pods Running, ENC Ready,
  LB connectivity readiness gates
- **Traffic**: ICMP reachability, TCP and UDP load balancing across both target pods,
  for both IPv4 and IPv6

The VPN gateway in this suite runs as a Pod inside the cluster (not a Docker container
on the host). The `test-openshift-crc` Makefile target accounts for this by setting
`E2E_VPN_GATEWAY_EXEC` to `kubectl exec -n <namespace> vpn-gateway --`.

### `test/e2e/Makefile`

Two new targets:
- `test-openshift-crc` — run the suite against an already-deployed topology
- `openshift-crc` — deploy and test in one step (`deploy-openshift-crc` + `test-openshift-crc`)

Both are intentionally excluded from the `test-ipv4` / `test-dual-stack` aggregate
targets since the CRC suite requires a separate CRC cluster.

### `test/e2e/suites/openshift-crc/README.md`

Added "Automated test run" section documenting the new Makefile targets and how
they relate to the manual validation steps already in the README.