### PR TITLE
Standardize MaxLength to 64 for IP/CIDR fields + minor nfqlb/vpn-gateway fixes

### DIFF
--- a/api/v1alpha1/gatewayconfiguration_types.go
+++ b/api/v1alpha1/gatewayconfiguration_types.go
@@ -69,7 +69,7 @@ type InternalSubnet struct {
 	// cidr is the subnet CIDR for this network segment (e.g. "192.168.100.0/24").
 	// Must not overlap with CIDRs in other InternalSubnets. Default routes (0.0.0.0/0,
 	// ::/0) and IPv6 link-local addresses (fe80::/10) are not allowed.
-	// +kubebuilder:validation:MaxLength=43
+	// +kubebuilder:validation:MaxLength=64
 	// +kubebuilder:validation:XValidation:rule=isCIDR(self),message="Must be a valid CIDR notation!"
 	CIDR string `json:"cidr"`
 }

--- a/api/v1alpha1/gatewayrouter_types.go
+++ b/api/v1alpha1/gatewayrouter_types.go
@@ -32,6 +32,7 @@ type GatewayRouterSpec struct {
 	// Name of the interface to reach external gateway
 	Interface string `json:"interface"`
 
+	// +kubebuilder:validation:MaxLength=64
 	// +kubebuilder:validation:XValidation:rule=isIP(self),message=Must be an ip address
 
 	// Address of the Gateway Router

--- a/api/v1alpha1/l34route_types.go
+++ b/api/v1alpha1/l34route_types.go
@@ -75,7 +75,7 @@ type L34RouteSpec struct {
 	// The destination CIDRs should not have overlaps.
 	// Each destinationCIDR must be an IPv4/32 or IPv6/128 CIDR
 	// +kubebuilder:validation:MaxItems=100
-	// +kubebuilder:validation:items:MaxLength=50
+	// +kubebuilder:validation:items:MaxLength=64
 	// +kubebuilder:validation:XValidation:message="each destinationCIDR must be an IPv4/32 or IPv6/128 CIDR",rule="self.all(c, isCIDR(c) && (cidr(c).prefixLength() == 32 || cidr(c).prefixLength() == 128))"
 	//nolint:tagliatelle
 	DestinationCIDRs []string `json:"destinationCIDRs"`
@@ -84,7 +84,7 @@ type L34RouteSpec struct {
 	// The source CIDRs should not have overlaps.
 	// +optional
 	// +kubebuilder:validation:MaxItems=100
-	// +kubebuilder:validation:items:MaxLength=50
+	// +kubebuilder:validation:items:MaxLength=64
 	// +kubebuilder:validation:XValidation:message="each sourceCIDR must be a valid CIDR",rule="self.all(c, isCIDR(c))"
 	//nolint:tagliatelle
 	SourceCIDRs []string `json:"sourceCIDRs,omitempty"`

--- a/api/v1alpha1/loadbalancerendpointslice_types.go
+++ b/api/v1alpha1/loadbalancerendpointslice_types.go
@@ -101,7 +101,7 @@ type EndpointTarget struct {
 type EndpointAddress struct {
 	// ip is the IP address of the endpoint.
 	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:MaxLength=45
+	// +kubebuilder:validation:MaxLength=64
 	IP string `json:"ip"`
 
 	// family is the IP address family.

--- a/config/crd/bases/meridio-2.nordix.org_gatewayconfigurations.yaml
+++ b/config/crd/bases/meridio-2.nordix.org_gatewayconfigurations.yaml
@@ -90,7 +90,7 @@ spec:
                         cidr is the subnet CIDR for this network segment (e.g. "192.168.100.0/24").
                         Must not overlap with CIDRs in other InternalSubnets. Default routes (0.0.0.0/0,
                         ::/0) and IPv6 link-local addresses (fe80::/10) are not allowed.
-                      maxLength: 43
+                      maxLength: 64
                       type: string
                       x-kubernetes-validations:
                       - message: Must be a valid CIDR notation!

--- a/config/crd/bases/meridio-2.nordix.org_gatewayrouters.yaml
+++ b/config/crd/bases/meridio-2.nordix.org_gatewayrouters.yaml
@@ -41,6 +41,7 @@ spec:
             properties:
               address:
                 description: Address of the Gateway Router
+                maxLength: 64
                 type: string
                 x-kubernetes-validations:
                 - message: Must be an ip address

--- a/config/crd/bases/meridio-2.nordix.org_l34routes.yaml
+++ b/config/crd/bases/meridio-2.nordix.org_l34routes.yaml
@@ -195,7 +195,7 @@ spec:
                   The destination CIDRs should not have overlaps.
                   Each destinationCIDR must be an IPv4/32 or IPv6/128 CIDR
                 items:
-                  maxLength: 50
+                  maxLength: 64
                   type: string
                 maxItems: 100
                 type: array
@@ -411,7 +411,7 @@ spec:
                   Source CIDRs allowed in the L34Route.
                   The source CIDRs should not have overlaps.
                 items:
-                  maxLength: 50
+                  maxLength: 64
                   type: string
                 maxItems: 100
                 type: array

--- a/config/crd/bases/meridio-2.nordix.org_loadbalancerendpointslices.yaml
+++ b/config/crd/bases/meridio-2.nordix.org_loadbalancerendpointslices.yaml
@@ -97,7 +97,7 @@ spec:
                             type: string
                           ip:
                             description: ip is the IP address of the endpoint.
-                            maxLength: 45
+                            maxLength: 64
                             minLength: 1
                             type: string
                         required:

--- a/hack/vpn-gateway/Dockerfile
+++ b/hack/vpn-gateway/Dockerfile
@@ -16,9 +16,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /tmp
-RUN wget https://gitlab.nic.cz/labs/bird/-/archive/v3.1.2/bird-v3.1.2.tar.gz \
-    && tar -xzf bird-v3.1.2.tar.gz \
-    && cd bird-v3.1.2 \
+RUN wget https://github.com/CZ-NIC/bird/archive/refs/tags/v3.1.2.tar.gz \
+    && tar -xzf v3.1.2.tar.gz \
+    && cd bird-3.1.2 \
     && autoreconf -i \
     && ./configure \
     && make -j$(nproc) \

--- a/internal/nfqlb/const.go
+++ b/internal/nfqlb/const.go
@@ -17,14 +17,9 @@ limitations under the License.
 package nfqlb
 
 const (
-	ownfw          = 0
-	nfqlbCmd       = "nfqlb"
-	tableName      = "table-nfqlb"
-	chainName      = "nfqlb"
-	localChainName = "nfqlb-local"
-	ipv4VIPSetName = "ipv4-vips"
-	ipv6VIPSetName = "ipv6-vips"
-	maxPortRange   = "0-65535"
+	ownfw        = 0
+	nfqlbCmd     = "nfqlb"
+	maxPortRange = "0-65535"
 
 	defaultQueue          = "0:3"
 	defaultQLength        = 1024
@@ -32,4 +27,6 @@ const (
 	defaultMaxTargets     = 100
 
 	maglevMMultiplier = 100
+
+	rulePriority = 32000
 )

--- a/internal/nfqlb/routing.go
+++ b/internal/nfqlb/routing.go
@@ -25,8 +25,6 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
-const rulePriority = 32000
-
 var errInvalidIP = errors.New("the ip address is invalid")
 
 // CleanupStaleRules removes all fwmark-based policy rules and their routing tables


### PR DESCRIPTION
## Summary

The API types used inconsistent `MaxLength` values across fields that represent IP addresses and CIDRs:

| CRD | Field | Old MaxLength | Represents |
|-----|-------|---------------|------------|
| GatewayConfiguration | `internalSubnets[].cidr` | 43 | CIDR |
| EndpointNetworkConfiguration | `network.subnet` | 64 | CIDR |
| L34Route | `destinationCIDRs[]`, `sourceCIDRs[]` | 50 | CIDR |
| LoadBalancerEndpointSlice | `addresses[].ip` | 45 | Plain IP |
| GatewayRouter | `spec.address` | *(none)* | Plain IP |

This PR standardizes all of them to a single value, **64**, and fills in the one field (`GatewayRouter.spec.address`) that previously had no length bound at all.

## Issue

#193 

## Why 64, and why one value for everything

The theoretical maximum length across every legitimate IP/CIDR representation (IPv4, compressed IPv6, and even the RFC-valid but rarely-emitted expanded IPv4-mapped IPv6 CIDR) is 49 characters. Deriving the *tightest* correct bound per field/representation would mean maintaining a small matrix of values (39/43/45/49) and re-deriving it correctly every time a new field is added.

That precision buys very little here, because most of these fields already carry a semantic CEL check (`isCIDR(self)` / `isIP(self)`) alongside `MaxLength`. The CEL rule does the real correctness work — a garbage string is rejected regardless of length — so `MaxLength` is only a coarse guard against pathological input sizes before CEL evaluation runs. Picking the mathematically tightest value there has no correctness benefit.

There's also no resource cost to a larger bound: string fields in etcd/JSON are sized to their actual content, not to the schema's declared `MaxLength`, so a more permissive bound doesn't pre-allocate memory or storage.

Given that, one comfortably permissive value applied uniformly is simpler than a per-field matrix, and avoids a future schema bump if an edge case (a non-minimal representation, a new field reusing this pattern) shows up. **64** was chosen because it was already in use in this codebase (`EndpointNetworkConfiguration.network.subnet`), so it's an established, round, and clearly-permissive precedent rather than a new arbitrary number.

## Note on CEL cost budget

One field (`EndpointNetworkConfiguration.network.subnet`) already had a **parent-level** CEL rule (`cidr(self.network.subnet).ip().family() == ...`) that parses this field. While standardizing lengths, I also tried adding a direct `isCIDR(self)` CEL check on the field itself, since it had no format validation of its own — but that pushed the CRD's estimated CEL rule cost over Kubernetes' admission budget (envtest caught this immediately in `make test`). That additional CEL rule was reverted; this PR only changes `MaxLength`, no new validation logic.

## Additional minor fixes picked up in this PR

While already touching this branch, I folded in two small, unrelated fixes flagged during review:

- **`internal/nfqlb`: centralize constants.** Moved the stray `rulePriority` constant from `routing.go` into the package's existing `const.go`, and removed five unused constants (`tableName`, `chainName`, `localChainName`, `ipv4VIPSetName`, `ipv6VIPSetName`) left over from before nftables logic moved to `internal/nftables`. #231 
- **`hack/vpn-gateway/Dockerfile`: fix flaky BIRD download in e2e builds.** `gitlab.nic.cz` was intermittently returning `403 Forbidden` for CI/datacenter traffic, breaking e2e image builds. Switched to the official CZ-NIC GitHub mirror (`github.com/CZ-NIC/bird`), which is reachable from GitHub Actions runners. Verified by building the `bird-builder` stage locally end-to-end.
