### PR TITLE
Reject cross-namespace backendRef enqueues in LB and DG controllers

### DIFF
--- a/internal/controller/distributiongroup/mappers.go
+++ b/internal/controller/distributiongroup/mappers.go
@@ -92,6 +92,14 @@ func (r *DistributionGroupReconciler) mapL34RouteToDistributionGroup(ctx context
 
 	requests := make([]ctrl.Request, 0, len(dgKeys))
 	for key := range dgKeys {
+		// Guard against enqueueing DistributionGroups outside this controller's
+		// watched namespace. An explicit backendRef.Namespace is not validated
+		// anywhere in the admission path, so a resolved key may point outside our
+		// scope. When r.Namespace is empty the controller watches cluster-wide, so
+		// no restriction applies.
+		if r.Namespace != "" && key.Namespace != r.Namespace {
+			continue
+		}
 		requests = append(requests, ctrl.Request{NamespacedName: key})
 	}
 	return requests

--- a/internal/controller/distributiongroup/mappers_test.go
+++ b/internal/controller/distributiongroup/mappers_test.go
@@ -1,0 +1,108 @@
+/*
+Copyright (c) 2026 OpenInfra Foundation Europe. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package distributiongroup
+
+import (
+	"context"
+	"testing"
+
+	meridio2v1alpha1 "github.com/nordix/meridio-2/api/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+const testOtherNamespace = "other-ns"
+
+func TestMapL34RouteToDistributionGroup_SameNamespace(t *testing.T) {
+	dgGroup := meridio2v1alpha1.GroupVersion.Group
+	dgKind := kindDistributionGroup
+
+	route := &meridio2v1alpha1.L34Route{
+		ObjectMeta: metav1.ObjectMeta{Name: "route-1", Namespace: "default"},
+		Spec: meridio2v1alpha1.L34RouteSpec{
+			BackendRefs: []gatewayv1.BackendRef{
+				{BackendObjectReference: gatewayv1.BackendObjectReference{
+					Group: (*gatewayv1.Group)(&dgGroup),
+					Kind:  (*gatewayv1.Kind)(&dgKind),
+					Name:  "dg-1",
+				}},
+			},
+		},
+	}
+
+	r := &DistributionGroupReconciler{Namespace: "default"}
+	requests := r.mapL34RouteToDistributionGroup(context.Background(), route)
+
+	assert.Len(t, requests, 1)
+	assert.Equal(t, "dg-1", requests[0].Name)
+	assert.Equal(t, "default", requests[0].Namespace)
+}
+
+func TestMapL34RouteToDistributionGroup_CrossNamespaceRejected(t *testing.T) {
+	dgGroup := meridio2v1alpha1.GroupVersion.Group
+	dgKind := kindDistributionGroup
+	otherNs := testOtherNamespace
+
+	// backendRef explicitly points outside the controller's watched namespace.
+	route := &meridio2v1alpha1.L34Route{
+		ObjectMeta: metav1.ObjectMeta{Name: "route-1", Namespace: "default"},
+		Spec: meridio2v1alpha1.L34RouteSpec{
+			BackendRefs: []gatewayv1.BackendRef{
+				{BackendObjectReference: gatewayv1.BackendObjectReference{
+					Group:     (*gatewayv1.Group)(&dgGroup),
+					Kind:      (*gatewayv1.Kind)(&dgKind),
+					Name:      "dg-1",
+					Namespace: (*gatewayv1.Namespace)(&otherNs),
+				}},
+			},
+		},
+	}
+
+	r := &DistributionGroupReconciler{Namespace: "default"}
+	requests := r.mapL34RouteToDistributionGroup(context.Background(), route)
+
+	assert.Empty(t, requests)
+}
+
+func TestMapL34RouteToDistributionGroup_ClusterWideAllowsAnyNamespace(t *testing.T) {
+	dgGroup := meridio2v1alpha1.GroupVersion.Group
+	dgKind := kindDistributionGroup
+	otherNs := testOtherNamespace
+
+	route := &meridio2v1alpha1.L34Route{
+		ObjectMeta: metav1.ObjectMeta{Name: "route-1", Namespace: "default"},
+		Spec: meridio2v1alpha1.L34RouteSpec{
+			BackendRefs: []gatewayv1.BackendRef{
+				{BackendObjectReference: gatewayv1.BackendObjectReference{
+					Group:     (*gatewayv1.Group)(&dgGroup),
+					Kind:      (*gatewayv1.Kind)(&dgKind),
+					Name:      "dg-1",
+					Namespace: (*gatewayv1.Namespace)(&otherNs),
+				}},
+			},
+		},
+	}
+
+	// Namespace == "" means cluster-wide operation: no restriction applies.
+	r := &DistributionGroupReconciler{Namespace: ""}
+	requests := r.mapL34RouteToDistributionGroup(context.Background(), route)
+
+	assert.Len(t, requests, 1)
+	assert.Equal(t, "dg-1", requests[0].Name)
+	assert.Equal(t, testOtherNamespace, requests[0].Namespace)
+}

--- a/internal/controller/loadbalancer/controller.go
+++ b/internal/controller/loadbalancer/controller.go
@@ -111,6 +111,20 @@ func resolveBackendRefDG(backendRef gatewayv1.BackendRef, routeNamespace string)
 func (c *Controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logr := log.FromContext(ctx)
 
+	// Defense-in-depth: this controller's cache and all its internal state
+	// (c.instances/c.targets/c.flows, keyed by name only) are scoped to a single
+	// namespace. A request for any other namespace cannot be a legitimate
+	// DistributionGroup for this Gateway (namespaces are immutable in Kubernetes,
+	// so this can only indicate a mis-constructed request, e.g. from an unvalidated
+	// cross-namespace backendRef). Reject it before the Get call below, since a
+	// NotFound here is treated as "deleted" and triggers destructive cleanup keyed
+	// by name only, which could tear down an unrelated same-named DG in our namespace.
+	if req.Namespace != c.GatewayNamespace {
+		logr.V(1).Info("Ignoring reconcile request outside Gateway namespace",
+			"requestNamespace", req.Namespace, "gatewayNamespace", c.GatewayNamespace)
+		return ctrl.Result{}, nil
+	}
+
 	// Get DistributionGroup
 	distGroup := &meridio2v1alpha1.DistributionGroup{}
 	if err := c.Get(ctx, req.NamespacedName, distGroup); err != nil {
@@ -260,7 +274,7 @@ func (c *Controller) gatewayEnqueue(ctx context.Context, obj client.Object) []ct
 
 	// 1. Direct: DGs with spec.parentRefs pointing to this Gateway
 	dgList := &meridio2v1alpha1.DistributionGroupList{}
-	if err := c.List(ctx, dgList); err != nil {
+	if err := c.List(ctx, dgList, client.InNamespace(c.GatewayNamespace)); err != nil {
 		log.FromContext(ctx).Error(err, "Failed to list DistributionGroups in gatewayEnqueue")
 	} else {
 		for _, dg := range dgList.Items {
@@ -289,7 +303,7 @@ func (c *Controller) gatewayEnqueue(ctx context.Context, obj client.Object) []ct
 				continue
 			}
 			for _, backendRef := range route.Spec.BackendRefs {
-				if key, isDG := resolveBackendRefDG(backendRef, route.Namespace); isDG {
+				if key, isDG := resolveBackendRefDG(backendRef, route.Namespace); isDG && key.Namespace == c.GatewayNamespace {
 					enqueued[key] = struct{}{}
 				}
 			}
@@ -413,7 +427,7 @@ func (c *Controller) l34RouteEnqueue(ctx context.Context, obj client.Object) []c
 	// Enqueue all DistributionGroups referenced by this route
 	var requests []ctrl.Request
 	for _, backendRef := range route.Spec.BackendRefs {
-		if key, isDG := resolveBackendRefDG(backendRef, route.Namespace); isDG {
+		if key, isDG := resolveBackendRefDG(backendRef, route.Namespace); isDG && key.Namespace == c.GatewayNamespace {
 			requests = append(requests, ctrl.Request{NamespacedName: key})
 		}
 	}

--- a/internal/controller/loadbalancer/controller_test.go
+++ b/internal/controller/loadbalancer/controller_test.go
@@ -1205,6 +1205,37 @@ var _ = Describe("LoadBalancer Controller", func() {
 			Expect(requests[0].Name).To(Equal("distgroup-1"))
 			Expect(requests[1].Name).To(Equal("distgroup-2"))
 		})
+
+		It("should not enqueue a DG backendRef whose explicit namespace differs from GatewayNamespace", func() {
+			group := meridio2v1alpha1.GroupVersion.Group
+			kind := kindDistributionGroup
+			otherNs := gatewayv1.Namespace("other-ns")
+
+			l34route := &meridio2v1alpha1.L34Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: namespace,
+				},
+				Spec: meridio2v1alpha1.L34RouteSpec{
+					ParentRefs: []gatewayv1.ParentReference{
+						{Name: gatewayv1.ObjectName(gatewayName)},
+					},
+					BackendRefs: []gatewayv1.BackendRef{
+						{
+							BackendObjectReference: gatewayv1.BackendObjectReference{
+								Group:     (*gatewayv1.Group)(&group),
+								Kind:      (*gatewayv1.Kind)(&kind),
+								Name:      "same-name-dg",
+								Namespace: &otherNs,
+							},
+						},
+					},
+				},
+			}
+
+			requests := controller.l34RouteEnqueue(ctx, l34route)
+			Expect(requests).To(BeEmpty())
+		})
 	})
 
 	Describe("Instance cleanup on deletion", func() {
@@ -1253,7 +1284,7 @@ var _ = Describe("LoadBalancer Controller", func() {
 
 			// Reconcile with non-existent DistributionGroup
 			result, err := controller.Reconcile(ctx, reconcile.Request{
-				NamespacedName: client.ObjectKey{Name: distGroup.Name},
+				NamespacedName: client.ObjectKey{Name: distGroup.Name, Namespace: namespace},
 			})
 
 			Expect(err).ToNot(HaveOccurred())
@@ -1294,6 +1325,42 @@ var _ = Describe("LoadBalancer Controller", func() {
 			requests := controller.gatewayEnqueue(ctx, gateway)
 			Expect(requests).To(HaveLen(1))
 			Expect(requests[0].Name).To(Equal("direct-dg"))
+		})
+
+		It("should not enqueue a same-named DistributionGroup residing in a different namespace", func() {
+			// Note: the manager's real cache is already namespace-scoped
+			// (cache.Options.DefaultNamespaces), so this can't happen against a real
+			// cluster. The fake client used here isn't scoped, so this test verifies
+			// the explicit client.InNamespace(c.GatewayNamespace) guard directly,
+			// independent of that cache-level protection.
+			//
+			// The DG lives in "other-ns" but its parentRef explicitly targets
+			// c.GatewayNamespace ("default"), so the parentRef-namespace check alone
+			// would not exclude it — only scoping the List call does.
+			dgOtherNs := &meridio2v1alpha1.DistributionGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "direct-dg",
+					Namespace: "other-ns",
+				},
+				Spec: meridio2v1alpha1.DistributionGroupSpec{
+					ParentRefs: []meridio2v1alpha1.ParentReference{
+						{Name: gatewayName, Namespace: ptr.To(namespace)},
+					},
+				},
+			}
+
+			fakeClient = newFakeClient(scheme, dgOtherNs)
+			controller.Client = fakeClient
+
+			gateway := &gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      gatewayName,
+					Namespace: namespace,
+				},
+			}
+
+			requests := controller.gatewayEnqueue(ctx, gateway)
+			Expect(requests).To(BeEmpty())
 		})
 
 		It("should enqueue DG referenced indirectly via L34Route", func() {
@@ -1605,6 +1672,82 @@ var _ = Describe("LoadBalancer Controller", func() {
 
 			requests := controller.gatewayEnqueue(ctx, gateway)
 			Expect(requests).To(BeEmpty())
+		})
+
+		It("should not enqueue a DG backendRef whose explicit namespace differs from GatewayNamespace", func() {
+			group := meridio2v1alpha1.GroupVersion.Group
+			kind := kindDistributionGroup
+			otherNs := gatewayv1.Namespace("other-ns")
+
+			// Same name as a DG that could legitimately exist in GatewayNamespace,
+			// to mirror the destructive-cleanup scenario this guard prevents.
+			l34route := &meridio2v1alpha1.L34Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cross-ns-route",
+					Namespace: namespace,
+				},
+				Spec: meridio2v1alpha1.L34RouteSpec{
+					ParentRefs: []gatewayv1.ParentReference{
+						{Name: gatewayv1.ObjectName(gatewayName)},
+					},
+					BackendRefs: []gatewayv1.BackendRef{
+						{
+							BackendObjectReference: gatewayv1.BackendObjectReference{
+								Group:     (*gatewayv1.Group)(&group),
+								Kind:      (*gatewayv1.Kind)(&kind),
+								Name:      "test-distgroup",
+								Namespace: &otherNs,
+							},
+						},
+					},
+					DestinationCIDRs: []string{"20.0.0.1/32"},
+					Protocols:        []meridio2v1alpha1.TransportProtocol{meridio2v1alpha1.TCP},
+					Priority:         1,
+				},
+			}
+
+			fakeClient = newFakeClient(scheme, l34route)
+			controller.Client = fakeClient
+
+			gateway := &gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      gatewayName,
+					Namespace: namespace,
+				},
+			}
+
+			requests := controller.gatewayEnqueue(ctx, gateway)
+			Expect(requests).To(BeEmpty())
+		})
+	})
+
+	Describe("Reconcile namespace guard", func() {
+		It("should ignore requests outside GatewayNamespace without touching internal state", func() {
+			// A DG with the same name is actively managed in GatewayNamespace.
+			// A request for the same name in a different namespace must be
+			// rejected before it can trigger NotFound-driven cleanup.
+			mockInstance := &mockNFQLBInstance{
+				name:  "test-distgroup",
+				flows: make(map[string]nfqlb.Flow),
+			}
+			controller.instances = map[string]nfqlbInstance{"test-distgroup": mockInstance}
+			controller.flows = map[string]map[string]*meridio2v1alpha1.L34Route{"test-distgroup": {}}
+			controller.targets = map[string]map[int]struct{}{"test-distgroup": {}}
+
+			fakeClient = newFakeClient(scheme)
+			controller.Client = fakeClient
+
+			result, err := controller.Reconcile(ctx, reconcile.Request{
+				NamespacedName: client.ObjectKey{Name: "test-distgroup", Namespace: "other-ns"},
+			})
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(reconcile.Result{}))
+
+			// State for the same-named DG in GatewayNamespace must remain intact.
+			Expect(controller.instances).To(HaveKey("test-distgroup"))
+			Expect(controller.flows).To(HaveKey("test-distgroup"))
+			Expect(controller.targets).To(HaveKey("test-distgroup"))
 		})
 	})
 })

--- a/internal/controller/loadbalancer/controller_test.go
+++ b/internal/controller/loadbalancer/controller_test.go
@@ -1327,7 +1327,7 @@ var _ = Describe("LoadBalancer Controller", func() {
 			Expect(requests[0].Name).To(Equal("direct-dg"))
 		})
 
-		It("should not enqueue a same-named DistributionGroup residing in a different namespace", func() {
+		It("should not enqueue a DG with direct parentRef when the DG resides in a different namespace", func() {
 			// Note: the manager's real cache is already namespace-scoped
 			// (cache.Options.DefaultNamespaces), so this can't happen against a real
 			// cluster. The fake client used here isn't scoped, so this test verifies


### PR DESCRIPTION
## Description

### Issue

#230 

### Problem

Both the LoadBalancer controller (`resolveBackendRefDG()`) and the DistributionGroup controller (`extractDGsFromBackendRefs()`) resolve a `gatewayv1.BackendRef` to a `client.ObjectKey`, honoring an explicit `backendRef.Namespace` with no validation against the caller's scope. The resolved key is enqueued as a `ctrl.Request` unconditionally, without checking it matches the controller's expected namespace scope. No protection exists in the admission path (no CEL validation, no webhook check, no `ReferenceGrant`).

**LB controller impact (destructive):** The LB controller's cache and internal state (`c.instances`/`c.targets`/`c.flows`) are scoped to a single namespace and keyed by name only. A cross-namespace `backendRef` whose name collides with a real DG in the Gateway's namespace triggers a spurious `NotFound` on `Get`, which `Reconcile` treats as "deleted" and tears down the real DG's live NFQLB instance, policy routes, and readiness file — causing a traffic outage until the next reconcile.

**DG controller impact (hygiene):** Same unguarded pattern, currently harmless since cleanup is driven by Kubernetes garbage collection via `ownerReferences`, not by the reconciler's `NotFound` branch. A bogus cross-namespace enqueue just wastes a reconcile cycle today, but matters if cluster-wide operation (`Namespace == ""`) is pursued later.

### Fix

**LB controller** (`internal/controller/loadbalancer/controller.go`):
- Enqueue-time guard in `gatewayEnqueue()` and `l34RouteEnqueue()`: only enqueue a resolved `resolveBackendRefDG()` key if `key.Namespace == c.GatewayNamespace`. `resolveBackendRefDG` itself stays a generic extraction function.
- Defense-in-depth guard at the top of `Reconcile()`: reject any `req.Namespace != c.GatewayNamespace` before the `Get` call, closing off the destructive `NotFound`→cleanup path regardless of which mapper produced the request.
- Scoped the direct-parentRef `DistributionGroupList` call in `gatewayEnqueue()` with `client.InNamespace(c.GatewayNamespace)` for consistency with every other `List` call in the package.

**DG controller** (`internal/controller/distributiongroup/mappers.go`):
- Same enqueue-time guard in `mapL34RouteToDistributionGroup()`, respecting the controller's documented cluster-wide mode (`Namespace == ""` means no restriction applies).

### Out of scope (per issue)
- `belongsToGateway()` — not exploitable today (caller invariant via namespace-scoped cache), no fix requested.
- CEL validation / webhook validation on `backendRefs[].namespace` and a `ReferenceGrant` implementation — noted as context for the gap, not requested deliverables here.
- DG controller cluster-wide mode — explicitly deferred to its own follow-up when that mode is actually pursued.

### Testing
- New/updated tests for every guard, each verified to fail when its corresponding fix is reverted and pass once restored:
  - LB: `Reconcile` namespace guard, `gatewayEnqueue` cross-namespace rejection (both via backendRef and via direct-parentRef DG in another namespace), `l34RouteEnqueue` cross-namespace rejection.
  - DG: `mapL34RouteToDistributionGroup` same-namespace, cross-namespace-rejected, and cluster-wide-passthrough cases.